### PR TITLE
Add Context7 docs lookup tool to review agent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,11 @@ OPENAI_API_KEY=
 # ANTHROPIC_API_KEY=
 # GOOGLE_GENERATIVE_AI_API_KEY=
 
+# --- Context7 (optional — agent uses for library-docs lookup) ---
+# Anonymous calls work for public libraries with rate limits.
+# Get a key at https://context7.com/dashboard for higher limits + private repos.
+CONTEXT7_API_KEY=
+
 # --- Docker Compose ---
 # Compose loads this file by default (`env_file: .env`). For a one-off alternate path use:
 #   PR_AGENT_ENV_FILE=/path/to/.env docker compose up

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ GitHub App webhook service that performs automated pull request reviews using [`
 - **Agent loop:** after the main `MAX_TOOL_ROUNDS` limit, the service runs up to **`MAX_FINALIZE_ROUNDS`** additional model turns if the conversation still ends with pending `toolResult` messages, then—if still stuck—forces one **text-only** completion (tools cleared) so the webhook does not end with an unfinished tool chain.
 - **Review concurrency:** full review runs are bounded by **`REVIEW_CONCURRENCY`** (default `2`), enforced by an Effect `Semaphore` Layer (`ReviewQueue`), so bursts of webhook deliveries cannot start unbounded concurrent LLM/tool loops. Per-process (in-memory); multi-replica deployments are at-least-once.
 - **Upstream tools:** `@github-tools/sdk` targets the Vercel AI ecosystem; errors mentioning workflow/durable/approval may mean a tool is not viable in plain Node—check logs; you may need fewer presets or direct REST for that action.
+- **Library docs lookup:** the review agent also gets two Context7 tools (`resolveLibraryId`, `getLibraryDocs`) that hit `https://context7.com/api` to verify upstream API claims before flagging findings. Anonymous calls work for public libraries with rate limits; set **`CONTEXT7_API_KEY`** for higher limits and private repos. See [docs/adr/0003-context7-docs-tool.md](docs/adr/0003-context7-docs-tool.md) for why the SDK is bypassed.
 - **Bot identity** for self-suppression is cached **per `GITHUB_APP_ID`**, so multiple GitHub Apps in one process do not share the same cache entry.
 
 ## GitHub App setup (summary)

--- a/docs/adr/0003-context7-docs-tool.md
+++ b/docs/adr/0003-context7-docs-tool.md
@@ -1,0 +1,22 @@
+# ADR 0003 — Context7 docs tool, direct REST instead of `@upstash/context7-sdk`
+
+## Status
+
+Accepted.
+
+## Context
+
+We added a Context7 documentation-lookup tool to the agent's tool set (`src/agent/context7Tools.ts`) so the review loop can verify upstream API behaviour before flagging findings. The natural client would be `@upstash/context7-sdk`, but its constructor (`packages/sdk/src/client.ts:22-28` as of v0.3.0) hard-throws when neither the `apiKey` constructor option nor the `CONTEXT7_API_KEY` env var is set. We want anonymous fallback (rate-limited but functional) so the tool keeps working in local smoke tests and forks that have not signed up for an API key — which the SDK forbids.
+
+## Decision
+
+`src/agent/context7Tools.ts` calls `https://context7.com/api/v2/libs/search` and `/v2/context` directly via Node's native `fetch`. The `Authorization: Bearer ...` header is attached only when `cfg.context7ApiKey` is non-empty. Two tools are exposed to the LLM, named `resolveLibraryId` and `getLibraryDocs` to match the camelCase convention of the surrounding `@github-tools/sdk` tool set.
+
+## Consequences
+
+- We lose the SDK's 5-retry exponential backoff (`packages/sdk/src/client.ts:39-42`). A transient Context7 failure surfaces to the LLM as an `isError: true` `toolResult` on the first try, and the model can retry on a later turn. This matches how `@github-tools/sdk` failures are already handled.
+- The Context7 REST contract is now a private dependency of this repo. If `/v2/libs/search` or `/v2/context` change shape, the tool breaks before the SDK would.
+
+## Reversal
+
+If Context7 exposes an explicit "anonymous mode" SDK constructor (e.g. `new Context7({ allowAnonymous: true })`), swap the `fetch` calls in `context7Tools.ts` for the SDK. The tool surface (`resolveLibraryId` / `getLibraryDocs`) and the system-prompt directive in `src/agent/reviewRun.ts` stay unchanged.

--- a/src/agent/context7Tools.ts
+++ b/src/agent/context7Tools.ts
@@ -1,0 +1,117 @@
+import { z } from "zod";
+
+const CONTEXT7_BASE_URL = "https://context7.com/api";
+
+const resolveLibraryIdSchema = z.object({
+	libraryName: z
+		.string()
+		.describe("Third-party library name to resolve, e.g. 'react', 'next.js', 'zod'."),
+	query: z
+		.string()
+		.optional()
+		.describe(
+			"Optional ranking query; defaults to libraryName. Use to disambiguate when several packages share a name.",
+		),
+});
+
+const getLibraryDocsSchema = z.object({
+	libraryId: z
+		.string()
+		.describe(
+			"Context7 library ID returned by resolveLibraryId, e.g. '/facebook/react' or '/vercel/next.js'.",
+		),
+	topic: z
+		.string()
+		.optional()
+		.describe(
+			"Optional topic or API question to focus the returned docs, e.g. 'hooks', 'middleware', 'schema typing'.",
+		),
+});
+
+type Context7Tool = {
+	readonly description: string;
+	readonly inputSchema: z.ZodType;
+	readonly execute: (args: Record<string, unknown>) => Promise<string>;
+};
+
+function authHeader(apiKey: string): Record<string, string> {
+	return apiKey ? { Authorization: `Bearer ${apiKey}` } : {};
+}
+
+async function context7Get(url: string, apiKey: string): Promise<string> {
+	const res = await fetch(url, {
+		method: "GET",
+		headers: {
+			Accept: "application/json, text/plain",
+			...authHeader(apiKey),
+		},
+	});
+
+	if (!res.ok) {
+		let detail = "";
+		try {
+			const body = (await res.json()) as { error?: string; message?: string };
+			detail = body.error ?? body.message ?? "";
+		} catch {
+			try {
+				detail = await res.text();
+			} catch {
+				/* response body is unreadable; keep detail empty */
+			}
+		}
+		throw new Error(`Context7 ${res.status} ${res.statusText}${detail ? `: ${detail}` : ""}`);
+	}
+
+	const contentType = res.headers.get("content-type") ?? "";
+	if (contentType.includes("application/json")) {
+		const body = await res.json();
+		return JSON.stringify(body, null, 2);
+	}
+	return await res.text();
+}
+
+/**
+ * Library-docs lookup tools the review agent uses to verify upstream API claims.
+ * Calls https://context7.com/api directly; SDK was avoided because its constructor
+ * rejects missing API keys, which would break anonymous fallback.
+ * See docs/adr/0003-context7-docs-tool.md.
+ */
+export function buildContext7Toolset({ apiKey }: { apiKey: string }) {
+	const resolveLibraryId: Context7Tool = {
+		description:
+			"Resolve an external library name (e.g. 'react') to its canonical Context7 library ID (e.g. '/facebook/react'). Always call before getLibraryDocs unless an exact slash-prefixed ID is already known.",
+		inputSchema: resolveLibraryIdSchema,
+		execute: async (args) => {
+			const parsed = resolveLibraryIdSchema.parse(args);
+			const params = new URLSearchParams({
+				libraryName: parsed.libraryName,
+				query: parsed.query?.trim() || parsed.libraryName,
+			});
+			return context7Get(
+				`${CONTEXT7_BASE_URL}/v2/libs/search?${params.toString()}`,
+				apiKey,
+			);
+		},
+	};
+
+	const getLibraryDocs: Context7Tool = {
+		description:
+			"Fetch current documentation for a third-party library by its Context7 library ID. Returns formatted prose. Use to verify a claim about upstream API shape or version-specific behaviour before flagging a finding.",
+		inputSchema: getLibraryDocsSchema,
+		execute: async (args) => {
+			const parsed = getLibraryDocsSchema.parse(args);
+			const params = new URLSearchParams({
+				libraryId: parsed.libraryId,
+				type: "txt",
+			});
+			const topic = parsed.topic?.trim();
+			if (topic) params.set("query", topic);
+			return context7Get(
+				`${CONTEXT7_BASE_URL}/v2/context?${params.toString()}`,
+				apiKey,
+			);
+		},
+	};
+
+	return { resolveLibraryId, getLibraryDocs };
+}

--- a/src/agent/reviewRun.ts
+++ b/src/agent/reviewRun.ts
@@ -2,6 +2,7 @@ import { complete, getModel } from "@earendil-works/pi-ai";
 import type { AssistantMessage, Context, Message, ToolCall } from "@earendil-works/pi-ai";
 import type { Config } from "../config.js";
 import { bridgeGithubToolsToPi } from "../bridge/aiSdkToolsToPiTools.js";
+import { buildContext7Toolset } from "./context7Tools.js";
 import { buildCodeReviewToolset } from "./githubTools.js";
 import { log } from "../log.js";
 
@@ -77,6 +78,7 @@ const automatedSystemPrompt = [
 	"2. Trace data flow to prove a reachable trigger path",
 	"3. Check if the pattern appears elsewhere (may be deliberate)",
 	"4. Align test assumptions vs production behaviour when citing tests",
+	"5. When a finding hinges on third-party library behaviour (an external API's shape, semantics, or version-specific availability), call resolveLibraryId to get the canonical Context7 ID, then getLibraryDocs to verify the claim against current docs. Do not pre-warm—only look up to verify a claim you are about to make.",
 	"",
 	"## Reporting gate",
 	"### Report if at least one is true",
@@ -131,7 +133,8 @@ export async function runFullPrReview(params: {
 	const { cfg, token, owner, repo, prNumber, headSha, userSupplement } = params;
 
 	const ghToolset = buildCodeReviewToolset(token) as unknown as Record<string, unknown>;
-	const { piTools, executeTool } = bridgeGithubToolsToPi(ghToolset);
+	const ctxToolset = buildContext7Toolset({ apiKey: cfg.context7ApiKey });
+	const { piTools, executeTool } = bridgeGithubToolsToPi({ ...ghToolset, ...ctxToolset });
 
 	const model = getModel(cfg.piProvider, cfg.piModel as never);
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -92,6 +92,8 @@ export function loadConfig() {
 		throw new Error("WEBHOOK_TIMEOUT_MS must be a positive number");
 	}
 
+	const context7ApiKey = optionalEnv("CONTEXT7_API_KEY", "");
+
 	const logLevel = optionalEnv("LOG_LEVEL", "info") as "debug" | "info" | "warn" | "error";
 	if (!["debug", "info", "warn", "error"].includes(logLevel)) {
 		throw new Error('LOG_LEVEL must be one of debug, info, warn, error');
@@ -108,6 +110,7 @@ export function loadConfig() {
 		maxFinalizeRounds,
 		reviewConcurrency,
 		webhookTimeoutMs,
+		context7ApiKey,
 		logLevel,
 	};
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,11 @@ function main() {
   }
 
   initLog(cfg.logLevel);
-  log.info("boot", { provider: cfg.piProvider, model: cfg.piModel });
+  log.info("boot", {
+    provider: cfg.piProvider,
+    model: cfg.piModel,
+    context7_enabled: cfg.context7ApiKey.length > 0,
+  });
   log.info("runtime_selected", { runtime: "effect" });
   startEffectWebhookServer(cfg);
 }

--- a/test/context7Tools.test.ts
+++ b/test/context7Tools.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildContext7Toolset } from "../src/agent/context7Tools.js";
+import { bridgeGithubToolsToPi } from "../src/bridge/aiSdkToolsToPiTools.js";
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+	return new Response(JSON.stringify(body), {
+		...init,
+		headers: { "content-type": "application/json", ...(init?.headers ?? {}) },
+	});
+}
+
+function txtResponse(body: string, init?: ResponseInit): Response {
+	return new Response(body, {
+		...init,
+		headers: { "content-type": "text/plain", ...(init?.headers ?? {}) },
+	});
+}
+
+function headersOf(init: RequestInit | undefined): Record<string, string> {
+	const h = init?.headers;
+	if (!h) return {};
+	if (h instanceof Headers) return Object.fromEntries(h.entries());
+	if (Array.isArray(h)) return Object.fromEntries(h);
+	return h as Record<string, string>;
+}
+
+describe("buildContext7Toolset", () => {
+	it("exposes both tools through bridgeGithubToolsToPi", () => {
+		const toolset = buildContext7Toolset({ apiKey: "" });
+		const { piTools } = bridgeGithubToolsToPi(toolset);
+		expect(piTools.map((t) => t.name).sort()).toEqual(["getLibraryDocs", "resolveLibraryId"]);
+	});
+
+	it("converts the resolveLibraryId Zod schema and requires libraryName", () => {
+		const { piTools } = bridgeGithubToolsToPi(buildContext7Toolset({ apiKey: "" }));
+		const tool = piTools.find((t) => t.name === "resolveLibraryId");
+		expect(tool?.parameters).toMatchObject({
+			type: "object",
+			properties: {
+				libraryName: { type: "string" },
+				query: { type: "string" },
+			},
+		});
+		expect((tool?.parameters as { required?: string[] }).required).toContain("libraryName");
+	});
+
+	it("converts the getLibraryDocs Zod schema and requires libraryId", () => {
+		const { piTools } = bridgeGithubToolsToPi(buildContext7Toolset({ apiKey: "" }));
+		const tool = piTools.find((t) => t.name === "getLibraryDocs");
+		expect(tool?.parameters).toMatchObject({
+			type: "object",
+			properties: {
+				libraryId: { type: "string" },
+				topic: { type: "string" },
+			},
+		});
+		expect((tool?.parameters as { required?: string[] }).required).toContain("libraryId");
+	});
+
+	it("resolveLibraryId hits /v2/libs/search, defaults query to libraryName, omits Authorization when key is empty", async () => {
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValueOnce(jsonResponse({ results: [{ id: "/facebook/react", title: "React" }] }));
+
+		try {
+			const toolset = buildContext7Toolset({ apiKey: "" });
+			const out = await toolset.resolveLibraryId.execute({ libraryName: "react" });
+
+			expect(fetchSpy).toHaveBeenCalledTimes(1);
+			const [url, init] = fetchSpy.mock.calls[0]!;
+			const u = new URL(String(url));
+			expect(u.origin + u.pathname).toBe("https://context7.com/api/v2/libs/search");
+			expect(u.searchParams.get("libraryName")).toBe("react");
+			expect(u.searchParams.get("query")).toBe("react");
+			expect(headersOf(init).Authorization).toBeUndefined();
+			expect(out).toContain("/facebook/react");
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
+	it("getLibraryDocs sends type=txt, trims topic into query, and attaches Authorization when apiKey is set", async () => {
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValueOnce(txtResponse("# React Hooks\nuseState is..."));
+
+		try {
+			const toolset = buildContext7Toolset({ apiKey: "ctx7sk-test" });
+			const out = await toolset.getLibraryDocs.execute({
+				libraryId: "/facebook/react",
+				topic: "  hooks  ",
+			});
+
+			const [url, init] = fetchSpy.mock.calls[0]!;
+			const u = new URL(String(url));
+			expect(u.pathname).toBe("/api/v2/context");
+			expect(u.searchParams.get("libraryId")).toBe("/facebook/react");
+			expect(u.searchParams.get("type")).toBe("txt");
+			expect(u.searchParams.get("query")).toBe("hooks");
+			expect(headersOf(init).Authorization).toBe("Bearer ctx7sk-test");
+			expect(out).toContain("React Hooks");
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
+	it("getLibraryDocs omits the query param when topic is absent", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(txtResponse("anything"));
+
+		try {
+			const toolset = buildContext7Toolset({ apiKey: "" });
+			await toolset.getLibraryDocs.execute({ libraryId: "/facebook/react" });
+			const [url] = fetchSpy.mock.calls[0]!;
+			expect(new URL(String(url)).searchParams.get("query")).toBeNull();
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
+	it("throws with status + body detail on non-2xx", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+			jsonResponse({ error: "Invalid library" }, { status: 404, statusText: "Not Found" }),
+		);
+
+		try {
+			const toolset = buildContext7Toolset({ apiKey: "" });
+			await expect(toolset.getLibraryDocs.execute({ libraryId: "/no/such/lib" })).rejects.toThrow(
+				/Context7 404.*Invalid library/,
+			);
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- New `src/agent/context7Tools.ts` exposes `resolveLibraryId` + `getLibraryDocs` to the review agent. Calls `https://context7.com/api` directly via Node `fetch`; `Authorization: Bearer …` is attached only when `CONTEXT7_API_KEY` is set (optional — anonymous calls work for public libraries with lower rate limits). Failed responses throw so the existing executor wraps them into `isError` toolResults.
- `runFullPrReview` merges the new tools into the existing `bridgeGithubToolsToPi` call; `automatedSystemPrompt` gains one step under "Analysis discipline before flagging" so the LLM looks up docs only to verify a claim it is about to make, not pre-emptively. `loadConfig` reads the new env var; `src/index.ts` adds a `context7_enabled` flag to the boot log; `.env.example` and `README.md` are updated.
- `docs/adr/0003-context7-docs-tool.md` records why direct REST was chosen over `@upstash/context7-sdk` (the SDK constructor hard-throws on missing key, which would break anonymous fallback). `test/context7Tools.test.ts` covers Zod→JSON-Schema conversion, URL/query construction, conditional `Authorization` header, and the error path via `vi.spyOn(globalThis, "fetch")`.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm test` — 18 files / 77 tests pass (baseline 17 / 70; +1 file, +7 tests)
- [ ] Manual smoke against a real PR with and without `CONTEXT7_API_KEY` set; confirm boot log shows the right `context7_enabled` value and `agent_tool_round` lines include `resolveLibraryId` / `getLibraryDocs`
- [ ] Forced failure: point `fetch` at a non-2xx host, confirm the model receives an `isError: true` toolResult and the review continues rather than crashing the webhook