### PR TITLE
Fix /ask reply delivery after webhook ack

### DIFF
--- a/src/commands/slashCommandFlow.ts
+++ b/src/commands/slashCommandFlow.ts
@@ -89,38 +89,114 @@ export function runSlashCommandFlow(
 				return;
 			}
 
-			const headSha = yield* surface.getPullRequestHeadSha(
-				ctx.token,
-				ctx.owner,
-				ctx.repo,
-				ctx.replyTarget.prNumber,
-			);
 			const askQueue = yield* AskQueue;
 			const queueLabel = `${ctx.owner}/${ctx.repo}#${ctx.replyTarget.prNumber}:ask`;
 
-			yield* askQueue.submit(
-				queueLabel,
+			const publishAskAnswer = (answer: string) =>
 				Effect.gen(function* () {
-					const result = yield* Effect.tryPromise({
-						try: () =>
-							runAskRun({
-								cfg: ctx.cfg,
-								token: ctx.token,
-								tokenExpiresAtTs: ctx.tokenExpiresAtTs,
-								tokenTtlMs: ctx.tokenTtlMs,
+					if (ctx.replyTarget.kind === "inlineReviewThread") {
+						yield* surface
+							.replyOnInlineReviewThread(
+								ctx.token,
+								ctx.owner,
+								ctx.repo,
+								ctx.replyTarget.prNumber,
+								ctx.replyTarget.inReplyToCommentId,
+								answer,
+							)
+							.pipe(
+								Effect.catchAll((err) => {
+									const message = err instanceof Error ? err.message : String(err);
+									log.warn("ask_inline_reply_failed", {
+										owner: ctx.owner,
+										repo: ctx.repo,
+										pr: ctx.replyTarget.prNumber,
+										inReplyToCommentId: ctx.replyTarget.inReplyToCommentId,
+										message,
+									});
+									const fallback = [
+										"_Could not reply in the review thread; posting here instead._",
+										"",
+										answer,
+									].join("\n");
+									return surface.postPrConversationComment(
+										ctx.token,
+										ctx.owner,
+										ctx.repo,
+										ctx.replyTarget.prNumber,
+										fallback,
+									);
+								}),
+							);
+						return;
+					}
+					yield* surface.postPrConversationComment(
+						ctx.token,
+						ctx.owner,
+						ctx.repo,
+						ctx.replyTarget.prNumber,
+						answer,
+					);
+				});
+
+			const askWork = askQueue
+				.submit(
+					queueLabel,
+					Effect.gen(function* () {
+						const headSha = yield* surface.getPullRequestHeadSha(
+							ctx.token,
+							ctx.owner,
+							ctx.repo,
+							ctx.replyTarget.prNumber,
+						);
+						const result = yield* Effect.tryPromise({
+							try: () =>
+								runAskRun({
+									cfg: ctx.cfg,
+									token: ctx.token,
+									tokenExpiresAtTs: ctx.tokenExpiresAtTs,
+									tokenTtlMs: ctx.tokenTtlMs,
+									owner: ctx.owner,
+									repo: ctx.repo,
+									prNumber: ctx.replyTarget.prNumber,
+									headSha,
+									question,
+									replyTarget: ctx.replyTarget,
+									codeAnchor: ctx.codeAnchor,
+								}),
+							catch: (e) => (e instanceof Error ? e : new Error(String(e))),
+						});
+						yield* publishAskAnswer(result.answer).pipe(Effect.uninterruptible);
+						log.info("ask_reply_delivered", {
+							owner: ctx.owner,
+							repo: ctx.repo,
+							pr: ctx.replyTarget.prNumber,
+							inline: ctx.replyTarget.kind === "inlineReviewThread",
+						});
+					}),
+				)
+				.pipe(
+					Effect.tapError((err) =>
+						Effect.sync(() => {
+							const message = err instanceof Error ? err.message : String(err);
+							log.error("ask_background_failed", {
 								owner: ctx.owner,
 								repo: ctx.repo,
-								prNumber: ctx.replyTarget.prNumber,
-								headSha,
-								question,
-								replyTarget: ctx.replyTarget,
-								codeAnchor: ctx.codeAnchor,
-							}),
-						catch: (e) => (e instanceof Error ? e : new Error(String(e))),
-					});
-					yield* postReply(result.answer);
-				}),
-			);
+								pr: ctx.replyTarget.prNumber,
+								message,
+							});
+						}),
+					),
+					Effect.catchAll(() => Effect.void),
+				);
+
+			yield* Effect.forkDaemon(askWork);
+			log.info("ask_dispatched", {
+				owner: ctx.owner,
+				repo: ctx.repo,
+				pr: ctx.replyTarget.prNumber,
+				label: queueLabel,
+			});
 			return;
 		}
 

--- a/src/effect/services/prGithubSurface.ts
+++ b/src/effect/services/prGithubSurface.ts
@@ -1,5 +1,6 @@
 import { Context, Effect, Layer } from "effect";
 import { installationOctokit } from "../../github/appAuth.js";
+import { log } from "../../log.js";
 
 const EYES = "eyes" as const;
 
@@ -60,7 +61,7 @@ export class PrGithubSurface extends Context.Tag("PrGithubSurface")<
 			prNumber: number,
 			inReplyToCommentId: number,
 			body: string,
-		) => Effect.Effect<void, Error>;
+		) => Effect.Effect<{ commentId: number }, Error>;
 		readonly getPullRequestHeadSha: (
 			apiToken: string,
 			owner: string,
@@ -120,13 +121,21 @@ export const PrGithubSurfaceLive = Layer.succeed(
 		replyOnInlineReviewThread: (apiToken, owner, repo, prNumber, inReplyToCommentId, body) =>
 			tryRest(async () => {
 				const octokit = installationOctokit(apiToken);
-				await octokit.rest.pulls.createReplyForReviewComment({
+				const { data } = await octokit.rest.pulls.createReplyForReviewComment({
 					owner,
 					repo,
 					pull_number: prNumber,
 					comment_id: inReplyToCommentId,
 					body,
 				});
+				log.info("inline_review_reply_posted", {
+					owner,
+					repo,
+					pr: prNumber,
+					inReplyToCommentId,
+					replyCommentId: data.id,
+				});
+				return { commentId: data.id };
 			}),
 
 		getPullRequestHeadSha: (apiToken, owner, repo, prNumber) =>

--- a/test/prGithubSurfaceService.test.ts
+++ b/test/prGithubSurfaceService.test.ts
@@ -137,7 +137,7 @@ describe("PrGithubSurface service", () => {
 	});
 
 	it("replyOnInlineReviewThread posts via pulls.createReplyForReviewComment", async () => {
-		const createReplyForReviewComment = vi.fn().mockResolvedValue({});
+		const createReplyForReviewComment = vi.fn().mockResolvedValue({ data: { id: 456 } });
 		const stub = makeOctokitStub({ createReplyForReviewComment });
 		const spy = vi.spyOn(appAuth, "installationOctokit").mockReturnValue(stub);
 

--- a/test/slashCommandFlow.test.ts
+++ b/test/slashCommandFlow.test.ts
@@ -56,7 +56,7 @@ function makeSurface(spies: SurfaceSpies, headSha = "abc"): Layer.Layer<PrGithub
 			},
 			replyOnInlineReviewThread: (...args) => {
 				spies.replyOnInlineReviewThread(...args);
-				return Effect.void;
+				return Effect.succeed({ commentId: 1001 });
 			},
 			getPullRequestHeadSha: (...args) => {
 				spies.getPullRequestHeadSha(...args);
@@ -101,6 +101,15 @@ function provideSlashLayers(spies: SurfaceSpies, opts?: {
 			Effect.provide(makeReviewQueue(opts?.reviewSubmitSpy)),
 			Effect.provide(makeAskQueue(opts?.askSubmitSpy)),
 		);
+}
+
+/** `/ask` runs in a forkDaemon; yield so background reply I/O can finish in tests. */
+function flushForkedWork<A, E, R>(effect: Effect.Effect<A, E, R>) {
+	return Effect.gen(function* () {
+		const result = yield* effect;
+		yield* Effect.sleep("50 millis");
+		return result;
+	});
 }
 
 function newSpies(): SurfaceSpies {
@@ -312,17 +321,19 @@ describe("runSlashCommandFlow", () => {
 
 		try {
 			await Effect.runPromise(
-				runSlashCommandFlow(
-					baseCtx({
-						body: "/ask what is this for?",
-						replyTarget: { kind: "inlineReviewThread", prNumber: 3, inReplyToCommentId: 99 },
-						codeAnchor: {
-							path: "apps/web/src/components/core/sessions/session-card.tsx",
-							line: 3,
-							diffHunk: "+import { useHydrationSafeDistance } from ...",
-						},
-					}),
-				).pipe(provideSlashLayers(spies, { askSubmitSpy, headSha: "abc123" })),
+				flushForkedWork(
+					runSlashCommandFlow(
+						baseCtx({
+							body: "/ask what is this for?",
+							replyTarget: { kind: "inlineReviewThread", prNumber: 3, inReplyToCommentId: 99 },
+							codeAnchor: {
+								path: "apps/web/src/components/core/sessions/session-card.tsx",
+								line: 3,
+								diffHunk: "+import { useHydrationSafeDistance } from ...",
+							},
+						}),
+					).pipe(provideSlashLayers(spies, { askSubmitSpy, headSha: "abc123" })),
+				),
 			);
 
 			expect(askSubmitSpy).toHaveBeenCalledWith("o/r#3:ask");
@@ -355,8 +366,10 @@ describe("runSlashCommandFlow", () => {
 		});
 
 		await Effect.runPromise(
-			runSlashCommandFlow(baseCtx({ body: "/ask what changed?" })).pipe(
-				provideSlashLayers(spies, { headSha: "sha1" }),
+			flushForkedWork(
+				runSlashCommandFlow(baseCtx({ body: "/ask what changed?" })).pipe(
+					provideSlashLayers(spies, { headSha: "sha1" }),
+				),
 			),
 		);
 


### PR DESCRIPTION
## Summary

Fixes a production bug where `/ask` logged `ask_completed` but never posted a reply on inline review threads. The webhook handler returned before ask work finished, and the reply step could be interrupted when GitHub closed the connection.

- Dispatch `/ask` work via `forkDaemon` so the webhook acks immediately and LLM/tool work runs in the background
- Wrap reply posting in `Effect.uninterruptible` so delivery is not dropped mid-flight
- Fall back to a PR conversation comment when inline thread reply fails
- Log `ask_dispatched`, `ask_reply_delivered`, and `inline_review_reply_posted` with comment IDs for easier debugging

## Test plan

- [x] `npm test` (205 tests)
- [ ] Redeploy and retry `/ask` on an inline review comment; confirm reply appears in thread
- [ ] Confirm logs show `ask_dispatched` → `ask_completed` → `inline_review_reply_posted` → `ask_reply_delivered`