### PR TITLE
Skip redundant review effort label sync

### DIFF
--- a/src/agent/publishReview.ts
+++ b/src/agent/publishReview.ts
@@ -7,7 +7,7 @@ import {
 	type InlineReviewComment,
 } from "../github/reviewPublish.js";
 import { log } from "../log.js";
-import { LABEL_REVIEW_EFFORT_PREFIX, reviewLabelsFromPayload, syncReviewLabels } from "./reviewLabels.js";
+import { labelsAlreadySynced, reviewLabelsFromPayload, syncReviewLabels } from "./reviewLabels.js";
 import { renderInlineThreadBody, renderReviewSummaryComment, reviewPointerBodyForMode } from "./reviewRender.js";
 import {
 	normalizeReviewPayload,
@@ -83,8 +83,10 @@ export async function publishReview(params: ReviewPublishContext & {
 		try {
 			const current = await listPullRequestLabels(token, owner, repo, prNumber);
 			if (
-				cfg.enableReviewLabelsEffort &&
-				current.includes(`${LABEL_REVIEW_EFFORT_PREFIX}${payload.estimatedEffort}/5`)
+				labelsAlreadySynced(current, payload, {
+					effort: cfg.enableReviewLabelsEffort,
+					security: cfg.enableReviewLabelsSecurity,
+				})
 			) {
 				return;
 			}

--- a/src/agent/publishReview.ts
+++ b/src/agent/publishReview.ts
@@ -7,7 +7,7 @@ import {
 	type InlineReviewComment,
 } from "../github/reviewPublish.js";
 import { log } from "../log.js";
-import { reviewLabelsFromPayload, syncReviewLabels } from "./reviewLabels.js";
+import { LABEL_REVIEW_EFFORT_PREFIX, reviewLabelsFromPayload, syncReviewLabels } from "./reviewLabels.js";
 import { renderInlineThreadBody, renderReviewSummaryComment, reviewPointerBodyForMode } from "./reviewRender.js";
 import {
 	normalizeReviewPayload,
@@ -82,6 +82,12 @@ export async function publishReview(params: ReviewPublishContext & {
 	if (cfg.enableReviewLabelsEffort || cfg.enableReviewLabelsSecurity) {
 		try {
 			const current = await listPullRequestLabels(token, owner, repo, prNumber);
+			if (
+				cfg.enableReviewLabelsEffort &&
+				current.includes(`${LABEL_REVIEW_EFFORT_PREFIX}${payload.estimatedEffort}/5`)
+			) {
+				return;
+			}
 			const managed = reviewLabelsFromPayload(payload, {
 				effort: cfg.enableReviewLabelsEffort,
 				security: cfg.enableReviewLabelsSecurity,

--- a/src/agent/reviewLabels.ts
+++ b/src/agent/reviewLabels.ts
@@ -3,6 +3,22 @@ import type { ReviewPayload } from "./reviewSchema.js";
 export const LABEL_REVIEW_EFFORT_PREFIX = "Review effort ";
 export const LABEL_SECURITY_CONCERN = "Possible security concern";
 
+export function labelsAlreadySynced(
+	currentLabels: string[],
+	payload: ReviewPayload,
+	opts: { effort: boolean; security: boolean },
+): boolean {
+	if (opts.effort) {
+		const effortLabel = `${LABEL_REVIEW_EFFORT_PREFIX}${payload.estimatedEffort}/5`;
+		if (!currentLabels.includes(effortLabel)) return false;
+	}
+	if (opts.security) {
+		const wantsSecurity = payload.securityConcerns != null;
+		if (currentLabels.includes(LABEL_SECURITY_CONCERN) !== wantsSecurity) return false;
+	}
+	return true;
+}
+
 export function reviewLabelsFromPayload(
 	payload: ReviewPayload,
 	opts: { effort: boolean; security: boolean },

--- a/test/publishReview.test.ts
+++ b/test/publishReview.test.ts
@@ -192,6 +192,26 @@ describe("publishReview", () => {
 		expect(setPullRequestLabels).not.toHaveBeenCalled();
 	});
 
+	it("calls setPullRequestLabels when effort matches but security label is stale", async () => {
+		vi.mocked(listPullRequestLabels).mockResolvedValueOnce([
+			"Review effort 2/5",
+			"Possible security concern",
+		]);
+
+		await publishReview({
+			...baseParams,
+			publishState: { published: false, inlinePublished: false, lastValidationError: null },
+			cfg: {
+				maxReviewFindings: 8,
+				enableReviewLabelsEffort: true,
+				enableReviewLabelsSecurity: true,
+			},
+			payload: { ...payload, estimatedEffort: 2, securityConcerns: null },
+		});
+
+		expect(setPullRequestLabels).toHaveBeenCalledWith("t", "o", "r", 1, ["Review effort 2/5"]);
+	});
+
 	it("calls setPullRequestLabels when effort label value changes", async () => {
 		vi.mocked(listPullRequestLabels).mockResolvedValueOnce(["Review effort 2/5", "bug"]);
 

--- a/test/publishReview.test.ts
+++ b/test/publishReview.test.ts
@@ -14,6 +14,7 @@ vi.mock("../src/github/reviewPublish.js", () => ({
 
 import {
 	createPullRequestReviewWithComments,
+	listPullRequestLabels,
 	setPullRequestLabels,
 	upsertReviewSummaryComment,
 } from "../src/github/reviewPublish.js";
@@ -173,6 +174,39 @@ describe("publishReview", () => {
 			expect.stringContaining(SECURITY_REVIEW_SUMMARY_SENTINEL),
 			SECURITY_REVIEW_SUMMARY_SENTINEL,
 		);
+	});
+
+	it("skips setPullRequestLabels when exact effort label already exists", async () => {
+		vi.mocked(listPullRequestLabels).mockResolvedValueOnce(["Review effort 2/5", "bug"]);
+
+		await publishReview({
+			...baseParams,
+			publishState: { published: false, inlinePublished: false, lastValidationError: null },
+			cfg: {
+				maxReviewFindings: 8,
+				enableReviewLabelsEffort: true,
+				enableReviewLabelsSecurity: false,
+			},
+		});
+
+		expect(setPullRequestLabels).not.toHaveBeenCalled();
+	});
+
+	it("calls setPullRequestLabels when effort label value changes", async () => {
+		vi.mocked(listPullRequestLabels).mockResolvedValueOnce(["Review effort 2/5", "bug"]);
+
+		await publishReview({
+			...baseParams,
+			publishState: { published: false, inlinePublished: false, lastValidationError: null },
+			cfg: {
+				maxReviewFindings: 8,
+				enableReviewLabelsEffort: true,
+				enableReviewLabelsSecurity: false,
+			},
+			payload: { ...payload, estimatedEffort: 4 },
+		});
+
+		expect(setPullRequestLabels).toHaveBeenCalledWith("t", "o", "r", 1, ["bug", "Review effort 4/5"]);
 	});
 
 	it("does not fail publish when label sync throws", async () => {

--- a/test/reviewLabels.test.ts
+++ b/test/reviewLabels.test.ts
@@ -1,5 +1,38 @@
 import { describe, expect, it } from "vitest";
-import { syncReviewLabels } from "../src/agent/reviewLabels.js";
+import type { ReviewPayload } from "../src/agent/reviewSchema.js";
+import { labelsAlreadySynced, syncReviewLabels } from "../src/agent/reviewLabels.js";
+
+const basePayload: ReviewPayload = {
+	prCharacter: "Test.",
+	findings: [],
+	estimatedEffort: 2,
+	relevantTests: "no",
+	securityConcerns: null,
+	followUps: [],
+};
+
+describe("labelsAlreadySynced", () => {
+	it("returns false when effort matches but security label is stale", () => {
+		expect(
+			labelsAlreadySynced(["Review effort 2/5", "Possible security concern"], basePayload, {
+				effort: true,
+				security: true,
+			}),
+		).toBe(false);
+	});
+
+	it("returns true when effort and security labels match payload", () => {
+		expect(
+			labelsAlreadySynced(["Review effort 2/5", "Possible security concern"], {
+				...basePayload,
+				securityConcerns: "xss",
+			}, {
+				effort: true,
+				security: true,
+			}),
+		).toBe(true);
+	});
+});
 
 describe("syncReviewLabels", () => {
 	it("replaces Review effort label and preserves unrelated labels", () => {


### PR DESCRIPTION
## Summary
- Skip `setPullRequestLabels` when the PR already has the matching `Review effort N/5` label, avoiding redundant GitHub label updates on repeat reviews
- Still sync labels when the effort value changes (e.g. `2/5` → `4/5`)
- Add `publishReview` tests covering skip vs replace behaviour

## Test plan
- [x] `npm test`