### PR TITLE
Harden GitHub REST for large PR reviews

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,10 @@ REVIEW_CONCURRENCY=2
 # Max P0/P1/P2 findings rendered inline and in the review summary table (schema cap is 8)
 MAX_REVIEW_FINDINGS=8
 
+# Cap listPullRequestFiles output (file count and total patch bytes)
+MAX_PR_FILES_LISTED=300
+MAX_PR_FILES_PATCH_BYTES=500000
+
 # Optional PR labels from structured review
 ENABLE_REVIEW_LABELS_EFFORT=true
 ENABLE_REVIEW_LABELS_SECURITY=false

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,3 +18,6 @@ This file is **domain language only** — not a specification of how the system 
 - **Review payload** — The structured, validated description of a completed review run (findings plus overview gates), emitted once per review run via `submitReview`.
 - **Review summary comment** — A server-rendered comment on the PR conversation, identified by the sentinel `## PR Agent Review`, containing navigation and overview gates—not duplicated finding bodies from inline review threads.
 - **Security review summary comment** — Same shape as a review summary comment, identified by `## PR Agent Security Review`; may coexist with a general review summary on the same PR.
+- **Probable secondary rate limit** — GitHub returned an auth-shaped error while the installation token is still within its TTL; treated as a likely pacing/abuse limit for logging and cooldown, not a confirmed diagnosis.
+- **Truncated change set** — File listing for a review run where some changed files are omitted due to configured caps; the run continues with explicit truncation metadata.
+- **Rate-limit circuit** — After repeated classified rate-limit failures in one review run, further GitHub investigation tools are short-circuited; `submitReview` remains available.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ GitHub App webhook service that performs automated pull request reviews using [`
 - **Bot identity** for self-suppression is cached **per `GITHUB_APP_ID`**, so multiple GitHub Apps in one process do not share the same cache entry.
 - **`/review-security`** — trigger-only deep security review (DeepSec-adapted prompt; see [NOTICES.md](NOTICES.md)). Never runs on `pull_request` webhooks. Uses the same `ReviewQueue` and `MAX_TOOL_ROUNDS` as `/review`; large PRs may need a higher `MAX_TOOL_ROUNDS`. Posts a separate summary comment (`## PR Agent Security Review`) that can coexist with the general review summary.
 
+## Large PRs and GitHub rate limits
+
+- **`@octokit/plugin-throttling`** paces all installation-token REST calls (review tools, publish, reactions). Tune via env: `MAX_PR_FILES_LISTED` (default `300`), `MAX_PR_FILES_PATCH_BYTES` (default `500000`).
+- On tool failures, logs emit `github_tool_request_error` with `x-github-request-id`, `x-ratelimit-*`, and a **classification** — capture a redacted sample when debugging production limits.
+- See [docs/adr/0007-github-api-rate-limits.md](docs/adr/0007-github-api-rate-limits.md) for policy (secondary-limit retries, circuit breaker, truncation trade-offs).
+
 ## GitHub App setup (summary)
 
 1. Create a GitHub App; set **Webhook URL** to `https://<host>/webhooks` and **Webhook secret** → `WEBHOOK_SECRET`.

--- a/docs/adr/0007-github-api-rate-limits.md
+++ b/docs/adr/0007-github-api-rate-limits.md
@@ -1,0 +1,42 @@
+# ADR 0007 — GitHub API rate limits and resilient review tooling
+
+## Status
+
+Accepted.
+
+## Context
+
+Large PR reviews drive many GitHub REST/GraphQL tool calls in a single synchronous webhook. Production observed sustained `Bad credentials` errors during bursts; root cause was not proven, but the failure mode matches rate-limit / secondary-limit pressure (see [issue #9](https://github.com/prathamdby/pr-agent/issues/9)).
+
+`@octokit/plugin-retry` alone does not pace requests or honor `Retry-After` for secondary limits.
+
+## Decision
+
+1. **Global throttling** — Compose `@octokit/plugin-throttling` with `@octokit/plugin-retry` on every `installationOctokit()` instance (review tools, publish, PR-surface I/O). Plugin order: `retry`, then `throttling` (throttling outermost).
+
+2. **Hook policy**
+   - `onRateLimit`: retry when `retryCount < 2` (two retries).
+   - `onSecondaryRateLimit`: retry only when `retryAfter > 0` and `retryCount === 0`.
+
+3. **Structured logging** — On tool failure, log `github_tool_request_error` with status, `x-github-request-id`, `x-ratelimit-*`, `retry-after`, token age, and classification. Never log tokens.
+
+4. **App-layer classification** — After the plugin exhausts retries, classify errors (`rate_limit`, `secondary_rate_limit`, `probable_secondary` for young-token `Bad credentials`, `token_expired`, `auth`, `other`). Inject cooldown text into `toolResult` for rate classes.
+
+5. **Circuit breaker** — After 3 consecutive classified rate-limit failures in one review run, short-circuit non-`submitReview` GitHub tools for the remainder of the run; nudge the model to call `submitReview`.
+
+6. **`listPullRequestFiles`** — Server-side pagination (`per_page: 100`), caps `MAX_PR_FILES_LISTED` (default 300) and `MAX_PR_FILES_PATCH_BYTES` (default 500_000). Remove client `page`/`perPage` from the tool schema.
+
+7. **Prompt discipline** — Prefer patches from `listPullRequestFiles`; limit `searchCode` / `getBlame`.
+
+## Consequences
+
+- Reviews on large PRs may run longer (throttle waits); synchronous webhook contract unchanged; `WEBHOOK_TIMEOUT_MS` remains logging-only.
+- Truncated PRs (>300 files) degrade review coverage by design.
+- Throttle state is per-process; `REVIEW_CONCURRENCY > 1` or multi-replica deploys can still burst the same installation.
+- `probable_secondary` is a heuristic; use structured logs to disprove in production.
+
+## Deferred
+
+- Async webhook ack (early `200`).
+- Mid-review installation token re-mint.
+- Cross-process rate-limit coordination (Redis Bottleneck clustering).

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@effect/platform-node": "0.106.0",
         "@octokit/auth-app": "^8.1.2",
         "@octokit/plugin-retry": "^8.1.0",
+        "@octokit/plugin-throttling": "^11.0.3",
         "@octokit/rest": "^21.1.1",
         "effect": "3.21.2",
         "zod": "^4.3.6"
@@ -1749,6 +1750,22 @@
       },
       "peerDependencies": {
         "@octokit/core": ">=7"
+      }
+    },
+    "node_modules/@octokit/plugin-throttling": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-11.0.3.tgz",
+      "integrity": "sha512-34eE0RkFCKycLl2D2kq7W+LovheM/ex3AwZCYN8udpi6bxsyjZidb2McXs69hZhLmJlDqTSP8cH+jSRpiaijBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": "^7.0.0"
       }
     },
     "node_modules/@octokit/request": {

--- a/package.json
+++ b/package.json
@@ -17,13 +17,14 @@
   },
   "dependencies": {
     "@earendil-works/pi-ai": "^0.74.0",
+    "@effect/platform": "0.96.1",
+    "@effect/platform-node": "0.106.0",
     "@octokit/auth-app": "^8.1.2",
     "@octokit/plugin-retry": "^8.1.0",
+    "@octokit/plugin-throttling": "^11.0.3",
     "@octokit/rest": "^21.1.1",
-    "zod": "^4.3.6",
     "effect": "3.21.2",
-    "@effect/platform": "0.96.1",
-    "@effect/platform-node": "0.106.0"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^22.13.14",

--- a/src/agent/githubTools.ts
+++ b/src/agent/githubTools.ts
@@ -100,17 +100,22 @@ async function listPullRequestFilesPaginated(
 	omittedCount: number;
 	warning?: string;
 }> {
-	const all: Array<{
+	const files: Array<{
 		filename: string;
 		status: string;
 		additions: number;
 		deletions: number;
 		changes: number;
 		patch?: string;
+		patchOmitted?: boolean;
 	}> = [];
 
 	let truncated = false;
 	let omittedCount = 0;
+	let omittedCountLowerBound = false;
+	let patchBytes = 0;
+	let patchOmittedCount = 0;
+	let patchCapReached = false;
 
 	for (let page = 1; ; page++) {
 		const { data } = await octokit.rest.pulls.listFiles({
@@ -123,45 +128,61 @@ async function listPullRequestFilesPaginated(
 		if (data.length === 0) break;
 		let consumed = 0;
 		for (const file of data) {
-			if (all.length >= limits.maxPrFilesListed) {
+			if (files.length >= limits.maxPrFilesListed) {
 				truncated = true;
 				omittedCount += data.length - consumed;
+				if (data.length === 100) omittedCountLowerBound = true;
 				break;
 			}
-			all.push({
+
+			const rawPatch = file.patch ?? undefined;
+			let patch: string | undefined = rawPatch;
+			let patchOmitted: true | undefined;
+
+			if (rawPatch != null && !patchCapReached) {
+				const patchLen = Buffer.byteLength(rawPatch, "utf8");
+				if (patchBytes + patchLen <= limits.maxPrFilesPatchBytes) {
+					patchBytes += patchLen;
+					patchOmitted = undefined;
+				} else {
+					patchCapReached = true;
+					patchOmittedCount++;
+					patch = undefined;
+					patchOmitted = true;
+				}
+			} else if (rawPatch != null && patchCapReached) {
+				patch = undefined;
+				patchOmitted = true;
+				patchOmittedCount++;
+			} else {
+				patch = undefined;
+				patchOmitted = undefined;
+			}
+
+			files.push({
 				filename: file.filename,
 				status: file.status,
 				additions: file.additions,
 				deletions: file.deletions,
 				changes: file.changes,
-				patch: file.patch ?? undefined,
+				patch,
+				...(patchOmitted ? { patchOmitted } : {}),
 			});
 			consumed++;
+
+			if (patchCapReached) break;
 		}
-		if (truncated) break;
+		if (truncated || patchCapReached) break;
 		if (data.length < 100) break;
 	}
 
-	let patchBytes = 0;
-	let patchOmittedCount = 0;
-	const files = all.map((file) => {
-		const patch = file.patch;
-		if (patch == null) {
-			return { ...file, patch: undefined };
-		}
-		const patchLen = Buffer.byteLength(patch, "utf8");
-		if (patchBytes + patchLen <= limits.maxPrFilesPatchBytes) {
-			patchBytes += patchLen;
-			return file;
-		}
-		patchOmittedCount++;
-		return { ...file, patch: undefined, patchOmitted: true as const };
-	});
-
 	const warnings: string[] = [];
 	if (truncated) {
+		const omittedLabel = omittedCountLowerBound
+			? `at least ${omittedCount}`
+			: String(omittedCount);
 		warnings.push(
-			`Change set truncated to ${limits.maxPrFilesListed} files (${omittedCount} omitted).`,
+			`Change set truncated to ${limits.maxPrFilesListed} files (${omittedLabel} omitted).`,
 		);
 	}
 	if (patchOmittedCount > 0) {

--- a/src/agent/githubTools.ts
+++ b/src/agent/githubTools.ts
@@ -115,6 +115,7 @@ async function listPullRequestFilesPaginated(
 	let omittedCountLowerBound = false;
 	let patchBytes = 0;
 	let patchOmittedCount = 0;
+	let patchSkippedFileCount = 0;
 	let patchCapReached = false;
 
 	for (let page = 1; ; page++) {
@@ -172,6 +173,11 @@ async function listPullRequestFilesPaginated(
 
 			if (patchCapReached) break;
 		}
+		if (patchCapReached) {
+			const skippedOnPage = data.length - consumed;
+			omittedCount += skippedOnPage;
+			patchSkippedFileCount += skippedOnPage;
+		}
 		if (truncated || patchCapReached) break;
 		if (data.length < 100) break;
 	}
@@ -186,8 +192,12 @@ async function listPullRequestFilesPaginated(
 		);
 	}
 	if (patchOmittedCount > 0) {
+		const patchParts = [`patches omitted for ${patchOmittedCount} file(s)`];
+		if (patchSkippedFileCount > 0) {
+			patchParts.push(`${patchSkippedFileCount} additional file(s) not listed`);
+		}
 		warnings.push(
-			`Unified diff patches omitted for ${patchOmittedCount} file(s) after ${limits.maxPrFilesPatchBytes} byte cap.`,
+			`Unified diff ${patchParts.join("; ")} after ${limits.maxPrFilesPatchBytes} byte cap.`,
 		);
 	}
 	const warning = warnings.length > 0 ? warnings.join(" ") : undefined;

--- a/src/agent/githubTools.ts
+++ b/src/agent/githubTools.ts
@@ -80,11 +80,98 @@ type BlameResponse = {
 	};
 };
 
-export function buildGithubTools(token: string): {
+async function listPullRequestFilesPaginated(
+	octokit: ReturnType<typeof installationOctokit>,
+	owner: string,
+	repo: string,
+	pullNumber: number,
+	limits: { maxPrFilesListed: number; maxPrFilesPatchBytes: number },
+): Promise<{
+	files: Array<{
+		filename: string;
+		status: string;
+		additions: number;
+		deletions: number;
+		changes: number;
+		patch?: string;
+		patchOmitted?: boolean;
+	}>;
+	truncated: boolean;
+	omittedCount: number;
+	warning?: string;
+}> {
+	const all: Array<{
+		filename: string;
+		status: string;
+		additions: number;
+		deletions: number;
+		changes: number;
+		patch?: string;
+	}> = [];
+
+	let truncated = false;
+	let omittedCount = 0;
+
+	for (let page = 1; ; page++) {
+		const { data } = await octokit.rest.pulls.listFiles({
+			owner,
+			repo,
+			pull_number: pullNumber,
+			per_page: 100,
+			page,
+		});
+		if (data.length === 0) break;
+		let consumed = 0;
+		for (const file of data) {
+			if (all.length >= limits.maxPrFilesListed) {
+				truncated = true;
+				omittedCount += data.length - consumed;
+				break;
+			}
+			all.push({
+				filename: file.filename,
+				status: file.status,
+				additions: file.additions,
+				deletions: file.deletions,
+				changes: file.changes,
+				patch: file.patch ?? undefined,
+			});
+			consumed++;
+		}
+		if (truncated) break;
+		if (data.length < 100) break;
+	}
+
+	let patchBytes = 0;
+	const files = all.map((file) => {
+		const patch = file.patch;
+		if (patch == null) {
+			return { ...file, patch: undefined };
+		}
+		const patchLen = Buffer.byteLength(patch, "utf8");
+		if (patchBytes + patchLen <= limits.maxPrFilesPatchBytes) {
+			patchBytes += patchLen;
+			return file;
+		}
+		return { ...file, patch: undefined, patchOmitted: true as const };
+	});
+
+	const warning = truncated
+		? `Change set truncated to ${limits.maxPrFilesListed} files (${omittedCount} omitted).`
+		: undefined;
+
+	return { files, truncated, omittedCount, warning };
+}
+
+export function buildGithubTools(
+	token: string,
+	limits?: { maxPrFilesListed: number; maxPrFilesPatchBytes: number },
+): {
 	piTools: PiTool[];
 	executors: Record<string, (args: Record<string, unknown>) => Promise<unknown>>;
 } {
 	const octokit = installationOctokit(token);
+	const fileLimits = limits ?? { maxPrFilesListed: 300, maxPrFilesPatchBytes: 500_000 };
 
 	const getPullRequest: ReviewTool = {
 		description: "Get detailed information about a specific pull request",
@@ -148,25 +235,15 @@ export function buildGithubTools(token: string): {
 			owner: z.string().describe("Repository owner"),
 			repo: z.string().describe("Repository name"),
 			pullNumber: z.number().describe("Pull request number"),
-			perPage: z.number().optional().default(30).describe("Number of results to return (max 100)"),
-			page: z.number().optional().default(1).describe("Page number for pagination"),
 		}),
-		run: async ({ owner, repo, pullNumber, perPage, page }) => {
-			const { data } = await octokit.rest.pulls.listFiles({
-				owner,
-				repo,
-				pull_number: pullNumber,
-				per_page: perPage,
-				page,
-			});
-			return data.map((file) => ({
-				filename: file.filename,
-				status: file.status,
-				additions: file.additions,
-				deletions: file.deletions,
-				changes: file.changes,
-				patch: file.patch,
-			}));
+		run: async ({ owner, repo, pullNumber }) => {
+			const result = await listPullRequestFilesPaginated(octokit, owner, repo, pullNumber, fileLimits);
+			return {
+				files: result.files,
+				truncated: result.truncated,
+				omittedCount: result.omittedCount,
+				warning: result.warning,
+			};
 		},
 	};
 

--- a/src/agent/githubTools.ts
+++ b/src/agent/githubTools.ts
@@ -115,7 +115,6 @@ async function listPullRequestFilesPaginated(
 	let omittedCountLowerBound = false;
 	let patchBytes = 0;
 	let patchOmittedCount = 0;
-	let patchSkippedFileCount = 0;
 	let patchCapReached = false;
 
 	for (let page = 1; ; page++) {
@@ -171,11 +170,6 @@ async function listPullRequestFilesPaginated(
 			});
 			consumed++;
 		}
-		if (patchCapReached && !truncated) {
-			const skippedOnPage = data.length - consumed;
-			omittedCount += skippedOnPage;
-			patchSkippedFileCount += skippedOnPage;
-		}
 		if (truncated) break;
 		if (data.length < 100) break;
 	}
@@ -190,12 +184,8 @@ async function listPullRequestFilesPaginated(
 		);
 	}
 	if (patchOmittedCount > 0) {
-		const patchParts = [`patches omitted for ${patchOmittedCount} file(s)`];
-		if (patchSkippedFileCount > 0) {
-			patchParts.push(`${patchSkippedFileCount} additional file(s) not listed`);
-		}
 		warnings.push(
-			`Unified diff ${patchParts.join("; ")} after ${limits.maxPrFilesPatchBytes} byte cap.`,
+			`Unified diff patches omitted for ${patchOmittedCount} file(s) after ${limits.maxPrFilesPatchBytes} byte cap.`,
 		);
 	}
 	const warning = warnings.length > 0 ? warnings.join(" ") : undefined;

--- a/src/agent/githubTools.ts
+++ b/src/agent/githubTools.ts
@@ -170,15 +170,13 @@ async function listPullRequestFilesPaginated(
 				...(patchOmitted ? { patchOmitted } : {}),
 			});
 			consumed++;
-
-			if (patchCapReached) break;
 		}
-		if (patchCapReached) {
+		if (patchCapReached && !truncated) {
 			const skippedOnPage = data.length - consumed;
 			omittedCount += skippedOnPage;
 			patchSkippedFileCount += skippedOnPage;
 		}
-		if (truncated || patchCapReached) break;
+		if (truncated) break;
 		if (data.length < 100) break;
 	}
 

--- a/src/agent/githubTools.ts
+++ b/src/agent/githubTools.ts
@@ -143,6 +143,7 @@ async function listPullRequestFilesPaginated(
 	}
 
 	let patchBytes = 0;
+	let patchOmittedCount = 0;
 	const files = all.map((file) => {
 		const patch = file.patch;
 		if (patch == null) {
@@ -153,12 +154,22 @@ async function listPullRequestFilesPaginated(
 			patchBytes += patchLen;
 			return file;
 		}
+		patchOmittedCount++;
 		return { ...file, patch: undefined, patchOmitted: true as const };
 	});
 
-	const warning = truncated
-		? `Change set truncated to ${limits.maxPrFilesListed} files (${omittedCount} omitted).`
-		: undefined;
+	const warnings: string[] = [];
+	if (truncated) {
+		warnings.push(
+			`Change set truncated to ${limits.maxPrFilesListed} files (${omittedCount} omitted).`,
+		);
+	}
+	if (patchOmittedCount > 0) {
+		warnings.push(
+			`Unified diff patches omitted for ${patchOmittedCount} file(s) after ${limits.maxPrFilesPatchBytes} byte cap.`,
+		);
+	}
+	const warning = warnings.length > 0 ? warnings.join(" ") : undefined;
 
 	return { files, truncated, omittedCount, warning };
 }

--- a/src/agent/reviewRun.ts
+++ b/src/agent/reviewRun.ts
@@ -9,10 +9,10 @@ import { automatedSecuritySystemPrompt, githubToolingDiscipline } from "./securi
 import { buildSubmitReviewTool, filterReviewAgentExecutors, filterReviewAgentTools } from "./submitReviewTool.js";
 import type { ReviewMode } from "./reviewSchema.js";
 import {
+	bumpRateLimitConsecutiveFailures,
 	classifyGithubToolError,
 	formatToolErrorMessage,
 	isInstallationTokenNearExpiry,
-	isRateLimitClassification,
 	logGithubToolRequestError,
 } from "../github/githubRequestError.js";
 
@@ -294,21 +294,36 @@ export async function runFullPrReview(params: {
 				continue;
 			}
 
-			try {
-				if (
-					githubExecutorNames.has(call.name) &&
-					isInstallationTokenNearExpiry(tokenExpiresAtTs)
-				) {
-					log.warn("token_expired_before_tool", {
-						tool: call.name,
-						tokenExpiresInSeconds: Math.max(
-							0,
-							Math.floor((tokenExpiresAtTs - Date.now()) / 1000),
-						),
-					});
-					throw new Error("Installation token is near expiry for this review run");
-				}
+			const isGithubTool = githubExecutorNames.has(call.name);
 
+			if (isGithubTool && isInstallationTokenNearExpiry(tokenExpiresAtTs)) {
+				log.warn("token_expired_before_tool", {
+					tool: call.name,
+					tokenExpiresInSeconds: Math.max(
+						0,
+						Math.floor((tokenExpiresAtTs - Date.now()) / 1000),
+					),
+				});
+				isError = true;
+				const classified = classifyGithubToolError(
+					new Error("token near expiry guard"),
+					{ expiresAtTs: tokenExpiresAtTs },
+				);
+				logGithubToolRequestError(call.name, null, logCtx, classified);
+				text = formatToolErrorMessage(call.name, null, classified);
+				rateLimitConsecutiveFailures = 0;
+				context.messages.push({
+					role: "toolResult",
+					toolCallId: call.id,
+					toolName: call.name,
+					content: [{ type: "text", text }],
+					isError,
+					timestamp: Date.now(),
+				});
+				continue;
+			}
+
+			try {
 				const exec = executors[call.name];
 				if (!exec) throw new Error(`Unknown tool: ${call.name}`);
 				const out = await exec(call.arguments);
@@ -321,34 +336,34 @@ export async function runFullPrReview(params: {
 				}
 			} catch (e) {
 				isError = true;
-				const isGithubTool = githubExecutorNames.has(call.name);
 				if (isGithubTool) {
 					const classified = classifyGithubToolError(e, { expiresAtTs: tokenExpiresAtTs });
 					logGithubToolRequestError(call.name, e, logCtx, classified);
 					text = formatToolErrorMessage(call.name, e, classified);
 
-					if (isRateLimitClassification(classified.classification)) {
-						rateLimitConsecutiveFailures++;
-						if (
-							!rateLimitCircuitOpen &&
-							rateLimitConsecutiveFailures >= RATE_LIMIT_CIRCUIT_THRESHOLD
-						) {
-							rateLimitCircuitOpen = true;
-							log.warn("review_rate_limit_circuit_open", {
-								consecutiveFailures: rateLimitConsecutiveFailures,
-								owner,
-								repo,
-								pr: prNumber,
-								mode: reviewMode,
+					rateLimitConsecutiveFailures = bumpRateLimitConsecutiveFailures(
+						rateLimitConsecutiveFailures,
+						classified.classification,
+					);
+					if (
+						!rateLimitCircuitOpen &&
+						rateLimitConsecutiveFailures >= RATE_LIMIT_CIRCUIT_THRESHOLD
+					) {
+						rateLimitCircuitOpen = true;
+						log.warn("review_rate_limit_circuit_open", {
+							consecutiveFailures: rateLimitConsecutiveFailures,
+							owner,
+							repo,
+							pr: prNumber,
+							mode: reviewMode,
+						});
+						if (!circuitUserMessageSent) {
+							circuitUserMessageSent = true;
+							context.messages.push({
+								role: "user",
+								content: CIRCUIT_OPEN_USER_MESSAGE,
+								timestamp: Date.now(),
 							});
-							if (!circuitUserMessageSent) {
-								circuitUserMessageSent = true;
-								context.messages.push({
-									role: "user",
-									content: CIRCUIT_OPEN_USER_MESSAGE,
-									timestamp: Date.now(),
-								});
-							}
 						}
 					}
 				} else {

--- a/src/agent/reviewRun.ts
+++ b/src/agent/reviewRun.ts
@@ -193,6 +193,7 @@ export async function runFullPrReview(params: {
 	cfg: Config;
 	token: string;
 	tokenExpiresAtTs: number;
+	tokenTtlMs: number;
 	owner: string;
 	repo: string;
 	prNumber: number;
@@ -200,9 +201,13 @@ export async function runFullPrReview(params: {
 	mode?: ReviewMode;
 	userSupplement?: string;
 }): Promise<ReviewRunResult> {
-	const { cfg, token, tokenExpiresAtTs, owner, repo, prNumber, headSha, userSupplement } = params;
+	const { cfg, token, tokenExpiresAtTs, tokenTtlMs, owner, repo, prNumber, headSha, userSupplement } =
+		params;
 	if (!Number.isFinite(tokenExpiresAtTs)) {
 		throw new Error("tokenExpiresAtTs must be a finite timestamp in milliseconds");
+	}
+	if (!Number.isFinite(tokenTtlMs) || tokenTtlMs <= 0) {
+		throw new Error("tokenTtlMs must be a positive finite duration in milliseconds");
 	}
 	const reviewMode = params.mode ?? "review";
 
@@ -267,6 +272,7 @@ export async function runFullPrReview(params: {
 
 	const logCtx = {
 		expiresAtTs: tokenExpiresAtTs,
+		ttlMs: tokenTtlMs,
 		owner,
 		repo,
 		prNumber,
@@ -310,7 +316,7 @@ export async function runFullPrReview(params: {
 				isError = true;
 				const classified = classifyGithubToolError(
 					new Error("token near expiry guard"),
-					{ expiresAtTs: tokenExpiresAtTs },
+					{ expiresAtTs: tokenExpiresAtTs, ttlMs: tokenTtlMs },
 				);
 				logGithubToolRequestError(call.name, null, logCtx, classified);
 				text = formatToolErrorMessage(call.name, null, classified);
@@ -339,7 +345,10 @@ export async function runFullPrReview(params: {
 			} catch (e) {
 				isError = true;
 				if (isGithubTool) {
-					const classified = classifyGithubToolError(e, { expiresAtTs: tokenExpiresAtTs });
+					const classified = classifyGithubToolError(e, {
+						expiresAtTs: tokenExpiresAtTs,
+						ttlMs: tokenTtlMs,
+					});
 					logGithubToolRequestError(call.name, e, logCtx, classified);
 					text = formatToolErrorMessage(call.name, e, classified);
 

--- a/src/agent/reviewRun.ts
+++ b/src/agent/reviewRun.ts
@@ -226,13 +226,15 @@ export async function runFullPrReview(params: {
 		state: submitState,
 	});
 
+	const reviewGithubExecutors = filterReviewAgentExecutors(gh.executors);
+
 	const piTools: PiTool[] = [
 		...filterReviewAgentTools(gh.piTools),
 		...ctx7.piTools,
 		submitTool,
 	];
 	const executors: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
-		...filterReviewAgentExecutors(gh.executors),
+		...reviewGithubExecutors,
 		...ctx7.executors,
 		submitReview: submitExecutor,
 	};
@@ -279,7 +281,7 @@ export async function runFullPrReview(params: {
 		mode: reviewMode,
 	};
 
-	const githubExecutorNames = new Set(Object.keys(gh.executors));
+	const githubExecutorNames = new Set(Object.keys(reviewGithubExecutors));
 
 	async function appendToolResults(toolCalls: ToolCall[]) {
 		for (const call of toolCalls) {

--- a/src/agent/reviewRun.ts
+++ b/src/agent/reviewRun.ts
@@ -314,7 +314,6 @@ export async function runFullPrReview(params: {
 				);
 				logGithubToolRequestError(call.name, null, logCtx, classified);
 				text = formatToolErrorMessage(call.name, null, classified);
-				rateLimitConsecutiveFailures = 0;
 				context.messages.push({
 					role: "toolResult",
 					toolCallId: call.id,

--- a/src/agent/reviewRun.ts
+++ b/src/agent/reviewRun.ts
@@ -5,9 +5,22 @@ import { log } from "../log.js";
 import { buildContext7Tools } from "./context7Tools.js";
 import { buildGithubTools } from "./githubTools.js";
 import { createIssueComment } from "../github/reviewPublish.js";
-import { automatedSecuritySystemPrompt } from "./securityPrompt.js";
+import { automatedSecuritySystemPrompt, githubToolingDiscipline } from "./securityPrompt.js";
 import { buildSubmitReviewTool, filterReviewAgentExecutors, filterReviewAgentTools } from "./submitReviewTool.js";
 import type { ReviewMode } from "./reviewSchema.js";
+import {
+	classifyGithubToolError,
+	formatToolErrorMessage,
+	isInstallationTokenNearExpiry,
+	isRateLimitClassification,
+	logGithubToolRequestError,
+} from "../github/githubRequestError.js";
+
+const RATE_LIMIT_CIRCUIT_THRESHOLD = 3;
+const CIRCUIT_OPEN_USER_MESSAGE =
+	"Stop GitHub tool calls; call submitReview now with your current analysis from the conversation above.";
+const CIRCUIT_OPEN_TOOL_RESULT =
+	"Rate-limit circuit open: further GitHub investigation tools are blocked for this review run. Call submitReview now.";
 
 const PUBLISH_FALLBACK_SENTINEL = "## PR Agent Review — could not publish structured output";
 const SECURITY_PUBLISH_FALLBACK_SENTINEL =
@@ -76,8 +89,10 @@ function buildAutomatedSystemPrompt(): string {
 		"",
 		"## Getting started (GitHub tooling)",
 		"1. Understand context: inspect the PR body, linked issues/tickets via tools where possible, head SHA, and file list touched by this PR.",
-		"2. Obtain the change set: inspect the unified diff / changed files via tools; work through everything that changed—leave no touched file unscanned.",
+		"2. Obtain the change set: call `listPullRequestFiles` and inspect patches; work through everything that changed—leave no touched file unscanned.",
 		"3. Do not speculate: verify suspicion with reads against the codebase or API responses reachable through tools.",
+		"",
+		githubToolingDiscipline,
 		"",
 		"<!-- BEGIN_SHARED_METHODOLOGY -->",
 		"",
@@ -177,6 +192,7 @@ function buildAutomatedSystemPrompt(): string {
 export async function runFullPrReview(params: {
 	cfg: Config;
 	token: string;
+	tokenExpiresAtTs: number;
 	owner: string;
 	repo: string;
 	prNumber: number;
@@ -184,10 +200,13 @@ export async function runFullPrReview(params: {
 	mode?: ReviewMode;
 	userSupplement?: string;
 }): Promise<ReviewRunResult> {
-	const { cfg, token, owner, repo, prNumber, headSha, userSupplement } = params;
+	const { cfg, token, tokenExpiresAtTs, owner, repo, prNumber, headSha, userSupplement } = params;
 	const reviewMode = params.mode ?? "review";
 
-	const gh = buildGithubTools(token);
+	const gh = buildGithubTools(token, {
+		maxPrFilesListed: cfg.maxPrFilesListed,
+		maxPrFilesPatchBytes: cfg.maxPrFilesPatchBytes,
+	});
 	const ctx7 = buildContext7Tools({ apiKey: cfg.context7ApiKey });
 	const submitState = { published: false, inlinePublished: false, lastValidationError: null };
 	const publishCtx = { owner, repo, prNumber, headSha };
@@ -239,12 +258,57 @@ export async function runFullPrReview(params: {
 	let lastAssistant: AssistantMessage | null = null;
 	let stopLoop = false;
 	let publishAttempts = 0;
+	let rateLimitConsecutiveFailures = 0;
+	let rateLimitCircuitOpen = false;
+	let circuitUserMessageSent = false;
+
+	const logCtx = {
+		expiresAtTs: tokenExpiresAtTs,
+		owner,
+		repo,
+		prNumber,
+		mode: reviewMode,
+	};
+
+	const githubExecutorNames = new Set(Object.keys(gh.executors));
 
 	async function appendToolResults(toolCalls: ToolCall[]) {
 		for (const call of toolCalls) {
 			let text: string;
 			let isError = false;
+
+			if (
+				rateLimitCircuitOpen &&
+				call.name !== "submitReview" &&
+				githubExecutorNames.has(call.name)
+			) {
+				log.info("github_tool_circuit_short_circuit", { tool: call.name });
+				context.messages.push({
+					role: "toolResult",
+					toolCallId: call.id,
+					toolName: call.name,
+					content: [{ type: "text", text: CIRCUIT_OPEN_TOOL_RESULT }],
+					isError: true,
+					timestamp: Date.now(),
+				});
+				continue;
+			}
+
 			try {
+				if (
+					githubExecutorNames.has(call.name) &&
+					isInstallationTokenNearExpiry(tokenExpiresAtTs)
+				) {
+					log.warn("token_expired_before_tool", {
+						tool: call.name,
+						tokenExpiresInSeconds: Math.max(
+							0,
+							Math.floor((tokenExpiresAtTs - Date.now()) / 1000),
+						),
+					});
+					throw new Error("Installation token is near expiry for this review run");
+				}
+
 				const exec = executors[call.name];
 				if (!exec) throw new Error(`Unknown tool: ${call.name}`);
 				const out = await exec(call.arguments);
@@ -252,10 +316,45 @@ export async function runFullPrReview(params: {
 				if (call.name === "submitReview" && submitState.published) {
 					stopLoop = true;
 				}
+				if (githubExecutorNames.has(call.name)) {
+					rateLimitConsecutiveFailures = 0;
+				}
 			} catch (e) {
 				isError = true;
-				text = e instanceof Error ? e.message : `Error executing ${call.name}: ${String(e)}`;
-				log.warn("tool_execute_failed", { tool: call.name, message: text });
+				const isGithubTool = githubExecutorNames.has(call.name);
+				if (isGithubTool) {
+					const classified = classifyGithubToolError(e, { expiresAtTs: tokenExpiresAtTs });
+					logGithubToolRequestError(call.name, e, logCtx, classified);
+					text = formatToolErrorMessage(call.name, e, classified);
+
+					if (isRateLimitClassification(classified.classification)) {
+						rateLimitConsecutiveFailures++;
+						if (
+							!rateLimitCircuitOpen &&
+							rateLimitConsecutiveFailures >= RATE_LIMIT_CIRCUIT_THRESHOLD
+						) {
+							rateLimitCircuitOpen = true;
+							log.warn("review_rate_limit_circuit_open", {
+								consecutiveFailures: rateLimitConsecutiveFailures,
+								owner,
+								repo,
+								pr: prNumber,
+								mode: reviewMode,
+							});
+							if (!circuitUserMessageSent) {
+								circuitUserMessageSent = true;
+								context.messages.push({
+									role: "user",
+									content: CIRCUIT_OPEN_USER_MESSAGE,
+									timestamp: Date.now(),
+								});
+							}
+						}
+					}
+				} else {
+					text = e instanceof Error ? e.message : `Error executing ${call.name}: ${String(e)}`;
+					log.warn("tool_execute_failed", { tool: call.name, message: text });
+				}
 			}
 
 			context.messages.push({

--- a/src/agent/reviewRun.ts
+++ b/src/agent/reviewRun.ts
@@ -201,6 +201,9 @@ export async function runFullPrReview(params: {
 	userSupplement?: string;
 }): Promise<ReviewRunResult> {
 	const { cfg, token, tokenExpiresAtTs, owner, repo, prNumber, headSha, userSupplement } = params;
+	if (!Number.isFinite(tokenExpiresAtTs)) {
+		throw new Error("tokenExpiresAtTs must be a finite timestamp in milliseconds");
+	}
 	const reviewMode = params.mode ?? "review";
 
 	const gh = buildGithubTools(token, {

--- a/src/agent/reviewRun.ts
+++ b/src/agent/reviewRun.ts
@@ -263,7 +263,7 @@ export async function runFullPrReview(params: {
 	let publishAttempts = 0;
 	let rateLimitConsecutiveFailures = 0;
 	let rateLimitCircuitOpen = false;
-	let circuitUserMessageSent = false;
+	let circuitUserMessagePending = false;
 
 	const logCtx = {
 		expiresAtTs: tokenExpiresAtTs,
@@ -359,14 +359,7 @@ export async function runFullPrReview(params: {
 							pr: prNumber,
 							mode: reviewMode,
 						});
-						if (!circuitUserMessageSent) {
-							circuitUserMessageSent = true;
-							context.messages.push({
-								role: "user",
-								content: CIRCUIT_OPEN_USER_MESSAGE,
-								timestamp: Date.now(),
-							});
-						}
+						circuitUserMessagePending = true;
 					}
 				} else {
 					text = e instanceof Error ? e.message : `Error executing ${call.name}: ${String(e)}`;
@@ -380,6 +373,15 @@ export async function runFullPrReview(params: {
 				toolName: call.name,
 				content: [{ type: "text", text }],
 				isError,
+				timestamp: Date.now(),
+			});
+		}
+
+		if (circuitUserMessagePending) {
+			circuitUserMessagePending = false;
+			context.messages.push({
+				role: "user",
+				content: CIRCUIT_OPEN_USER_MESSAGE,
 				timestamp: Date.now(),
 			});
 		}

--- a/src/agent/securityPrompt.ts
+++ b/src/agent/securityPrompt.ts
@@ -4,12 +4,21 @@
  * https://github.com/vercel-labs/deepsec
  */
 
+export const githubToolingDiscipline = [
+	"## GitHub tooling discipline",
+	"- Call `listPullRequestFiles` once and prefer each file's `patch` before `getFileContent`.",
+	"- Call `searchCode` and `getBlame` only when a finding genuinely depends on them (Search API ~30 req/min; GraphQL points are separate).",
+	"- If a tool result includes rate-limit cooldown text, do not issue further GitHub tools until the cooldown elapses; call submitReview with your current analysis.",
+].join("\n");
+
 export const automatedSecuritySystemPrompt = [
 	"You are a world-class security researcher with deep expertise in web application security, authentication systems, and modern application frameworks across many languages. You think like an attacker: you look for subtle logic flaws, not just textbook vulnerabilities. You have a track record of finding bugs that automated tools miss — race conditions, auth bypasses via parameter manipulation, and trust boundary violations.",
 	"",
 	"You are reviewing the changed files in a pull request. The PR diff is your investigation surface. Use the available GitHub tools to fetch file content, related code, and history; trace user-controlled input through the diff and into any code it reaches.",
 	"",
 	"**Static analysis only.** Do NOT attempt to reproduce, exploit, or trigger any vulnerability. Do not run the target code, send requests against any endpoint, or execute proof-of-concept scripts. Review the source code only.",
+	"",
+	githubToolingDiscipline,
 	"",
 	"## Severity classification (security findings only)",
 	"",

--- a/src/commands/slashCommandFlow.ts
+++ b/src/commands/slashCommandFlow.ts
@@ -17,6 +17,7 @@ export type ReplyTarget =
 export type SlashContext = {
 	readonly cfg: Config;
 	readonly token: string;
+	readonly tokenExpiresAtTs: number;
 	readonly owner: string;
 	readonly repo: string;
 	readonly botUserId: number;
@@ -93,6 +94,7 @@ export function runSlashCommandFlow(
 						runFullPrReview({
 							cfg: ctx.cfg,
 							token: ctx.token,
+							tokenExpiresAtTs: ctx.tokenExpiresAtTs,
 							owner: ctx.owner,
 							repo: ctx.repo,
 							prNumber: ctx.replyTarget.prNumber,

--- a/src/commands/slashCommandFlow.ts
+++ b/src/commands/slashCommandFlow.ts
@@ -18,6 +18,7 @@ export type SlashContext = {
 	readonly cfg: Config;
 	readonly token: string;
 	readonly tokenExpiresAtTs: number;
+	readonly tokenTtlMs: number;
 	readonly owner: string;
 	readonly repo: string;
 	readonly botUserId: number;
@@ -95,6 +96,7 @@ export function runSlashCommandFlow(
 							cfg: ctx.cfg,
 							token: ctx.token,
 							tokenExpiresAtTs: ctx.tokenExpiresAtTs,
+							tokenTtlMs: ctx.tokenTtlMs,
 							owner: ctx.owner,
 							repo: ctx.repo,
 							prNumber: ctx.replyTarget.prNumber,

--- a/src/config.ts
+++ b/src/config.ts
@@ -107,6 +107,16 @@ export function loadConfig() {
 	const enableReviewLabelsEffort = optionalEnv("ENABLE_REVIEW_LABELS_EFFORT", "true") === "true";
 	const enableReviewLabelsSecurity = optionalEnv("ENABLE_REVIEW_LABELS_SECURITY", "false") === "true";
 
+	const maxPrFilesListed = Number(optionalEnv("MAX_PR_FILES_LISTED", "300"));
+	if (!Number.isFinite(maxPrFilesListed) || maxPrFilesListed < 1) {
+		throw new Error("MAX_PR_FILES_LISTED must be a positive number");
+	}
+
+	const maxPrFilesPatchBytes = Number(optionalEnv("MAX_PR_FILES_PATCH_BYTES", "500000"));
+	if (!Number.isFinite(maxPrFilesPatchBytes) || maxPrFilesPatchBytes < 1) {
+		throw new Error("MAX_PR_FILES_PATCH_BYTES must be a positive number");
+	}
+
 	const logLevel = optionalEnv("LOG_LEVEL", "info") as "debug" | "info" | "warn" | "error";
 	if (!["debug", "info", "warn", "error"].includes(logLevel)) {
 		throw new Error('LOG_LEVEL must be one of debug, info, warn, error');
@@ -128,6 +138,8 @@ export function loadConfig() {
 		maxReviewFindings,
 		enableReviewLabelsEffort,
 		enableReviewLabelsSecurity,
+		maxPrFilesListed,
+		maxPrFilesPatchBytes,
 		logLevel,
 	};
 }

--- a/src/effect/services/githubInstallationToken.ts
+++ b/src/effect/services/githubInstallationToken.ts
@@ -1,6 +1,6 @@
 import { Clock, Context, Deferred, Effect, Layer, Ref } from "effect";
 import type { Config } from "../../config.js";
-import { mintInstallationAuth } from "../../github/appAuth.js";
+import { mintInstallationAuth, type InstallationToken } from "../../github/appAuth.js";
 import { log } from "../../log.js";
 
 const FRESHNESS_BUFFER_MS = 60_000;
@@ -8,12 +8,12 @@ const FALLBACK_TTL_MS = 55 * 60 * 1000;
 
 type Entry =
   | { readonly tag: "value"; readonly token: string; readonly expiresAtTs: number }
-  | { readonly tag: "pending"; readonly deferred: Deferred.Deferred<string, Error> };
+  | { readonly tag: "pending"; readonly deferred: Deferred.Deferred<InstallationToken, Error> };
 
 type StoreAction =
-  | { readonly tag: "hit"; readonly token: string }
-  | { readonly tag: "wait"; readonly deferred: Deferred.Deferred<string, Error> }
-  | { readonly tag: "claim"; readonly deferred: Deferred.Deferred<string, Error> };
+  | { readonly tag: "hit"; readonly token: InstallationToken }
+  | { readonly tag: "wait"; readonly deferred: Deferred.Deferred<InstallationToken, Error> }
+  | { readonly tag: "claim"; readonly deferred: Deferred.Deferred<InstallationToken, Error> };
 
 export class GithubInstallationToken extends Context.Tag("GithubInstallationToken")<
   GithubInstallationToken,
@@ -21,7 +21,7 @@ export class GithubInstallationToken extends Context.Tag("GithubInstallationToke
     readonly getToken: (
       cfg: Pick<Config, "githubAppId" | "githubAppPrivateKey">,
       installationId: number,
-    ) => Effect.Effect<string, Error>;
+    ) => Effect.Effect<InstallationToken, Error>;
   }
 >() {}
 
@@ -34,13 +34,12 @@ export const GithubInstallationTokenLive = Layer.effect(
       getToken: (cfg, installationId) =>
         Effect.gen(function* () {
           const now = yield* Clock.currentTimeMillis;
-          const candidate = yield* Deferred.make<string, Error>();
+          const candidate = yield* Deferred.make<InstallationToken, Error>();
 
-          // Atomic check-and-claim: return fresh token, attach to in-flight mint, or claim it. Expired entries fall through to claim.
           const action = yield* Ref.modify(store, (map): readonly [StoreAction, Map<number, Entry>] => {
             const hit = map.get(installationId);
             if (hit && hit.tag === "value" && hit.expiresAtTs - FRESHNESS_BUFFER_MS > now) {
-              return [{ tag: "hit", token: hit.token }, map];
+              return [{ tag: "hit", token: { token: hit.token, expiresAtTs: hit.expiresAtTs } }, map];
             }
             if (hit && hit.tag === "pending") {
               return [{ tag: "wait", deferred: hit.deferred }, map];
@@ -52,22 +51,23 @@ export const GithubInstallationTokenLive = Layer.effect(
           if (action.tag === "hit") return action.token;
           if (action.tag === "wait") return yield* Deferred.await(action.deferred);
 
-          // Sole minter: on failure clear the pending entry so a later caller retries.
           return yield* Effect.tryPromise({
             try: () => mintInstallationAuth(cfg, installationId),
             catch: (e) => (e instanceof Error ? e : new Error(String(e))),
           }).pipe(
-            Effect.tap((auth) =>
-              Effect.gen(function* () {
-                const expiresAtTs = auth.expiresAt ? Date.parse(auth.expiresAt) : now + FALLBACK_TTL_MS;
+            Effect.flatMap((auth) => {
+              const expiresAtTs = auth.expiresAt ? Date.parse(auth.expiresAt) : now + FALLBACK_TTL_MS;
+              const value: InstallationToken = { token: auth.token, expiresAtTs };
+              return Effect.gen(function* () {
                 yield* Ref.update(store, (m) => {
                   m.set(installationId, { tag: "value", token: auth.token, expiresAtTs });
                   return m;
                 });
-                yield* Deferred.succeed(action.deferred, auth.token);
+                yield* Deferred.succeed(action.deferred, value);
                 log.debug("minted_installation_token", { installationId, expiresAt: auth.expiresAt });
-              }),
-            ),
+                return value;
+              });
+            }),
             Effect.tapError((err) =>
               Effect.gen(function* () {
                 yield* Ref.update(store, (m) => {
@@ -77,7 +77,6 @@ export const GithubInstallationTokenLive = Layer.effect(
                 yield* Deferred.fail(action.deferred, err);
               }),
             ),
-            Effect.map((auth) => auth.token),
           );
         }),
     });

--- a/src/effect/services/githubInstallationToken.ts
+++ b/src/effect/services/githubInstallationToken.ts
@@ -7,7 +7,7 @@ const FRESHNESS_BUFFER_MS = 60_000;
 const FALLBACK_TTL_MS = 55 * 60 * 1000;
 
 type Entry =
-  | { readonly tag: "value"; readonly token: string; readonly expiresAtTs: number }
+  | { readonly tag: "value"; readonly token: InstallationToken }
   | { readonly tag: "pending"; readonly deferred: Deferred.Deferred<InstallationToken, Error> };
 
 type StoreAction =
@@ -38,8 +38,8 @@ export const GithubInstallationTokenLive = Layer.effect(
 
           const action = yield* Ref.modify(store, (map): readonly [StoreAction, Map<number, Entry>] => {
             const hit = map.get(installationId);
-            if (hit && hit.tag === "value" && hit.expiresAtTs - FRESHNESS_BUFFER_MS > now) {
-              return [{ tag: "hit", token: { token: hit.token, expiresAtTs: hit.expiresAtTs } }, map];
+            if (hit && hit.tag === "value" && hit.token.expiresAtTs - FRESHNESS_BUFFER_MS > now) {
+              return [{ tag: "hit", token: hit.token }, map];
             }
             if (hit && hit.tag === "pending") {
               return [{ tag: "wait", deferred: hit.deferred }, map];
@@ -60,7 +60,7 @@ export const GithubInstallationTokenLive = Layer.effect(
               const value: InstallationToken = { token: auth.token, expiresAtTs };
               return Effect.gen(function* () {
                 yield* Ref.update(store, (m) => {
-                  m.set(installationId, { tag: "value", token: auth.token, expiresAtTs });
+                  m.set(installationId, { tag: "value", token: value });
                   return m;
                 });
                 yield* Deferred.succeed(action.deferred, value);

--- a/src/effect/services/githubInstallationToken.ts
+++ b/src/effect/services/githubInstallationToken.ts
@@ -56,7 +56,8 @@ export const GithubInstallationTokenLive = Layer.effect(
             catch: (e) => (e instanceof Error ? e : new Error(String(e))),
           }).pipe(
             Effect.flatMap((auth) => {
-              const expiresAtTs = auth.expiresAt ? Date.parse(auth.expiresAt) : now + FALLBACK_TTL_MS;
+              const parsed = auth.expiresAt ? Date.parse(auth.expiresAt) : Number.NaN;
+              const expiresAtTs = Number.isFinite(parsed) ? parsed : now + FALLBACK_TTL_MS;
               const value: InstallationToken = { token: auth.token, expiresAtTs };
               return Effect.gen(function* () {
                 yield* Ref.update(store, (m) => {

--- a/src/effect/services/githubInstallationToken.ts
+++ b/src/effect/services/githubInstallationToken.ts
@@ -58,7 +58,10 @@ export const GithubInstallationTokenLive = Layer.effect(
             Effect.flatMap((auth) => {
               const parsed = auth.expiresAt ? Date.parse(auth.expiresAt) : Number.NaN;
               const expiresAtTs = Number.isFinite(parsed) ? parsed : now + FALLBACK_TTL_MS;
-              const value: InstallationToken = { token: auth.token, expiresAtTs };
+              const ttlMs = Number.isFinite(parsed)
+                ? Math.max(0, expiresAtTs - now)
+                : FALLBACK_TTL_MS;
+              const value: InstallationToken = { token: auth.token, expiresAtTs, ttlMs };
               return Effect.gen(function* () {
                 yield* Ref.update(store, (m) => {
                   m.set(installationId, { tag: "value", token: value });

--- a/src/effect/services/webhookHandlers.ts
+++ b/src/effect/services/webhookHandlers.ts
@@ -1,6 +1,7 @@
 import { Context, Effect, Layer } from "effect";
 import type { Config } from "../../config.js";
 import { runFullPrReview } from "../../agent/reviewRun.js";
+import type { InstallationToken } from "../../github/appAuth.js";
 import { parseSlashCommand } from "../../commands/parseSlashCommand.js";
 import { runSlashCommandFlow } from "../../commands/slashCommandFlow.js";
 import { log } from "../../log.js";
@@ -18,11 +19,11 @@ const AUTOMATED_PR_ACTIONS = new Set(["opened", "synchronize", "reopened"]);
 export class WebhookHandlers extends Context.Tag("WebhookHandlers")<
 	WebhookHandlers,
 	{
-		readonly pullRequest: (cfg: Config, token: string, data: PullRequestData) => Effect.Effect<void, Error>;
-		readonly issueComment: (cfg: Config, token: string, data: IssueCommentData) => Effect.Effect<void, Error>;
+		readonly pullRequest: (cfg: Config, installation: InstallationToken, data: PullRequestData) => Effect.Effect<void, Error>;
+		readonly issueComment: (cfg: Config, installation: InstallationToken, data: IssueCommentData) => Effect.Effect<void, Error>;
 		readonly pullRequestReviewComment: (
 			cfg: Config,
-			token: string,
+			installation: InstallationToken,
 			data: PullRequestReviewCommentData,
 		) => Effect.Effect<void, Error>;
 	}
@@ -36,7 +37,7 @@ export const WebhookHandlersCore = Layer.effect(
 		const reviewQueue = yield* ReviewQueue;
 
 		return WebhookHandlers.of({
-			pullRequest: (cfg, token, data) =>
+			pullRequest: (cfg, installation, data) =>
 				Effect.gen(function* () {
 					const action = data.action;
 					if (!action || !AUTOMATED_PR_ACTIONS.has(action)) return;
@@ -45,6 +46,7 @@ export const WebhookHandlersCore = Layer.effect(
 					const repo = data.repository.name;
 					const prNumber = data.pull_request.number;
 					const headSha = data.pull_request.head.sha;
+					const { token, expiresAtTs: tokenExpiresAtTs } = installation;
 
 					yield* surface.acknowledgeOnPrConversation(token, owner, repo, prNumber);
 
@@ -54,7 +56,15 @@ export const WebhookHandlersCore = Layer.effect(
 						`${owner}/${repo}#${prNumber}:auto`,
 						Effect.tryPromise({
 							try: () =>
-								runFullPrReview({ cfg, token, owner, repo, prNumber, headSha }).then((result) => {
+								runFullPrReview({
+									cfg,
+									token,
+									tokenExpiresAtTs,
+									owner,
+									repo,
+									prNumber,
+									headSha,
+								}).then((result) => {
 									if (!result.published) {
 										log.warn("review_not_published", {
 											owner,
@@ -69,17 +79,19 @@ export const WebhookHandlersCore = Layer.effect(
 					);
 				}),
 
-			issueComment: (cfg, token, data) =>
+			issueComment: (cfg, installation, data) =>
 				Effect.gen(function* () {
 					if (data.action !== "created") return;
 					const body = data.comment.body ?? "";
 					if (!parseSlashCommand(body)) return;
 
+					const { token, expiresAtTs: tokenExpiresAtTs } = installation;
 					const botUserId = yield* botIdentity.getUserId(cfg, token);
 
 					yield* runSlashCommandFlow({
 						cfg,
 						token,
+						tokenExpiresAtTs,
 						owner: data.repository.owner.login,
 						repo: data.repository.name,
 						botUserId,
@@ -93,17 +105,19 @@ export const WebhookHandlersCore = Layer.effect(
 					);
 				}),
 
-			pullRequestReviewComment: (cfg, token, data) =>
+			pullRequestReviewComment: (cfg, installation, data) =>
 				Effect.gen(function* () {
 					if (data.action !== "created") return;
 					const body = data.comment.body ?? "";
 					if (!parseSlashCommand(body)) return;
 
+					const { token, expiresAtTs: tokenExpiresAtTs } = installation;
 					const botUserId = yield* botIdentity.getUserId(cfg, token);
 
 					yield* runSlashCommandFlow({
 						cfg,
 						token,
+						tokenExpiresAtTs,
 						owner: data.repository.owner.login,
 						repo: data.repository.name,
 						botUserId,

--- a/src/effect/services/webhookHandlers.ts
+++ b/src/effect/services/webhookHandlers.ts
@@ -46,7 +46,7 @@ export const WebhookHandlersCore = Layer.effect(
 					const repo = data.repository.name;
 					const prNumber = data.pull_request.number;
 					const headSha = data.pull_request.head.sha;
-					const { token, expiresAtTs: tokenExpiresAtTs } = installation;
+					const { token, expiresAtTs: tokenExpiresAtTs, ttlMs: tokenTtlMs } = installation;
 
 					yield* surface.acknowledgeOnPrConversation(token, owner, repo, prNumber);
 
@@ -60,6 +60,7 @@ export const WebhookHandlersCore = Layer.effect(
 									cfg,
 									token,
 									tokenExpiresAtTs,
+									tokenTtlMs,
 									owner,
 									repo,
 									prNumber,
@@ -85,13 +86,14 @@ export const WebhookHandlersCore = Layer.effect(
 					const body = data.comment.body ?? "";
 					if (!parseSlashCommand(body)) return;
 
-					const { token, expiresAtTs: tokenExpiresAtTs } = installation;
+					const { token, expiresAtTs: tokenExpiresAtTs, ttlMs: tokenTtlMs } = installation;
 					const botUserId = yield* botIdentity.getUserId(cfg, token);
 
 					yield* runSlashCommandFlow({
 						cfg,
 						token,
 						tokenExpiresAtTs,
+						tokenTtlMs,
 						owner: data.repository.owner.login,
 						repo: data.repository.name,
 						botUserId,
@@ -111,13 +113,14 @@ export const WebhookHandlersCore = Layer.effect(
 					const body = data.comment.body ?? "";
 					if (!parseSlashCommand(body)) return;
 
-					const { token, expiresAtTs: tokenExpiresAtTs } = installation;
+					const { token, expiresAtTs: tokenExpiresAtTs, ttlMs: tokenTtlMs } = installation;
 					const botUserId = yield* botIdentity.getUserId(cfg, token);
 
 					yield* runSlashCommandFlow({
 						cfg,
 						token,
 						tokenExpiresAtTs,
+						tokenTtlMs,
 						owner: data.repository.owner.login,
 						repo: data.repository.name,
 						botUserId,

--- a/src/github/appAuth.ts
+++ b/src/github/appAuth.ts
@@ -53,13 +53,18 @@ async function mintAppJwtToken(cfg: Pick<Config, "githubAppId" | "githubAppPriva
  */
 async function resolveBotIdentityViaAppSlug(cfg: Pick<Config, "githubAppId" | "githubAppPrivateKey">): Promise<BotIdentity> {
 	const jwtToken = await mintAppJwtToken(cfg);
-	const jwtOctokit = new ThrottledOctokit({ auth: jwtToken });
+	const jwtOctokit = new ThrottledOctokit({
+		auth: jwtToken,
+		throttle: { onRateLimit, onSecondaryRateLimit },
+	});
 	const { data } = await jwtOctokit.rest.apps.getAuthenticated();
 	if (!data?.slug) {
 		throw new Error("GitHub App /app response missing slug (cannot resolve bot user)");
 	}
 	const slug = data.slug;
-	const anon = new ThrottledOctokit();
+	const anon = new ThrottledOctokit({
+		throttle: { onRateLimit, onSecondaryRateLimit },
+	});
 	const { data: user } = await anon.rest.users.getByUsername({
 		username: `${slug}[bot]`,
 	});

--- a/src/github/appAuth.ts
+++ b/src/github/appAuth.ts
@@ -1,14 +1,22 @@
 import { createAppAuth, type InstallationAccessTokenAuthentication } from "@octokit/auth-app";
 import { Octokit } from "@octokit/rest";
 import { retry } from "@octokit/plugin-retry";
+import { throttling } from "@octokit/plugin-throttling";
 import type { Config } from "../config.js";
 import { log } from "../log.js";
+import { onRateLimit, onSecondaryRateLimit } from "./octokitThrottle.js";
 
-const RetryOctokit = Octokit.plugin(retry);
-export type InstallationOctokit = InstanceType<typeof RetryOctokit>;
+// @ts-expect-error — nested @octokit/core versions between rest, retry, and throttling plugins
+const ThrottledOctokit = Octokit.plugin(retry, throttling);
+export type InstallationOctokit = InstanceType<typeof ThrottledOctokit>;
 
 export type CachedInstallationToken = InstallationAccessTokenAuthentication & { expiresAtTs: number };
 export type BotIdentity = { userId: number; login: string };
+
+export type InstallationToken = {
+	readonly token: string;
+	readonly expiresAtTs: number;
+};
 
 export async function mintInstallationAuth(
 	cfg: Pick<Config, "githubAppId" | "githubAppPrivateKey">,
@@ -25,7 +33,10 @@ export async function mintInstallationAuth(
 }
 
 export function installationOctokit(token: string): InstallationOctokit {
-	return new RetryOctokit({ auth: token });
+	return new ThrottledOctokit({
+		auth: token,
+		throttle: { onRateLimit, onSecondaryRateLimit },
+	});
 }
 
 async function mintAppJwtToken(cfg: Pick<Config, "githubAppId" | "githubAppPrivateKey">): Promise<string> {
@@ -42,13 +53,13 @@ async function mintAppJwtToken(cfg: Pick<Config, "githubAppId" | "githubAppPriva
  */
 async function resolveBotIdentityViaAppSlug(cfg: Pick<Config, "githubAppId" | "githubAppPrivateKey">): Promise<BotIdentity> {
 	const jwtToken = await mintAppJwtToken(cfg);
-	const jwtOctokit = new RetryOctokit({ auth: jwtToken });
+	const jwtOctokit = new ThrottledOctokit({ auth: jwtToken });
 	const { data } = await jwtOctokit.rest.apps.getAuthenticated();
 	if (!data?.slug) {
 		throw new Error("GitHub App /app response missing slug (cannot resolve bot user)");
 	}
 	const slug = data.slug;
-	const anon = new RetryOctokit();
+	const anon = new ThrottledOctokit();
 	const { data: user } = await anon.rest.users.getByUsername({
 		username: `${slug}[bot]`,
 	});

--- a/src/github/appAuth.ts
+++ b/src/github/appAuth.ts
@@ -16,6 +16,8 @@ export type BotIdentity = { userId: number; login: string };
 export type InstallationToken = {
 	readonly token: string;
 	readonly expiresAtTs: number;
+	/** Observed TTL at mint (ms); used for token_age_seconds in logs */
+	readonly ttlMs: number;
 };
 
 export async function mintInstallationAuth(

--- a/src/github/githubRequestError.ts
+++ b/src/github/githubRequestError.ts
@@ -125,6 +125,11 @@ export function extractGithubResponseMeta(err: RequestError): {
 function isPrimaryRateLimitExceeded(message: string, headers: ResponseHeaders | undefined): boolean {
 	if (headerString(headers, "x-ratelimit-remaining") !== "0") return false;
 	if (SECONDARY_RATE_MESSAGE.test(message)) return false;
+	const retryAfter = headerString(headers, "retry-after");
+	if (retryAfter) {
+		const parsed = Number(retryAfter);
+		if (Number.isFinite(parsed) && parsed > 0) return false;
+	}
 	const resource = headerString(headers, "x-ratelimit-resource");
 	if (resource == null) return false;
 	return resource === "core" || resource === "search";
@@ -175,6 +180,18 @@ export function classifyGithubToolError(
 			pluginSecondaryRateLimit: true,
 			...retry,
 		};
+	}
+
+	if (meta.retryAfterHeader) {
+		const parsed = Number(meta.retryAfterHeader);
+		if (Number.isFinite(parsed) && parsed > 0) {
+			return {
+				classification: "secondary_rate_limit",
+				pluginPrimaryRateLimit: false,
+				pluginSecondaryRateLimit: true,
+				...retry,
+			};
+		}
 	}
 
 	if (meta.pluginPrimaryRateLimit) {

--- a/src/github/githubRequestError.ts
+++ b/src/github/githubRequestError.ts
@@ -94,7 +94,7 @@ export function getTokenTiming(
 		ttlMs ??
 		(observedTtlMs > 0
 			? Math.min(MAX_ASSUMED_INSTALLATION_TOKEN_TTL_MS, observedTtlMs)
-			: MAX_ASSUMED_INSTALLATION_TOKEN_TTL_MS);
+			: 0);
 	const issuedAtTs = expiresAtTs - effectiveTtlMs;
 	const tokenAgeSeconds = Math.max(0, Math.floor((now - issuedAtTs) / 1000));
 	return { tokenAgeSeconds, tokenExpiresInSeconds };

--- a/src/github/githubRequestError.ts
+++ b/src/github/githubRequestError.ts
@@ -21,6 +21,7 @@ const BAD_CREDENTIALS_MESSAGE = /bad credentials/i;
 
 export type InstallationTokenContext = {
 	readonly expiresAtTs: number;
+	readonly ttlMs?: number;
 	readonly now?: number;
 };
 
@@ -49,11 +50,27 @@ export function isGithubRequestError(err: unknown): err is RequestError {
 	);
 }
 
+function graphqlRateLimitErrors(err: unknown): Array<{ type?: string }> {
+	const e = err as {
+		errors?: Array<{ type?: string }>;
+		data?: { errors?: Array<{ type?: string }> };
+		response?: { errors?: Array<{ type?: string }>; data?: { errors?: Array<{ type?: string }> } };
+	};
+	return (
+		e.errors ??
+		e.response?.errors ??
+		e.data?.errors ??
+		e.response?.data?.errors ??
+		[]
+	);
+}
+
 export function isGraphqlRateLimitError(err: unknown): boolean {
 	if (!(err instanceof Error)) return false;
+	// @octokit/plugin-throttling (wrap-request.js)
 	if (err.message === "GraphQL Rate Limit Exceeded") return true;
-	const response = (err as { response?: { data?: { errors?: Array<{ type?: string }> } } }).response;
-	return (response?.data?.errors ?? []).some((e) => e.type === "RATE_LIMITED");
+	// @octokit/graphql GraphqlResponseError exposes errors on err.errors / err.response.errors
+	return graphqlRateLimitErrors(err).some((e) => e.type === "RATE_LIMITED");
 }
 
 function headerString(headers: ResponseHeaders | undefined, name: string): string | undefined {
@@ -63,15 +80,22 @@ function headerString(headers: ResponseHeaders | undefined, name: string): strin
 	return String(v);
 }
 
-// GitHub does not return issued-at; age assumes a 1h TTL and may overstate real age when TTL is shorter (e.g. 10m)
-const ASSUMED_INSTALLATION_TOKEN_TTL_MS = 60 * 60 * 1000;
+// GitHub does not return issued-at; infer from expiresAt using min(observed TTL, 1h cap)
+const MAX_ASSUMED_INSTALLATION_TOKEN_TTL_MS = 60 * 60 * 1000;
 
 export function getTokenTiming(
 	expiresAtTs: number,
 	now: number = Date.now(),
+	ttlMs?: number,
 ): { tokenAgeSeconds: number; tokenExpiresInSeconds: number } {
 	const tokenExpiresInSeconds = Math.max(0, Math.floor((expiresAtTs - now) / 1000));
-	const issuedAtTs = expiresAtTs - ASSUMED_INSTALLATION_TOKEN_TTL_MS;
+	const observedTtlMs = Math.max(0, expiresAtTs - now);
+	const effectiveTtlMs =
+		ttlMs ??
+		(observedTtlMs > 0
+			? Math.min(MAX_ASSUMED_INSTALLATION_TOKEN_TTL_MS, observedTtlMs)
+			: MAX_ASSUMED_INSTALLATION_TOKEN_TTL_MS);
+	const issuedAtTs = expiresAtTs - effectiveTtlMs;
 	const tokenAgeSeconds = Math.max(0, Math.floor((now - issuedAtTs) / 1000));
 	return { tokenAgeSeconds, tokenExpiresInSeconds };
 }
@@ -182,16 +206,13 @@ export function classifyGithubToolError(
 		};
 	}
 
-	if (meta.retryAfterHeader) {
-		const parsed = Number(meta.retryAfterHeader);
-		if (Number.isFinite(parsed) && parsed > 0) {
-			return {
-				classification: "secondary_rate_limit",
-				pluginPrimaryRateLimit: false,
-				pluginSecondaryRateLimit: true,
-				...retry,
-			};
-		}
+	if (parsePositiveRetryAfterSeconds(meta.retryAfterHeader) != null) {
+		return {
+			classification: "secondary_rate_limit",
+			pluginPrimaryRateLimit: false,
+			pluginSecondaryRateLimit: true,
+			...retry,
+		};
 	}
 
 	if (meta.pluginPrimaryRateLimit) {
@@ -234,15 +255,20 @@ export function classifyGithubToolError(
 	};
 }
 
+function parsePositiveRetryAfterSeconds(header: string | undefined): number | undefined {
+	if (header == null || header === "") return undefined;
+	const parsed = Number(header);
+	if (Number.isFinite(parsed) && parsed > 0) return Math.ceil(parsed);
+	return undefined;
+}
+
 function resolveRetryAfter(
 	meta: ReturnType<typeof extractGithubResponseMeta>,
 	now: number,
 ): { retryAfterSeconds: number; retryAfterSource: RetryAfterSource } {
-	if (meta.retryAfterHeader) {
-		const parsed = Number(meta.retryAfterHeader);
-		if (Number.isFinite(parsed) && parsed > 0) {
-			return { retryAfterSeconds: Math.ceil(parsed), retryAfterSource: "header" };
-		}
+	const fromHeader = parsePositiveRetryAfterSeconds(meta.retryAfterHeader);
+	if (fromHeader != null) {
+		return { retryAfterSeconds: fromHeader, retryAfterSource: "header" };
 	}
 
 	if (meta.rateLimitReset) {
@@ -284,7 +310,7 @@ export function logGithubToolRequestError(
 	logCtx: GithubToolLogContext,
 	classified: ClassifiedGithubError,
 ): void {
-	const timing = getTokenTiming(logCtx.expiresAtTs, logCtx.now);
+	const timing = getTokenTiming(logCtx.expiresAtTs, logCtx.now, logCtx.ttlMs);
 	const base: Record<string, unknown> = {
 		tool,
 		classification: classified.classification,

--- a/src/github/githubRequestError.ts
+++ b/src/github/githubRequestError.ts
@@ -342,9 +342,13 @@ export function logGithubToolRequestError(
 		return;
 	}
 
-	log.warn("tool_execute_failed", {
-		tool,
-		message: err instanceof Error ? err.message.slice(0, MESSAGE_TRUNCATE) : String(err),
+	log.warn("github_tool_request_error", {
+		...base,
+		status: 0,
+		message:
+			err instanceof Error
+				? err.message.slice(0, MESSAGE_TRUNCATE)
+				: String(err),
 	});
 }
 

--- a/src/github/githubRequestError.ts
+++ b/src/github/githubRequestError.ts
@@ -240,6 +240,16 @@ export function isRateLimitClassification(
 	);
 }
 
+export function bumpRateLimitConsecutiveFailures(
+	consecutive: number,
+	classification: GithubToolErrorClassification,
+): number {
+	return isRateLimitClassification(classification) ? consecutive + 1 : 0;
+}
+
+export const TOKEN_EXPIRED_TOOL_MESSAGE =
+	"Installation token is near expiry; cannot call GitHub tools for this review run. Call submitReview with your current analysis if possible.";
+
 export function logGithubToolRequestError(
 	tool: string,
 	err: unknown,
@@ -294,7 +304,12 @@ export function logGithubToolRequestError(
 		log.warn("github_tool_request_error", {
 			...base,
 			status: 0,
-			message: err instanceof Error ? err.message.slice(0, MESSAGE_TRUNCATE) : String(err),
+			message:
+				err instanceof Error
+					? err.message.slice(0, MESSAGE_TRUNCATE)
+					: err == null
+						? "token near expiry guard"
+						: String(err),
 		});
 		return;
 	}
@@ -316,7 +331,7 @@ export function formatToolErrorMessage(
 			: `Error executing ${tool}: ${String(err)}`;
 
 	if (classified.classification === "token_expired") {
-		return `${base}\n\nInstallation token is near expiry; cannot call GitHub tools for this review run. Call submitReview with your current analysis if possible.`;
+		return TOKEN_EXPIRED_TOOL_MESSAGE;
 	}
 
 	if (!isRateLimitClassification(classified.classification)) {

--- a/src/github/githubRequestError.ts
+++ b/src/github/githubRequestError.ts
@@ -1,0 +1,328 @@
+import { RequestError } from "@octokit/request-error";
+import type { ResponseHeaders } from "@octokit/types";
+import { log } from "../log.js";
+
+export type GithubToolErrorClassification =
+	| "token_expired"
+	| "secondary_rate_limit"
+	| "rate_limit"
+	| "probable_secondary"
+	| "auth"
+	| "other";
+
+export type RetryAfterSource = "header" | "x-ratelimit-reset" | "default" | "plugin-fallback";
+
+const TOKEN_FRESHNESS_BUFFER_MS = 60_000;
+const DEFAULT_COOLDOWN_SECONDS = 60;
+const MESSAGE_TRUNCATE = 500;
+
+const SECONDARY_RATE_MESSAGE = /\bsecondary rate\b/i;
+const BAD_CREDENTIALS_MESSAGE = /bad credentials/i;
+
+export type InstallationTokenContext = {
+	readonly expiresAtTs: number;
+	readonly now?: number;
+};
+
+export type GithubToolLogContext = InstallationTokenContext & {
+	readonly owner: string;
+	readonly repo: string;
+	readonly prNumber: number;
+	readonly mode: string;
+};
+
+export type ClassifiedGithubError = {
+	readonly classification: GithubToolErrorClassification;
+	readonly pluginPrimaryRateLimit: boolean;
+	readonly pluginSecondaryRateLimit: boolean;
+	readonly retryAfterSeconds: number;
+	readonly retryAfterSource: RetryAfterSource;
+};
+
+export function isGithubRequestError(err: unknown): err is RequestError {
+	return (
+		err instanceof RequestError ||
+		(typeof err === "object" &&
+			err !== null &&
+			(err as RequestError).name === "HttpError" &&
+			typeof (err as RequestError).status === "number")
+	);
+}
+
+export function isGraphqlRateLimitError(err: unknown): boolean {
+	if (!(err instanceof Error)) return false;
+	if (err.message === "GraphQL Rate Limit Exceeded") return true;
+	const response = (err as { response?: { data?: { errors?: Array<{ type?: string }> } } }).response;
+	return (response?.data?.errors ?? []).some((e) => e.type === "RATE_LIMITED");
+}
+
+function headerString(headers: ResponseHeaders | undefined, name: string): string | undefined {
+	if (!headers) return undefined;
+	const v = headers[name as keyof ResponseHeaders];
+	if (v === undefined || v === null) return undefined;
+	return String(v);
+}
+
+const ASSUMED_INSTALLATION_TOKEN_TTL_MS = 60 * 60 * 1000;
+
+export function getTokenTiming(
+	expiresAtTs: number,
+	now: number = Date.now(),
+): { tokenAgeSeconds: number; tokenExpiresInSeconds: number } {
+	const tokenExpiresInSeconds = Math.max(0, Math.floor((expiresAtTs - now) / 1000));
+	const issuedAtTs = expiresAtTs - ASSUMED_INSTALLATION_TOKEN_TTL_MS;
+	const tokenAgeSeconds = Math.max(0, Math.floor((now - issuedAtTs) / 1000));
+	return { tokenAgeSeconds, tokenExpiresInSeconds };
+}
+
+export function isInstallationTokenNearExpiry(
+	expiresAtTs: number,
+	now: number = Date.now(),
+): boolean {
+	return now >= expiresAtTs - TOKEN_FRESHNESS_BUFFER_MS;
+}
+
+export function extractGithubResponseMeta(err: RequestError): {
+	status: number;
+	message: string;
+	method: string | undefined;
+	url: string | undefined;
+	githubRequestId: string | undefined;
+	rateLimitResource: string | undefined;
+	rateLimitRemaining: string | undefined;
+	rateLimitLimit: string | undefined;
+	rateLimitReset: string | undefined;
+	rateLimitUsed: string | undefined;
+	retryAfterHeader: string | undefined;
+	octokitRetryCount: number | undefined;
+	pluginPrimaryRateLimit: boolean;
+	pluginSecondaryRateLimit: boolean;
+} {
+	const headers = err.response?.headers;
+	const message = err.message.slice(0, MESSAGE_TRUNCATE);
+	return {
+		status: err.status,
+		message,
+		method: err.request?.method,
+		url: err.request?.url,
+		githubRequestId: headerString(headers, "x-github-request-id"),
+		rateLimitResource: headerString(headers, "x-ratelimit-resource"),
+		rateLimitRemaining: headerString(headers, "x-ratelimit-remaining"),
+		rateLimitLimit: headerString(headers, "x-ratelimit-limit"),
+		rateLimitReset: headerString(headers, "x-ratelimit-reset"),
+		rateLimitUsed: headerString(headers, "x-ratelimit-used"),
+		retryAfterHeader: headerString(headers, "retry-after"),
+		octokitRetryCount: (() => {
+			const rc = (err.request as unknown as { retryCount?: number }).retryCount;
+			return typeof rc === "number" ? rc : undefined;
+		})(),
+		pluginPrimaryRateLimit: headerString(headers, "x-ratelimit-remaining") === "0",
+		pluginSecondaryRateLimit: SECONDARY_RATE_MESSAGE.test(err.message),
+	};
+}
+
+export function classifyGithubToolError(
+	err: unknown,
+	ctx: InstallationTokenContext,
+): ClassifiedGithubError {
+	const now = ctx.now ?? Date.now();
+
+	if (isGraphqlRateLimitError(err)) {
+		return {
+			classification: "rate_limit",
+			pluginPrimaryRateLimit: true,
+			pluginSecondaryRateLimit: false,
+			retryAfterSeconds: DEFAULT_COOLDOWN_SECONDS,
+			retryAfterSource: "default",
+		};
+	}
+
+	if (!isGithubRequestError(err)) {
+		if (isInstallationTokenNearExpiry(ctx.expiresAtTs, now)) {
+			return {
+				classification: "token_expired",
+				pluginPrimaryRateLimit: false,
+				pluginSecondaryRateLimit: false,
+				retryAfterSeconds: 0,
+				retryAfterSource: "default",
+			};
+		}
+		return {
+			classification: "other",
+			pluginPrimaryRateLimit: false,
+			pluginSecondaryRateLimit: false,
+			retryAfterSeconds: DEFAULT_COOLDOWN_SECONDS,
+			retryAfterSource: "default",
+		};
+	}
+
+	const meta = extractGithubResponseMeta(err);
+	const retry = resolveRetryAfter(meta, now);
+
+	if (meta.pluginSecondaryRateLimit) {
+		return {
+			classification: "secondary_rate_limit",
+			pluginPrimaryRateLimit: meta.pluginPrimaryRateLimit,
+			pluginSecondaryRateLimit: true,
+			...retry,
+		};
+	}
+
+	if (meta.pluginPrimaryRateLimit) {
+		return {
+			classification: "rate_limit",
+			pluginPrimaryRateLimit: true,
+			pluginSecondaryRateLimit: false,
+			...retry,
+		};
+	}
+
+	if (
+		(err.status === 401 || err.status === 403) &&
+		BAD_CREDENTIALS_MESSAGE.test(err.message) &&
+		now < ctx.expiresAtTs - TOKEN_FRESHNESS_BUFFER_MS
+	) {
+		return {
+			classification: "probable_secondary",
+			pluginPrimaryRateLimit: meta.pluginPrimaryRateLimit,
+			pluginSecondaryRateLimit: false,
+			...retry,
+		};
+	}
+
+	if (err.status === 401 || err.status === 403) {
+		return {
+			classification: "auth",
+			pluginPrimaryRateLimit: meta.pluginPrimaryRateLimit,
+			pluginSecondaryRateLimit: false,
+			retryAfterSeconds: 0,
+			retryAfterSource: "default",
+		};
+	}
+
+	return {
+		classification: "other",
+		pluginPrimaryRateLimit: meta.pluginPrimaryRateLimit,
+		pluginSecondaryRateLimit: meta.pluginSecondaryRateLimit,
+		...retry,
+	};
+}
+
+function resolveRetryAfter(
+	meta: ReturnType<typeof extractGithubResponseMeta>,
+	now: number,
+): { retryAfterSeconds: number; retryAfterSource: RetryAfterSource } {
+	if (meta.retryAfterHeader) {
+		const parsed = Number(meta.retryAfterHeader);
+		if (Number.isFinite(parsed) && parsed > 0) {
+			return { retryAfterSeconds: Math.ceil(parsed), retryAfterSource: "header" };
+		}
+	}
+
+	if (meta.rateLimitReset) {
+		const resetMs = Number(meta.rateLimitReset) * 1000;
+		if (Number.isFinite(resetMs)) {
+			const seconds = Math.max(1, Math.ceil((resetMs - now) / 1000) + 1);
+			return { retryAfterSeconds: seconds, retryAfterSource: "x-ratelimit-reset" };
+		}
+	}
+
+	return { retryAfterSeconds: DEFAULT_COOLDOWN_SECONDS, retryAfterSource: "default" };
+}
+
+export function isRateLimitClassification(
+	classification: GithubToolErrorClassification,
+): boolean {
+	return (
+		classification === "rate_limit" ||
+		classification === "secondary_rate_limit" ||
+		classification === "probable_secondary"
+	);
+}
+
+export function logGithubToolRequestError(
+	tool: string,
+	err: unknown,
+	logCtx: GithubToolLogContext,
+	classified: ClassifiedGithubError,
+): void {
+	const timing = getTokenTiming(logCtx.expiresAtTs, logCtx.now);
+	const base: Record<string, unknown> = {
+		tool,
+		classification: classified.classification,
+		...timing,
+		owner: logCtx.owner,
+		repo: logCtx.repo,
+		pr: logCtx.prNumber,
+		mode: logCtx.mode,
+		pluginPrimaryRateLimit: classified.pluginPrimaryRateLimit,
+		pluginSecondaryRateLimit: classified.pluginSecondaryRateLimit,
+		retryAfterSeconds: classified.retryAfterSeconds,
+		retryAfterSource: classified.retryAfterSource,
+	};
+
+	if (isGithubRequestError(err)) {
+		const meta = extractGithubResponseMeta(err);
+		log.warn("github_tool_request_error", {
+			...base,
+			status: meta.status,
+			message: meta.message,
+			method: meta.method,
+			url: meta.url,
+			githubRequestId: meta.githubRequestId,
+			rateLimitResource: meta.rateLimitResource,
+			rateLimitRemaining: meta.rateLimitRemaining,
+			rateLimitLimit: meta.rateLimitLimit,
+			rateLimitReset: meta.rateLimitReset,
+			rateLimitUsed: meta.rateLimitUsed,
+			retryAfterHeader: meta.retryAfterHeader,
+			octokitRetryCount: meta.octokitRetryCount,
+		});
+		return;
+	}
+
+	if (isGraphqlRateLimitError(err)) {
+		log.warn("github_tool_request_error", {
+			...base,
+			status: 0,
+			message: err instanceof Error ? err.message.slice(0, MESSAGE_TRUNCATE) : String(err),
+		});
+		return;
+	}
+
+	if (classified.classification === "token_expired") {
+		log.warn("github_tool_request_error", {
+			...base,
+			status: 0,
+			message: err instanceof Error ? err.message.slice(0, MESSAGE_TRUNCATE) : String(err),
+		});
+		return;
+	}
+
+	log.warn("tool_execute_failed", {
+		tool,
+		message: err instanceof Error ? err.message.slice(0, MESSAGE_TRUNCATE) : String(err),
+	});
+}
+
+export function formatToolErrorMessage(
+	tool: string,
+	err: unknown,
+	classified: ClassifiedGithubError,
+): string {
+	const base =
+		err instanceof Error
+			? `Error executing ${tool}: ${err.message}`
+			: `Error executing ${tool}: ${String(err)}`;
+
+	if (classified.classification === "token_expired") {
+		return `${base}\n\nInstallation token is near expiry; cannot call GitHub tools for this review run. Call submitReview with your current analysis if possible.`;
+	}
+
+	if (!isRateLimitClassification(classified.classification)) {
+		return base;
+	}
+
+	const seconds = classified.retryAfterSeconds || DEFAULT_COOLDOWN_SECONDS;
+	return `${base}\n\nRate-limit cooldown ${seconds}s; do not issue tool calls until cooldown elapses`;
+}

--- a/src/github/githubRequestError.ts
+++ b/src/github/githubRequestError.ts
@@ -63,6 +63,7 @@ function headerString(headers: ResponseHeaders | undefined, name: string): strin
 	return String(v);
 }
 
+// GitHub does not return issued-at; age assumes a 1h TTL and may overstate real age when TTL is shorter (e.g. 10m)
 const ASSUMED_INSTALLATION_TOKEN_TTL_MS = 60 * 60 * 1000;
 
 export function getTokenTiming(
@@ -116,9 +117,17 @@ export function extractGithubResponseMeta(err: RequestError): {
 			const rc = (err.request as unknown as { retryCount?: number }).retryCount;
 			return typeof rc === "number" ? rc : undefined;
 		})(),
-		pluginPrimaryRateLimit: headerString(headers, "x-ratelimit-remaining") === "0",
-		pluginSecondaryRateLimit: SECONDARY_RATE_MESSAGE.test(err.message),
+		pluginPrimaryRateLimit: isPrimaryRateLimitExceeded(message, headers),
+		pluginSecondaryRateLimit: SECONDARY_RATE_MESSAGE.test(message),
 	};
+}
+
+function isPrimaryRateLimitExceeded(message: string, headers: ResponseHeaders | undefined): boolean {
+	if (headerString(headers, "x-ratelimit-remaining") !== "0") return false;
+	if (SECONDARY_RATE_MESSAGE.test(message)) return false;
+	const resource = headerString(headers, "x-ratelimit-resource");
+	if (resource == null) return false;
+	return resource === "core" || resource === "search";
 }
 
 export function classifyGithubToolError(
@@ -244,6 +253,7 @@ export function bumpRateLimitConsecutiveFailures(
 	consecutive: number,
 	classification: GithubToolErrorClassification,
 ): number {
+	if (classification === "token_expired") return consecutive;
 	return isRateLimitClassification(classification) ? consecutive + 1 : 0;
 }
 

--- a/src/github/githubRequestError.ts
+++ b/src/github/githubRequestError.ts
@@ -270,6 +270,7 @@ export function bumpRateLimitConsecutiveFailures(
 	consecutive: number,
 	classification: GithubToolErrorClassification,
 ): number {
+	// Preserve streak on token_expired so near-expiry blocks do not erase rate-limit circuit progress
 	if (classification === "token_expired") return consecutive;
 	return isRateLimitClassification(classification) ? consecutive + 1 : 0;
 }

--- a/src/github/octokitThrottle.ts
+++ b/src/github/octokitThrottle.ts
@@ -1,0 +1,39 @@
+import type { Octokit } from "@octokit/core";
+import type { EndpointDefaults } from "@octokit/types";
+import { log } from "../log.js";
+
+export const PRIMARY_RATE_LIMIT_MAX_RETRIES = 2;
+
+export function onRateLimit(
+	retryAfter: number,
+	options: Required<EndpointDefaults>,
+	_octokit: Octokit,
+	retryCount: number,
+): boolean {
+	const willRetry = retryCount < PRIMARY_RATE_LIMIT_MAX_RETRIES;
+	log.warn("octokit_on_rate_limit", {
+		method: options.method,
+		url: options.url,
+		retryAfter,
+		retryCount,
+		willRetry,
+	});
+	return willRetry;
+}
+
+export function onSecondaryRateLimit(
+	retryAfter: number,
+	options: Required<EndpointDefaults>,
+	_octokit: Octokit,
+	retryCount: number,
+): boolean {
+	const willRetry = retryAfter > 0 && retryCount === 0;
+	log.warn("octokit_on_secondary_rate_limit", {
+		method: options.method,
+		url: options.url,
+		retryAfter,
+		retryCount,
+		willRetry,
+	});
+	return willRetry;
+}

--- a/test/dispatchEffect.test.ts
+++ b/test/dispatchEffect.test.ts
@@ -27,6 +27,7 @@ const cfg: Config = {
 const fakeInstallationToken: InstallationToken = {
 	token: "fake-token",
 	expiresAtTs: Date.now() + 3_600_000,
+	ttlMs: 3_600_000,
 };
 
 type Trace = {

--- a/test/dispatchEffect.test.ts
+++ b/test/dispatchEffect.test.ts
@@ -4,6 +4,7 @@ import type { Config } from "../src/config.js";
 import { WebhookParseError } from "../src/webhook/parseGithubPayload.js";
 import { dispatchGithubEventEffect } from "../src/effect/programs/dispatchEffect.js";
 import { DeliveryDedupe } from "../src/effect/services/deliveryDedupe.js";
+import type { InstallationToken } from "../src/github/appAuth.js";
 import { GithubInstallationToken } from "../src/effect/services/githubInstallationToken.js";
 import { WebhookHandlers } from "../src/effect/services/webhookHandlers.js";
 import * as parseModule from "../src/webhook/parseGithubPayload.js";
@@ -21,6 +22,11 @@ const cfg: Config = {
 	reviewConcurrency: 2,
 	webhookTimeoutMs: 10000,
 	logLevel: "error",
+};
+
+const fakeInstallationToken: InstallationToken = {
+	token: "fake-token",
+	expiresAtTs: Date.now() + 3_600_000,
 };
 
 type Trace = {
@@ -55,7 +61,7 @@ function buildLayers(trace: Trace) {
 			getToken: (cfg, installationId) =>
 				Effect.sync(() => {
 					trace.getToken(cfg, installationId);
-					return "fake-token";
+					return fakeInstallationToken;
 				}),
 		}),
 	);
@@ -146,7 +152,7 @@ describe("dispatchGithubEventEffect ordering", () => {
 									getToken: (cfg, id) =>
 										Effect.sync(() => {
 											trace.getToken(cfg, id);
-											return "fake-token";
+											return fakeInstallationToken;
 										}),
 								}),
 							),
@@ -212,7 +218,7 @@ describe("dispatchGithubEventEffect ordering", () => {
 			);
 
 			expect(trace.getToken).toHaveBeenCalledWith(cfg, 7);
-			expect(trace.pullRequest).toHaveBeenCalledWith(cfg, "fake-token", parsedData);
+			expect(trace.pullRequest).toHaveBeenCalledWith(cfg, fakeInstallationToken, parsedData);
 		} finally {
 			spy.mockRestore();
 		}

--- a/test/githubInstallationTokenService.test.ts
+++ b/test/githubInstallationTokenService.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { Effect, Layer, TestClock, TestContext } from "effect";
+import { Clock, Effect, Layer, TestClock, TestContext } from "effect";
 import * as appAuth from "../src/github/appAuth.js";
 import {
   GithubInstallationToken,
@@ -137,21 +137,25 @@ describe("GithubInstallationToken service", () => {
 
   it("uses fallback TTL when auth.expiresAt is unparseable", async () => {
     const spy = mockMint("tok-a", "not-a-valid-date");
+    const fallbackTtlMs = 55 * 60 * 1000;
 
     const program = Effect.gen(function* () {
+      const now = yield* Clock.currentTimeMillis;
       const svc = yield* GithubInstallationToken;
-      return yield* svc.getToken(cfg, 1);
+      const token = yield* svc.getToken(cfg, 1);
+      return { now, token };
     });
 
     try {
-      const token = await Effect.runPromise(
+      const { now, token } = await Effect.runPromise(
         program.pipe(
           Effect.provide(GithubInstallationTokenLive),
           Effect.provide(TestContext.TestContext),
         ),
       );
       expect(Number.isFinite(token.expiresAtTs)).toBe(true);
-      expect(token.expiresAtTs).toBe(55 * 60 * 1000);
+      expect(token.expiresAtTs).toBe(now + fallbackTtlMs);
+      expect(token.ttlMs).toBe(fallbackTtlMs);
     } finally {
       spy.mockRestore();
     }

--- a/test/githubInstallationTokenService.test.ts
+++ b/test/githubInstallationTokenService.test.ts
@@ -135,6 +135,28 @@ describe("GithubInstallationToken service", () => {
     }
   });
 
+  it("uses fallback TTL when auth.expiresAt is unparseable", async () => {
+    const spy = mockMint("tok-a", "not-a-valid-date");
+
+    const program = Effect.gen(function* () {
+      const svc = yield* GithubInstallationToken;
+      return yield* svc.getToken(cfg, 1);
+    });
+
+    try {
+      const token = await Effect.runPromise(
+        program.pipe(
+          Effect.provide(GithubInstallationTokenLive),
+          Effect.provide(TestContext.TestContext),
+        ),
+      );
+      expect(Number.isFinite(token.expiresAtTs)).toBe(true);
+      expect(token.expiresAtTs).toBe(55 * 60 * 1000);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
   it("retries after a failed mint (pending entry is cleared)", async () => {
     let calls = 0;
     const spy = vi.spyOn(appAuth, "mintInstallationAuth").mockImplementation(async (_cfg, id) => {

--- a/test/githubInstallationTokenService.test.ts
+++ b/test/githubInstallationTokenService.test.ts
@@ -31,8 +31,8 @@ describe("GithubInstallationToken service", () => {
 
     try {
       const [a, b] = await Effect.runPromise(program.pipe(Effect.provide(GithubInstallationTokenLive)));
-      expect(a).toBe("tok-a");
-      expect(b).toBe("tok-a");
+      expect(a.token).toBe("tok-a");
+      expect(b.token).toBe("tok-a");
       expect(spy).toHaveBeenCalledTimes(1);
     } finally {
       spy.mockRestore();
@@ -67,8 +67,8 @@ describe("GithubInstallationToken service", () => {
           Effect.provide(TestContext.TestContext),
         ),
       );
-      expect(a).toBe("tok-1");
-      expect(b).toBe("tok-2");
+      expect(a.token).toBe("tok-1");
+      expect(b.token).toBe("tok-2");
       expect(spy).toHaveBeenCalledTimes(2);
     } finally {
       spy.mockRestore();
@@ -96,9 +96,9 @@ describe("GithubInstallationToken service", () => {
 
     try {
       const [a, b, aAgain] = await Effect.runPromise(program.pipe(Effect.provide(GithubInstallationTokenLive)));
-      expect(a).toBe("tok-1");
-      expect(b).toBe("tok-2");
-      expect(aAgain).toBe("tok-1");
+      expect(a.token).toBe("tok-1");
+      expect(b.token).toBe("tok-2");
+      expect(aAgain.token).toBe("tok-1");
       expect(spy).toHaveBeenCalledTimes(2);
     } finally {
       spy.mockRestore();
@@ -127,7 +127,7 @@ describe("GithubInstallationToken service", () => {
 
     try {
       const results = await Effect.runPromise(program.pipe(Effect.provide(GithubInstallationTokenLive)));
-      expect(results.every((r) => r === "tok-42")).toBe(true);
+      expect(results.every((r) => r.token === "tok-42")).toBe(true);
       expect(calls).toBe(1);
       expect(spy).toHaveBeenCalledTimes(1);
     } finally {
@@ -159,7 +159,7 @@ describe("GithubInstallationToken service", () => {
     try {
       const [first, second] = await Effect.runPromise(program.pipe(Effect.provide(GithubInstallationTokenLive)));
       expect(first._tag).toBe("Left");
-      expect(second).toBe("tok-5");
+      expect(second.token).toBe("tok-5");
       expect(calls).toBe(2);
     } finally {
       spy.mockRestore();

--- a/test/githubRequestError.test.ts
+++ b/test/githubRequestError.test.ts
@@ -35,12 +35,30 @@ describe("githubRequestError", () => {
 		expect(isRateLimitClassification(c.classification)).toBe(true);
 	});
 
-	it("classifies rate_limit when x-ratelimit-remaining is 0 even with Bad credentials message", () => {
+	it("classifies rate_limit when x-ratelimit-remaining is 0 on core with Bad credentials message", () => {
+		const err = httpError(401, "Bad credentials - https://docs.github.com/rest", {
+			"x-ratelimit-remaining": "0",
+			"x-ratelimit-resource": "core",
+		});
+		const c = classifyGithubToolError(err, { expiresAtTs: youngExpiry });
+		expect(c.classification).toBe("rate_limit");
+	});
+
+	it("classifies probable_secondary when remaining is 0 without core/search resource", () => {
 		const err = httpError(401, "Bad credentials - https://docs.github.com/rest", {
 			"x-ratelimit-remaining": "0",
 		});
 		const c = classifyGithubToolError(err, { expiresAtTs: youngExpiry });
-		expect(c.classification).toBe("rate_limit");
+		expect(c.classification).toBe("probable_secondary");
+	});
+
+	it("classifies secondary_rate_limit when remaining is 0 and message mentions secondary rate", () => {
+		const err = httpError(403, "Bad credentials; secondary rate limit", {
+			"x-ratelimit-remaining": "0",
+			"x-ratelimit-resource": "core",
+		});
+		const c = classifyGithubToolError(err, { expiresAtTs: youngExpiry });
+		expect(c.classification).toBe("secondary_rate_limit");
 	});
 
 	it("classifies Bad credentials as auth when token is near expiry (HttpError)", () => {
@@ -52,6 +70,7 @@ describe("githubRequestError", () => {
 	it("classifies rate_limit on near-expiry token when x-ratelimit-remaining is 0", () => {
 		const err = httpError(403, "API rate limit exceeded", {
 			"x-ratelimit-remaining": "0",
+			"x-ratelimit-resource": "core",
 		});
 		const c = classifyGithubToolError(err, { expiresAtTs: Date.now() + 30_000 });
 		expect(c.classification).toBe("rate_limit");
@@ -80,6 +99,7 @@ describe("githubRequestError", () => {
 		const reset = String(Math.floor(Date.now() / 1000) + 120);
 		const err = httpError(403, "API rate limit exceeded", {
 			"x-ratelimit-remaining": "0",
+			"x-ratelimit-resource": "core",
 			"x-ratelimit-reset": reset,
 		});
 		const c = classifyGithubToolError(err, { expiresAtTs: youngExpiry });
@@ -125,5 +145,9 @@ describe("githubRequestError", () => {
 		expect(n).toBe(0);
 		n = bumpRateLimitConsecutiveFailures(n, "probable_secondary");
 		expect(n).toBe(1);
+	});
+
+	it("bumpRateLimitConsecutiveFailures preserves count for token_expired", () => {
+		expect(bumpRateLimitConsecutiveFailures(2, "token_expired")).toBe(2);
 	});
 });

--- a/test/githubRequestError.test.ts
+++ b/test/githubRequestError.test.ts
@@ -1,0 +1,106 @@
+import { RequestError } from "@octokit/request-error";
+import { describe, expect, it } from "vitest";
+import {
+	classifyGithubToolError,
+	extractGithubResponseMeta,
+	formatToolErrorMessage,
+	isRateLimitClassification,
+} from "../src/github/githubRequestError.js";
+
+function httpError(
+	status: number,
+	message: string,
+	headers: Record<string, string> = {},
+): RequestError {
+	return new RequestError(message, status, {
+		request: { method: "GET", url: "https://api.github.com/test", headers: {} },
+		response: {
+			status,
+			url: "https://api.github.com/test",
+			headers,
+			data: { message },
+		},
+	});
+}
+
+describe("githubRequestError", () => {
+	const youngExpiry = Date.now() + 30 * 60 * 1000;
+
+	it("classifies probable_secondary for Bad credentials on young token without primary headers", () => {
+		const err = httpError(401, "Bad credentials - https://docs.github.com/rest");
+		const c = classifyGithubToolError(err, { expiresAtTs: youngExpiry });
+		expect(c.classification).toBe("probable_secondary");
+		expect(isRateLimitClassification(c.classification)).toBe(true);
+	});
+
+	it("classifies rate_limit when x-ratelimit-remaining is 0 even with Bad credentials message", () => {
+		const err = httpError(401, "Bad credentials - https://docs.github.com/rest", {
+			"x-ratelimit-remaining": "0",
+		});
+		const c = classifyGithubToolError(err, { expiresAtTs: youngExpiry });
+		expect(c.classification).toBe("rate_limit");
+	});
+
+	it("classifies Bad credentials as auth when token is near expiry (HttpError)", () => {
+		const err = httpError(401, "Bad credentials - https://docs.github.com/rest");
+		const c = classifyGithubToolError(err, { expiresAtTs: Date.now() + 30_000 });
+		expect(c.classification).toBe("auth");
+	});
+
+	it("classifies rate_limit on near-expiry token when x-ratelimit-remaining is 0", () => {
+		const err = httpError(403, "API rate limit exceeded", {
+			"x-ratelimit-remaining": "0",
+		});
+		const c = classifyGithubToolError(err, { expiresAtTs: Date.now() + 30_000 });
+		expect(c.classification).toBe("rate_limit");
+	});
+
+	it("classifies plain errors as token_expired when token is near expiry", () => {
+		const c = classifyGithubToolError(new Error("Installation token near expiry"), {
+			expiresAtTs: Date.now() + 30_000,
+		});
+		expect(c.classification).toBe("token_expired");
+	});
+
+	it("classifies secondary_rate_limit from message", () => {
+		const err = httpError(
+			403,
+			"You have exceeded a secondary rate limit. Please wait.",
+			{ "retry-after": "120" },
+		);
+		const c = classifyGithubToolError(err, { expiresAtTs: youngExpiry });
+		expect(c.classification).toBe("secondary_rate_limit");
+		expect(c.retryAfterSource).toBe("header");
+		expect(c.retryAfterSeconds).toBe(120);
+	});
+
+	it("classifies rate_limit when x-ratelimit-remaining is 0", () => {
+		const reset = String(Math.floor(Date.now() / 1000) + 120);
+		const err = httpError(403, "API rate limit exceeded", {
+			"x-ratelimit-remaining": "0",
+			"x-ratelimit-reset": reset,
+		});
+		const c = classifyGithubToolError(err, { expiresAtTs: youngExpiry });
+		expect(c.classification).toBe("rate_limit");
+	});
+
+	it("extractGithubResponseMeta maps lowercase headers", () => {
+		const err = httpError(429, "Too Many Requests", {
+			"x-github-request-id": "ABC:123",
+			"x-ratelimit-resource": "core",
+			"retry-after": "5",
+		});
+		const meta = extractGithubResponseMeta(err);
+		expect(meta.githubRequestId).toBe("ABC:123");
+		expect(meta.rateLimitResource).toBe("core");
+		expect(meta.retryAfterHeader).toBe("5");
+	});
+
+	it("formatToolErrorMessage includes cooldown for rate limit classes", () => {
+		const err = httpError(403, "secondary rate", { "retry-after": "10" });
+		const c = classifyGithubToolError(err, { expiresAtTs: youngExpiry });
+		const text = formatToolErrorMessage("getFileContent", err, c);
+		expect(text).toMatch(/Rate-limit cooldown 10s/);
+		expect(text).toMatch(/do not issue tool calls/);
+	});
+});

--- a/test/githubRequestError.test.ts
+++ b/test/githubRequestError.test.ts
@@ -1,10 +1,12 @@
 import { RequestError } from "@octokit/request-error";
 import { describe, expect, it } from "vitest";
 import {
+	bumpRateLimitConsecutiveFailures,
 	classifyGithubToolError,
 	extractGithubResponseMeta,
 	formatToolErrorMessage,
 	isRateLimitClassification,
+	TOKEN_EXPIRED_TOOL_MESSAGE,
 } from "../src/github/githubRequestError.js";
 
 function httpError(
@@ -102,5 +104,26 @@ describe("githubRequestError", () => {
 		const text = formatToolErrorMessage("getFileContent", err, c);
 		expect(text).toMatch(/Rate-limit cooldown 10s/);
 		expect(text).toMatch(/do not issue tool calls/);
+	});
+
+	it("formatToolErrorMessage returns a single message for token_expired", () => {
+		const c = classifyGithubToolError(new Error("guard"), {
+			expiresAtTs: Date.now() + 30_000,
+		});
+		expect(c.classification).toBe("token_expired");
+		expect(formatToolErrorMessage("getFileContent", new Error("guard"), c)).toBe(
+			TOKEN_EXPIRED_TOOL_MESSAGE,
+		);
+	});
+
+	it("bumpRateLimitConsecutiveFailures resets on non-rate-limit classifications", () => {
+		let n = 0;
+		n = bumpRateLimitConsecutiveFailures(n, "rate_limit");
+		n = bumpRateLimitConsecutiveFailures(n, "rate_limit");
+		expect(n).toBe(2);
+		n = bumpRateLimitConsecutiveFailures(n, "auth");
+		expect(n).toBe(0);
+		n = bumpRateLimitConsecutiveFailures(n, "probable_secondary");
+		expect(n).toBe(1);
 	});
 });

--- a/test/githubRequestError.test.ts
+++ b/test/githubRequestError.test.ts
@@ -5,6 +5,8 @@ import {
 	classifyGithubToolError,
 	extractGithubResponseMeta,
 	formatToolErrorMessage,
+	getTokenTiming,
+	isGraphqlRateLimitError,
 	isRateLimitClassification,
 	logGithubToolRequestError,
 	TOKEN_EXPIRED_TOOL_MESSAGE,
@@ -161,6 +163,23 @@ describe("githubRequestError", () => {
 
 	it("bumpRateLimitConsecutiveFailures preserves count for token_expired", () => {
 		expect(bumpRateLimitConsecutiveFailures(2, "token_expired")).toBe(2);
+	});
+
+	it("getTokenTiming uses minted ttlMs for age when fallback TTL is below 1h", () => {
+		const now = 1_000_000;
+		const fallbackTtlMs = 55 * 60 * 1000;
+		const expiresAtTs = now + fallbackTtlMs;
+		expect(getTokenTiming(expiresAtTs, now, fallbackTtlMs).tokenAgeSeconds).toBe(0);
+		expect(getTokenTiming(expiresAtTs, now + 5 * 60 * 1000, fallbackTtlMs).tokenAgeSeconds).toBe(
+			5 * 60,
+		);
+	});
+
+	it("isGraphqlRateLimitError matches GraphqlResponseError.errors shape", () => {
+		const err = Object.assign(new Error("Request failed due to following response errors"), {
+			errors: [{ type: "RATE_LIMITED", message: "rate limit" }],
+		});
+		expect(isGraphqlRateLimitError(err)).toBe(true);
 	});
 
 	it("logGithubToolRequestError emits github_tool_request_error for non-HTTP errors", () => {

--- a/test/githubRequestError.test.ts
+++ b/test/githubRequestError.test.ts
@@ -165,6 +165,13 @@ describe("githubRequestError", () => {
 		expect(bumpRateLimitConsecutiveFailures(2, "token_expired")).toBe(2);
 	});
 
+	it("getTokenTiming reports time since expiry when token is expired and ttlMs is omitted", () => {
+		const now = 1_000_000;
+		const expiresAtTs = now - 90_000;
+		expect(getTokenTiming(expiresAtTs, now).tokenExpiresInSeconds).toBe(0);
+		expect(getTokenTiming(expiresAtTs, now).tokenAgeSeconds).toBe(90);
+	});
+
 	it("getTokenTiming uses minted ttlMs for age when fallback TTL is below 1h", () => {
 		const now = 1_000_000;
 		const fallbackTtlMs = 55 * 60 * 1000;

--- a/test/githubRequestError.test.ts
+++ b/test/githubRequestError.test.ts
@@ -52,6 +52,16 @@ describe("githubRequestError", () => {
 		expect(c.classification).toBe("probable_secondary");
 	});
 
+	it("classifies secondary_rate_limit when retry-after is set without secondary message", () => {
+		const err = httpError(403, "API rate limit exceeded", {
+			"x-ratelimit-remaining": "0",
+			"x-ratelimit-resource": "core",
+			"retry-after": "30",
+		});
+		const c = classifyGithubToolError(err, { expiresAtTs: youngExpiry });
+		expect(c.classification).toBe("secondary_rate_limit");
+	});
+
 	it("classifies secondary_rate_limit when remaining is 0 and message mentions secondary rate", () => {
 		const err = httpError(403, "Bad credentials; secondary rate limit", {
 			"x-ratelimit-remaining": "0",

--- a/test/githubRequestError.test.ts
+++ b/test/githubRequestError.test.ts
@@ -1,13 +1,15 @@
 import { RequestError } from "@octokit/request-error";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
 	bumpRateLimitConsecutiveFailures,
 	classifyGithubToolError,
 	extractGithubResponseMeta,
 	formatToolErrorMessage,
 	isRateLimitClassification,
+	logGithubToolRequestError,
 	TOKEN_EXPIRED_TOOL_MESSAGE,
 } from "../src/github/githubRequestError.js";
+import { log } from "../src/log.js";
 
 function httpError(
 	status: number,
@@ -159,5 +161,36 @@ describe("githubRequestError", () => {
 
 	it("bumpRateLimitConsecutiveFailures preserves count for token_expired", () => {
 		expect(bumpRateLimitConsecutiveFailures(2, "token_expired")).toBe(2);
+	});
+
+	it("logGithubToolRequestError emits github_tool_request_error for non-HTTP errors", () => {
+		const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+		const err = new TypeError("fetch failed");
+		const classified = classifyGithubToolError(err, { expiresAtTs: youngExpiry });
+		const logCtx = {
+			expiresAtTs: youngExpiry,
+			owner: "o",
+			repo: "r",
+			prNumber: 1,
+			mode: "review",
+		};
+
+		logGithubToolRequestError("getFileContent", err, logCtx, classified);
+
+		expect(warn).toHaveBeenCalledWith(
+			"github_tool_request_error",
+			expect.objectContaining({
+				tool: "getFileContent",
+				classification: "other",
+				status: 0,
+				message: "fetch failed",
+				owner: "o",
+				repo: "r",
+				pr: 1,
+				mode: "review",
+				retryAfterSeconds: classified.retryAfterSeconds,
+			}),
+		);
+		warn.mockRestore();
 	});
 });

--- a/test/githubTools.test.ts
+++ b/test/githubTools.test.ts
@@ -152,22 +152,107 @@ describe("buildGithubTools — happy paths", () => {
 		expect(out[0]).toMatchObject({ authorLogin: "octocat" });
 	});
 
-	it("listPullRequestFiles forwards paging and returns patch", async () => {
-		const pullsListFiles = vi.fn().mockResolvedValue({
-			data: [
-				{ filename: "f.ts", status: "modified", additions: 1, deletions: 1, changes: 2, patch: "@@..." },
-			],
-		});
+	it("listPullRequestFiles paginates server-side at per_page 100 and returns patch", async () => {
+		const page1 = Array.from({ length: 100 }, (_, i) => ({
+			filename: `a${i}.ts`,
+			status: "modified",
+			additions: 1,
+			deletions: 1,
+			changes: 2,
+			patch: `@@a${i}`,
+		}));
+		const pullsListFiles = vi
+			.fn()
+			.mockResolvedValueOnce({ data: page1 })
+			.mockResolvedValueOnce({
+				data: [
+					{ filename: "b.ts", status: "added", additions: 1, deletions: 0, changes: 1, patch: "@@b" },
+				],
+			});
 		const { executors } = buildWithStub(makeOctokitStub({ pullsListFiles }));
 
 		const out = (await executors.listPullRequestFiles({
 			owner: "o",
 			repo: "r",
 			pullNumber: 3,
-		})) as Array<{ patch: string }>;
+		})) as { files: Array<{ patch: string }>; truncated: boolean };
 
-		expect(pullsListFiles).toHaveBeenCalledWith({ owner: "o", repo: "r", pull_number: 3, per_page: 30, page: 1 });
-		expect(out[0].patch).toBe("@@...");
+		expect(pullsListFiles).toHaveBeenNthCalledWith(1, {
+			owner: "o",
+			repo: "r",
+			pull_number: 3,
+			per_page: 100,
+			page: 1,
+		});
+		expect(pullsListFiles).toHaveBeenNthCalledWith(2, {
+			owner: "o",
+			repo: "r",
+			pull_number: 3,
+			per_page: 100,
+			page: 2,
+		});
+		expect(out.files).toHaveLength(101);
+		expect(out.files[0].patch).toBe("@@a0");
+		expect(out.truncated).toBe(false);
+	});
+
+	it("listPullRequestFiles truncates at maxPrFilesListed", async () => {
+		const rows = Array.from({ length: 5 }, (_, i) => ({
+			filename: `f${i}.ts`,
+			status: "modified",
+			additions: 1,
+			deletions: 1,
+			changes: 2,
+			patch: `@@${i}`,
+		}));
+		const pullsListFiles = vi.fn().mockResolvedValue({ data: rows });
+		vi.spyOn(appAuth, "installationOctokit").mockReturnValue(makeOctokitStub({ pullsListFiles }));
+		const { executors } = buildGithubTools("tok", { maxPrFilesListed: 3, maxPrFilesPatchBytes: 500_000 });
+
+		const out = (await executors.listPullRequestFiles({
+			owner: "o",
+			repo: "r",
+			pullNumber: 1,
+		})) as { files: unknown[]; truncated: boolean; omittedCount: number; warning?: string };
+
+		expect(pullsListFiles).toHaveBeenCalledTimes(1);
+		expect(out.files).toHaveLength(3);
+		expect(out.truncated).toBe(true);
+		expect(out.omittedCount).toBe(2);
+		expect(out.warning).toMatch(/truncated/i);
+	});
+
+	it("listPullRequestFiles stops pagination once maxPrFilesListed is reached", async () => {
+		const page1 = Array.from({ length: 100 }, (_, i) => ({
+			filename: `a${i}.ts`,
+			status: "modified",
+			additions: 1,
+			deletions: 1,
+			changes: 2,
+		}));
+		const page2 = Array.from({ length: 100 }, (_, i) => ({
+			filename: `b${i}.ts`,
+			status: "modified",
+			additions: 1,
+			deletions: 1,
+			changes: 2,
+		}));
+		const pullsListFiles = vi
+			.fn()
+			.mockResolvedValueOnce({ data: page1 })
+			.mockResolvedValueOnce({ data: page2 });
+		vi.spyOn(appAuth, "installationOctokit").mockReturnValue(makeOctokitStub({ pullsListFiles }));
+		const { executors } = buildGithubTools("tok", { maxPrFilesListed: 150, maxPrFilesPatchBytes: 500_000 });
+
+		const out = (await executors.listPullRequestFiles({
+			owner: "o",
+			repo: "r",
+			pullNumber: 1,
+		})) as { files: unknown[]; truncated: boolean };
+
+		expect(pullsListFiles).toHaveBeenCalledTimes(2);
+		expect(out.files).toHaveLength(150);
+		expect(out.truncated).toBe(true);
 	});
 
 	it("listPullRequestReviews returns authorLogin instead of bare author", async () => {

--- a/test/githubTools.test.ts
+++ b/test/githubTools.test.ts
@@ -264,6 +264,73 @@ describe("buildGithubTools — happy paths", () => {
 		expect(out.warning).toMatch(/250 byte cap/i);
 	});
 
+	it("listPullRequestFiles does not double-count omitted files when file and patch caps coincide", async () => {
+		const smallPatch = "x".repeat(49);
+		const bigPatch = "x".repeat(202);
+		const page = [
+			{
+				filename: "a.ts",
+				status: "modified",
+				additions: 1,
+				deletions: 1,
+				changes: 2,
+				patch: smallPatch,
+			},
+			{
+				filename: "b.ts",
+				status: "modified",
+				additions: 1,
+				deletions: 1,
+				changes: 2,
+				patch: smallPatch,
+			},
+			{
+				filename: "c.ts",
+				status: "modified",
+				additions: 1,
+				deletions: 1,
+				changes: 2,
+				patch: smallPatch,
+			},
+			{
+				filename: "d.ts",
+				status: "modified",
+				additions: 1,
+				deletions: 1,
+				changes: 2,
+				patch: smallPatch,
+			},
+			{
+				filename: "e.ts",
+				status: "modified",
+				additions: 1,
+				deletions: 1,
+				changes: 2,
+				patch: bigPatch,
+			},
+			...Array.from({ length: 5 }, (_, i) => ({
+				filename: `f${i}.ts`,
+				status: "modified",
+				additions: 1,
+				deletions: 1,
+				changes: 2,
+			})),
+		];
+		const pullsListFiles = vi.fn().mockResolvedValueOnce({ data: page });
+		vi.spyOn(appAuth, "installationOctokit").mockReturnValue(makeOctokitStub({ pullsListFiles }));
+		const { executors } = buildGithubTools("tok", { maxPrFilesListed: 5, maxPrFilesPatchBytes: 250 });
+
+		const out = (await executors.listPullRequestFiles({
+			owner: "o",
+			repo: "r",
+			pullNumber: 1,
+		})) as { truncated: boolean; omittedCount: number; files: unknown[] };
+
+		expect(out.truncated).toBe(true);
+		expect(out.files).toHaveLength(5);
+		expect(out.omittedCount).toBe(5);
+	});
+
 	it("listPullRequestFiles stops pagination when patch byte cap is reached", async () => {
 		const bigPatch = "x".repeat(202);
 		const smallPatch = "x".repeat(49);
@@ -309,9 +376,9 @@ describe("buildGithubTools — happy paths", () => {
 		};
 
 		expect(pullsListFiles).toHaveBeenCalledTimes(1);
-		expect(out.files).toHaveLength(2);
-		expect(out.omittedCount).toBe(1);
-		expect(out.warning).toMatch(/1 additional file\(s\) not listed/i);
+		expect(out.files).toHaveLength(3);
+		expect(out.omittedCount).toBe(0);
+		expect(out.warning).toMatch(/patches omitted for 2 file/i);
 	});
 
 	it("listPullRequestFiles uses at-least omitted count when more pages remain", async () => {

--- a/test/githubTools.test.ts
+++ b/test/githubTools.test.ts
@@ -265,40 +265,36 @@ describe("buildGithubTools — happy paths", () => {
 	});
 
 	it("listPullRequestFiles stops pagination when patch byte cap is reached", async () => {
-		const bigPatch = "x".repeat(200);
-		const page2 = [
-			{
-				filename: "extra.ts",
-				status: "modified",
-				additions: 1,
-				deletions: 1,
-				changes: 2,
-				patch: bigPatch,
-			},
-		];
-		const pullsListFiles = vi
-			.fn()
-			.mockResolvedValueOnce({
-				data: [
-					{
-						filename: "a.ts",
-						status: "modified",
-						additions: 1,
-						deletions: 1,
-						changes: 2,
-						patch: bigPatch,
-					},
-					{
-						filename: "b.ts",
-						status: "modified",
-						additions: 1,
-						deletions: 1,
-						changes: 2,
-						patch: bigPatch,
-					},
-				],
-			})
-			.mockResolvedValueOnce({ data: page2 });
+		const bigPatch = "x".repeat(202);
+		const smallPatch = "x".repeat(49);
+		const pullsListFiles = vi.fn().mockResolvedValueOnce({
+			data: [
+				{
+					filename: "a.ts",
+					status: "modified",
+					additions: 1,
+					deletions: 1,
+					changes: 2,
+					patch: smallPatch,
+				},
+				{
+					filename: "b.ts",
+					status: "modified",
+					additions: 1,
+					deletions: 1,
+					changes: 2,
+					patch: bigPatch,
+				},
+				{
+					filename: "c.ts",
+					status: "modified",
+					additions: 1,
+					deletions: 1,
+					changes: 2,
+					patch: smallPatch,
+				},
+			],
+		});
 		vi.spyOn(appAuth, "installationOctokit").mockReturnValue(makeOctokitStub({ pullsListFiles }));
 		const { executors } = buildGithubTools("tok", { maxPrFilesListed: 10, maxPrFilesPatchBytes: 250 });
 
@@ -306,10 +302,16 @@ describe("buildGithubTools — happy paths", () => {
 			owner: "o",
 			repo: "r",
 			pullNumber: 1,
-		})) as { files: unknown[] };
+		})) as {
+			files: unknown[];
+			omittedCount: number;
+			warning?: string;
+		};
 
 		expect(pullsListFiles).toHaveBeenCalledTimes(1);
 		expect(out.files).toHaveLength(2);
+		expect(out.omittedCount).toBe(1);
+		expect(out.warning).toMatch(/1 additional file\(s\) not listed/i);
 	});
 
 	it("listPullRequestFiles uses at-least omitted count when more pages remain", async () => {

--- a/test/githubTools.test.ts
+++ b/test/githubTools.test.ts
@@ -222,6 +222,48 @@ describe("buildGithubTools — happy paths", () => {
 		expect(out.warning).toMatch(/truncated/i);
 	});
 
+	it("listPullRequestFiles warns when patch bytes exceed maxPrFilesPatchBytes", async () => {
+		const bigPatch = "x".repeat(200);
+		const pullsListFiles = vi.fn().mockResolvedValue({
+			data: [
+				{
+					filename: "a.ts",
+					status: "modified",
+					additions: 1,
+					deletions: 1,
+					changes: 2,
+					patch: bigPatch,
+				},
+				{
+					filename: "b.ts",
+					status: "modified",
+					additions: 1,
+					deletions: 1,
+					changes: 2,
+					patch: bigPatch,
+				},
+			],
+		});
+		vi.spyOn(appAuth, "installationOctokit").mockReturnValue(makeOctokitStub({ pullsListFiles }));
+		const { executors } = buildGithubTools("tok", { maxPrFilesListed: 10, maxPrFilesPatchBytes: 250 });
+
+		const out = (await executors.listPullRequestFiles({
+			owner: "o",
+			repo: "r",
+			pullNumber: 1,
+		})) as {
+			files: Array<{ filename: string; patch?: string; patchOmitted?: boolean }>;
+			truncated: boolean;
+			warning?: string;
+		};
+
+		expect(out.files[0].patch).toBe(bigPatch);
+		expect(out.files[1].patchOmitted).toBe(true);
+		expect(out.truncated).toBe(false);
+		expect(out.warning).toMatch(/patches omitted for 1 file/i);
+		expect(out.warning).toMatch(/250 byte cap/i);
+	});
+
 	it("listPullRequestFiles stops pagination once maxPrFilesListed is reached", async () => {
 		const page1 = Array.from({ length: 100 }, (_, i) => ({
 			filename: `a${i}.ts`,

--- a/test/githubTools.test.ts
+++ b/test/githubTools.test.ts
@@ -264,6 +264,83 @@ describe("buildGithubTools — happy paths", () => {
 		expect(out.warning).toMatch(/250 byte cap/i);
 	});
 
+	it("listPullRequestFiles stops pagination when patch byte cap is reached", async () => {
+		const bigPatch = "x".repeat(200);
+		const page2 = [
+			{
+				filename: "extra.ts",
+				status: "modified",
+				additions: 1,
+				deletions: 1,
+				changes: 2,
+				patch: bigPatch,
+			},
+		];
+		const pullsListFiles = vi
+			.fn()
+			.mockResolvedValueOnce({
+				data: [
+					{
+						filename: "a.ts",
+						status: "modified",
+						additions: 1,
+						deletions: 1,
+						changes: 2,
+						patch: bigPatch,
+					},
+					{
+						filename: "b.ts",
+						status: "modified",
+						additions: 1,
+						deletions: 1,
+						changes: 2,
+						patch: bigPatch,
+					},
+				],
+			})
+			.mockResolvedValueOnce({ data: page2 });
+		vi.spyOn(appAuth, "installationOctokit").mockReturnValue(makeOctokitStub({ pullsListFiles }));
+		const { executors } = buildGithubTools("tok", { maxPrFilesListed: 10, maxPrFilesPatchBytes: 250 });
+
+		const out = (await executors.listPullRequestFiles({
+			owner: "o",
+			repo: "r",
+			pullNumber: 1,
+		})) as { files: unknown[] };
+
+		expect(pullsListFiles).toHaveBeenCalledTimes(1);
+		expect(out.files).toHaveLength(2);
+	});
+
+	it("listPullRequestFiles uses at-least omitted count when more pages remain", async () => {
+		const page = Array.from({ length: 100 }, (_, i) => ({
+			filename: `f${i}.ts`,
+			status: "modified",
+			additions: 1,
+			deletions: 1,
+			changes: 2,
+		}));
+		const pullsListFiles = vi
+			.fn()
+			.mockResolvedValueOnce({ data: page })
+			.mockResolvedValueOnce({ data: page })
+			.mockResolvedValueOnce({ data: page })
+			.mockResolvedValueOnce({ data: page });
+		vi.spyOn(appAuth, "installationOctokit").mockReturnValue(makeOctokitStub({ pullsListFiles }));
+		const { executors } = buildGithubTools("tok", { maxPrFilesListed: 300, maxPrFilesPatchBytes: 500_000 });
+
+		const out = (await executors.listPullRequestFiles({
+			owner: "o",
+			repo: "r",
+			pullNumber: 1,
+		})) as { truncated: boolean; omittedCount: number; warning?: string };
+
+		expect(pullsListFiles).toHaveBeenCalledTimes(4);
+		expect(out.truncated).toBe(true);
+		expect(out.omittedCount).toBe(100);
+		expect(out.warning).toMatch(/at least 100 omitted/i);
+	});
+
 	it("listPullRequestFiles stops pagination once maxPrFilesListed is reached", async () => {
 		const page1 = Array.from({ length: 100 }, (_, i) => ({
 			filename: `a${i}.ts`,

--- a/test/octokitThrottle.test.ts
+++ b/test/octokitThrottle.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+import { log } from "../src/log.js";
+import {
+	onRateLimit,
+	onSecondaryRateLimit,
+	PRIMARY_RATE_LIMIT_MAX_RETRIES,
+} from "../src/github/octokitThrottle.js";
+
+describe("octokitThrottle hooks", () => {
+	const options = { method: "GET", url: "https://api.github.com/repos/o/r/pulls/1" } as never;
+	const octokit = {} as never;
+
+	it("onRateLimit retries for retryCount 0 and 1", () => {
+		const logSpy = vi.spyOn(log, "warn").mockImplementation(() => {});
+		expect(onRateLimit(30, options, octokit, 0)).toBe(true);
+		expect(onRateLimit(30, options, octokit, 1)).toBe(true);
+		expect(onRateLimit(30, options, octokit, PRIMARY_RATE_LIMIT_MAX_RETRIES)).toBe(false);
+		logSpy.mockRestore();
+	});
+
+	it("onSecondaryRateLimit retries only when retryAfter > 0 and retryCount === 0", () => {
+		const logSpy = vi.spyOn(log, "warn").mockImplementation(() => {});
+		expect(onSecondaryRateLimit(60, options, octokit, 0)).toBe(true);
+		expect(onSecondaryRateLimit(60, options, octokit, 1)).toBe(false);
+		expect(onSecondaryRateLimit(0, options, octokit, 0)).toBe(false);
+		logSpy.mockRestore();
+	});
+});

--- a/test/reviewRun.test.ts
+++ b/test/reviewRun.test.ts
@@ -61,6 +61,7 @@ function reviewParams(
 		cfg,
 		token: "t",
 		tokenExpiresAtTs: farFutureTokenExpiry,
+		tokenTtlMs: 3_600_000,
 		owner: "o",
 		repo: "r",
 		prNumber: 1,

--- a/test/reviewRun.test.ts
+++ b/test/reviewRun.test.ts
@@ -52,6 +52,23 @@ const cfg = {
 	maxPrFilesPatchBytes: 500_000,
 } satisfies Config;
 
+const farFutureTokenExpiry = Date.now() + 3_600_000;
+
+function reviewParams(
+	overrides: Partial<Parameters<typeof runFullPrReview>[0]> = {},
+): Parameters<typeof runFullPrReview>[0] {
+	return {
+		cfg,
+		token: "t",
+		tokenExpiresAtTs: farFutureTokenExpiry,
+		owner: "o",
+		repo: "r",
+		prNumber: 1,
+		headSha: "sha",
+		...overrides,
+	};
+}
+
 const defaultCompleteResult = () => ({
 	role: "assistant" as const,
 	content: [{ type: "text" as const, text: "analysis without submitReview" }],
@@ -76,30 +93,28 @@ describe("runFullPrReview mode", () => {
 		vi.mocked(complete).mockImplementation(async () => defaultCompleteResult());
 	});
 
+	it("requires finite tokenExpiresAtTs", async () => {
+		await expect(runFullPrReview(reviewParams({ tokenExpiresAtTs: NaN }))).rejects.toThrow(
+			/tokenExpiresAtTs/,
+		);
+	});
+
 	it("selects security system prompt when mode is review-security", async () => {
-		await runFullPrReview({
-			cfg: { ...cfg, maxReviewPublishAttempts: 1, maxToolRounds: 1 },
-			token: "t",
-			owner: "o",
-			repo: "r",
-			prNumber: 1,
-			headSha: "sha",
-			mode: "review-security",
-		});
+		await runFullPrReview(
+			reviewParams({
+				cfg: { ...cfg, maxReviewPublishAttempts: 1, maxToolRounds: 1 },
+				mode: "review-security",
+			}),
+		);
 
 		const context = vi.mocked(complete).mock.calls[0]![1] as { systemPrompt: string };
 		expect(context.systemPrompt).toBe(automatedSecuritySystemPrompt);
 	});
 
 	it("selects general system prompt by default", async () => {
-		await runFullPrReview({
-			cfg: { ...cfg, maxReviewPublishAttempts: 1, maxToolRounds: 1 },
-			token: "t",
-			owner: "o",
-			repo: "r",
-			prNumber: 1,
-			headSha: "sha",
-		});
+		await runFullPrReview(
+			reviewParams({ cfg: { ...cfg, maxReviewPublishAttempts: 1, maxToolRounds: 1 } }),
+		);
 
 		const context = vi.mocked(complete).mock.calls[0]![1] as { systemPrompt: string };
 		expect(context.systemPrompt).toContain("senior staff software engineer");
@@ -109,15 +124,9 @@ describe("runFullPrReview mode", () => {
 	it("requires tools on round 0 for both modes when tools are available", async () => {
 		for (const mode of ["review", "review-security"] as const) {
 			vi.mocked(complete).mockClear();
-			await runFullPrReview({
-				cfg: { ...cfg, maxReviewPublishAttempts: 1, maxToolRounds: 1 },
-				token: "t",
-				owner: "o",
-				repo: "r",
-				prNumber: 1,
-				headSha: "sha",
-				mode,
-			});
+			await runFullPrReview(
+				reviewParams({ cfg: { ...cfg, maxReviewPublishAttempts: 1, maxToolRounds: 1 }, mode }),
+			);
 			expect(vi.mocked(complete).mock.calls[0]![2]).toEqual({ toolChoice: "required" });
 		}
 	});
@@ -166,15 +175,12 @@ describe("runFullPrReview mode", () => {
 		}));
 
 		const infoSpy = vi.spyOn(log, "info");
-		await runFullPrReview({
-			cfg: { ...cfg, maxReviewPublishAttempts: 1, maxToolRounds: 1 },
-			token: "t",
-			owner: "o",
-			repo: "r",
-			prNumber: 1,
-			headSha: "sha",
-			mode: "review-security",
-		});
+		await runFullPrReview(
+			reviewParams({
+				cfg: { ...cfg, maxReviewPublishAttempts: 1, maxToolRounds: 1 },
+				mode: "review-security",
+			}),
+		);
 
 		expect(infoSpy).toHaveBeenCalledWith(
 			"agent_tool_round",
@@ -183,15 +189,7 @@ describe("runFullPrReview mode", () => {
 	});
 
 	it("uses security fallback heading when security publish is exhausted", async () => {
-		await runFullPrReview({
-			cfg,
-			token: "t",
-			owner: "o",
-			repo: "r",
-			prNumber: 1,
-			headSha: "sha",
-			mode: "review-security",
-		});
+		await runFullPrReview(reviewParams({ mode: "review-security" }));
 
 		expect(createIssueComment).toHaveBeenCalledWith(
 			"t",
@@ -212,14 +210,7 @@ describe("runFullPrReview publish retries", () => {
 	it("retries submitReview up to maxReviewPublishAttempts before failing", async () => {
 		const infoSpy = vi.spyOn(log, "info");
 
-		const result = await runFullPrReview({
-			cfg,
-			token: "t",
-			owner: "o",
-			repo: "r",
-			prNumber: 1,
-			headSha: "sha",
-		});
+		const result = await runFullPrReview(reviewParams());
 
 		expect(result.published).toBe(false);
 		expect(result.publishAttempts).toBe(3);
@@ -234,14 +225,7 @@ describe("runFullPrReview publish retries", () => {
 	});
 
 	it("posts a maintainer-visible fallback comment when publish is exhausted", async () => {
-		const result = await runFullPrReview({
-			cfg,
-			token: "t",
-			owner: "o",
-			repo: "r",
-			prNumber: 1,
-			headSha: "sha",
-		});
+		const result = await runFullPrReview(reviewParams());
 
 		expect(result.published).toBe(false);
 		expect(createIssueComment).toHaveBeenCalledWith(

--- a/test/reviewRun.test.ts
+++ b/test/reviewRun.test.ts
@@ -48,6 +48,8 @@ const cfg = {
 	maxReviewFindings: 8,
 	enableReviewLabelsEffort: false,
 	enableReviewLabelsSecurity: false,
+	maxPrFilesListed: 300,
+	maxPrFilesPatchBytes: 500_000,
 } satisfies Config;
 
 const defaultCompleteResult = () => ({

--- a/test/slashCommandFlow.test.ts
+++ b/test/slashCommandFlow.test.ts
@@ -90,6 +90,7 @@ function baseCtx(overrides: Partial<SlashContext> = {}): SlashContext {
 		cfg,
 		token: "tok",
 		tokenExpiresAtTs: Date.now() + 3_600_000,
+		tokenTtlMs: 3_600_000,
 		owner: "o",
 		repo: "r",
 		botUserId: 1,

--- a/test/slashCommandFlow.test.ts
+++ b/test/slashCommandFlow.test.ts
@@ -89,6 +89,7 @@ function baseCtx(overrides: Partial<SlashContext> = {}): SlashContext {
 	return {
 		cfg,
 		token: "tok",
+		tokenExpiresAtTs: Date.now() + 3_600_000,
 		owner: "o",
 		repo: "r",
 		botUserId: 1,


### PR DESCRIPTION
## Summary

- Add `@octokit/plugin-throttling` (with existing retry) on all installation-token Octokit clients, with hook policy documented in ADR 0007
- Classify GitHub tool failures (`rate_limit`, `secondary_rate_limit`, `probable_secondary`, `token_expired`, etc.), log `github_tool_request_error` with rate-limit headers, and inject cooldown text into tool results
- Open a per-run rate-limit circuit after three consecutive classified failures; block further investigation tools while keeping `submitReview` available
- Cap `listPullRequestFiles` via `MAX_PR_FILES_LISTED` / `MAX_PR_FILES_PATCH_BYTES`, paginate server-side, and stop fetching once the file cap is reached
- Return `{ token, expiresAtTs }` from installation token minting and pass expiry through webhooks, slash commands, and the review loop pre-call guard
- Update prompts, README, CONTEXT glossary, `.env.example`, and tests

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (165 tests)
- [ ] Smoke a PR with ≥80 changed files and capture a redacted `github_tool_request_error` log sample (issue #9)