### PR TITLE
Skip PR review when there are no P0–P2 findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ GitHub App webhook service that performs automated pull request reviews using [`
 
 ## What it does
 
-- On **`pull_request`** (`opened`, `synchronize`, `reopened`), adds 👀 (`eyes`) on the PR issue, then runs an agent loop to inspect the PR and post a **`COMMENT`**-style GitHub review plus a timeline summary comment when the model succeeds.
+- On **`pull_request`** (`opened`, `synchronize`, `reopened`), adds 👀 (`eyes`) on the PR issue, then runs an agent loop to inspect the PR and upsert **`## PR Agent Review`** on the PR conversation when the model succeeds. A pull request review on the Files tab (with inline P0–P2 threads) is posted only when those severities are present.
 - On **`issue_comment`** and **`pull_request_review_comment`** (`created` only), detects `/help`, `/review`, and `/review-security`, reacts with 👀 on the PR + triggering comment where applicable, and routes commands.
 - Responds **`200`** only **after inline processing completes** — large models can exceed GitHub’s webhook timeouts; operators should tune `MAX_TOOL_ROUNDS`/model latency or revisit async delivery (tracked as a scaling concern in the plan).
 

--- a/src/agent/publishReview.ts
+++ b/src/agent/publishReview.ts
@@ -42,22 +42,33 @@ export async function publishReview(params: ReviewPublishContext & {
 			body: renderInlineThreadBody(f),
 		}));
 
-		const review = await createPullRequestReviewWithComments(token, owner, repo, prNumber, {
-			body: reviewPointerBodyForMode(mode),
-			event,
-			comments: comments.length > 0 ? comments : undefined,
-		});
+		if (comments.length > 0) {
+			const review = await createPullRequestReviewWithComments(token, owner, repo, prNumber, {
+				body: reviewPointerBodyForMode(mode),
+				event,
+				comments,
+			});
+
+			log.info("review_published_inline", {
+				mode,
+				owner,
+				repo,
+				pr: prNumber,
+				reviewId: review.id,
+				event,
+				inlineCount: comments.length,
+			});
+		} else {
+			log.info("review_inline_skipped", {
+				reason: "no_p0_p2_findings",
+				mode,
+				owner,
+				repo,
+				pr: prNumber,
+			});
+		}
 
 		publishState.inlinePublished = true;
-		log.info("review_published_inline", {
-			mode,
-			owner,
-			repo,
-			pr: prNumber,
-			reviewId: review.id,
-			event,
-			inlineCount: comments.length,
-		});
 	}
 
 	const summaryBody = renderReviewSummaryComment(payload, {

--- a/test/publishReview.test.ts
+++ b/test/publishReview.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { publishReview } from "../src/agent/publishReview.js";
 import * as reviewSchema from "../src/agent/reviewSchema.js";
 import type { ReviewPayload } from "../src/agent/reviewSchema.js";
-import { SECURITY_REVIEW_SUMMARY_SENTINEL } from "../src/agent/reviewSchema.js";
+import { REVIEW_SUMMARY_SENTINEL, SECURITY_REVIEW_SUMMARY_SENTINEL } from "../src/agent/reviewSchema.js";
 import { SECURITY_REVIEW_POINTER_BODY } from "../src/agent/reviewRender.js";
 
 vi.mock("../src/github/reviewPublish.js", () => ({
@@ -120,6 +120,57 @@ describe("publishReview", () => {
 			expect.objectContaining({ event: "REQUEST_CHANGES" }),
 		);
 		spy.mockRestore();
+	});
+
+	it.each([
+		{ label: "general", mode: undefined, sentinel: REVIEW_SUMMARY_SENTINEL },
+		{ label: "security", mode: "review-security" as const, sentinel: SECURITY_REVIEW_SUMMARY_SENTINEL },
+	])("skips PR review when there are no P0–P2 findings ($label)", async ({ mode, sentinel }) => {
+		const publishState = { published: false, inlinePublished: false, lastValidationError: null };
+
+		await publishReview({
+			...baseParams,
+			...(mode ? { mode } : {}),
+			publishState,
+			payload: { ...payload, findings: [] },
+		});
+
+		expect(createPullRequestReviewWithComments).not.toHaveBeenCalled();
+		expect(upsertReviewSummaryComment).toHaveBeenCalledWith(
+			"t",
+			"o",
+			"r",
+			1,
+			expect.stringContaining(sentinel),
+			sentinel,
+		);
+		expect(publishState.inlinePublished).toBe(true);
+	});
+
+	it("skips PR review when only P3 findings", async () => {
+		const publishState = { published: false, inlinePublished: false, lastValidationError: null };
+
+		await publishReview({
+			...baseParams,
+			publishState,
+			payload: {
+				...payload,
+				findings: [
+					{
+						severity: "P3",
+						file: "README.md",
+						startLine: 1,
+						endLine: 1,
+						title: "Typo",
+						detail: "minor",
+					},
+				],
+			},
+		});
+
+		expect(createPullRequestReviewWithComments).not.toHaveBeenCalled();
+		expect(upsertReviewSummaryComment).toHaveBeenCalled();
+		expect(publishState.inlinePublished).toBe(true);
 	});
 
 	it("uses COMMENT when only P2 findings", async () => {


### PR DESCRIPTION
## Summary
- Skip creating a GitHub pull request review (Files tab) when there are no P0–P2 inline findings, avoiding the pointer-only "See the structured review summary…" comment on clean reviews
- Continue upserting the PR conversation summary comment (`## PR Agent Review` / security sentinel) as before
- Document the two-surface behavior in README and add `publishReview` tests for empty findings, P3-only, and general/security modes

## Test plan
- [x] `npm test`