### PR TITLE
Clarify agent work DLQ and head SHA sentinel

### DIFF
--- a/src/agentWork/boss.ts
+++ b/src/agentWork/boss.ts
@@ -37,23 +37,21 @@ export async function createStartedBoss(cfg: Pick<Config, "databaseUrl">): Promi
 	return boss;
 }
 
+const deadLetterQueueOptions = (cfg: QueueConfig): QueueOptions => ({
+	retryLimit: 0,
+	retryDelay: 0,
+	retryBackoff: false,
+	deleteAfterSeconds: cfg.queueDeleteAfterSeconds,
+	retentionSeconds: cfg.queueRetentionSeconds,
+});
+
 export async function ensureAgentQueues(boss: PgBoss, cfg: QueueConfig): Promise<void> {
 	const defaults = queueDefaults(cfg);
-	await boss.createQueue(ACK_DEAD_LETTER_QUEUE, {
-		retryLimit: 0,
-		deleteAfterSeconds: cfg.queueDeleteAfterSeconds,
-		retentionSeconds: cfg.queueRetentionSeconds,
-	});
-	await boss.createQueue(REVIEW_DEAD_LETTER_QUEUE, {
-		retryLimit: 0,
-		deleteAfterSeconds: cfg.queueDeleteAfterSeconds,
-		retentionSeconds: cfg.queueRetentionSeconds,
-	});
-	await boss.createQueue(ASK_DEAD_LETTER_QUEUE, {
-		retryLimit: 0,
-		deleteAfterSeconds: cfg.queueDeleteAfterSeconds,
-		retentionSeconds: cfg.queueRetentionSeconds,
-	});
+	const dlq = deadLetterQueueOptions(cfg);
+	// DLQ rows are archival only; no workers subscribe to these queue names.
+	await boss.createQueue(ACK_DEAD_LETTER_QUEUE, dlq);
+	await boss.createQueue(REVIEW_DEAD_LETTER_QUEUE, dlq);
+	await boss.createQueue(ASK_DEAD_LETTER_QUEUE, dlq);
 	await boss.createQueue(ACK_QUEUE, {
 		...defaults,
 		policy: "standard",

--- a/src/agentWork/scheduler.ts
+++ b/src/agentWork/scheduler.ts
@@ -13,6 +13,7 @@ import { log } from "../log.js";
 import {
 	ACK_QUEUE,
 	ASK_QUEUE,
+	DEFERRED_HEAD_SHA,
 	REVIEW_QUEUE,
 	installationGroupId,
 	prResourceKey,
@@ -26,7 +27,11 @@ import {
 } from "./types.js";
 
 const AUTOMATED_PR_ACTIONS = new Set(["opened", "synchronize", "reopened"]);
-/** Lens used for webhook-driven PR reviews; superseding queries key on this value. */
+/**
+ * Automated PR webhook reviews only. Superseding/cancel_requested_at applies to
+ * auto-sourced items with this lens only; slash /review-security and /ask lanes
+ * are intentionally not preempted (ADR 0009 §7).
+ */
 const AUTOMATED_REVIEW_LENS: ReviewMode = "review";
 const MAX_STORED_COMMENT_TEXT_LEN = 16_384;
 
@@ -364,7 +369,7 @@ export function makeAgentWorkScheduler(pool: Pool, boss: PgBoss) {
 							repo: input.repo,
 							prNumber: input.prNumber,
 							installationId: input.installationId,
-							headSha: "deferred-to-worker",
+							headSha: DEFERRED_HEAD_SHA,
 						};
 						const targets: AckTarget[] = [
 							{ kind: "pr", prNumber: input.prNumber },
@@ -396,7 +401,7 @@ export function makeAgentWorkScheduler(pool: Pool, boss: PgBoss) {
 								});
 								return;
 							}
-							const headSha = "deferred-to-worker";
+							const headSha = DEFERRED_HEAD_SHA;
 							const askRef = { ...ref, headSha };
 							const workItemId = await createAskWorkItem(client, {
 								webhookEventId: event.id,

--- a/src/agentWork/types.ts
+++ b/src/agentWork/types.ts
@@ -20,11 +20,15 @@ export type WebhookHeaders = {
 	readonly rawBody: Buffer;
 };
 
+/** Resolve at worker execution time when headSha is DEFERRED_HEAD_SHA. */
+export const DEFERRED_HEAD_SHA = "deferred-to-worker";
+
 export type PrRef = {
 	readonly owner: string;
 	readonly repo: string;
 	readonly prNumber: number;
 	readonly installationId: number;
+	/** Commit SHA, or DEFERRED_HEAD_SHA for worker-side pulls.get resolution */
 	readonly headSha: string;
 };
 

--- a/src/agentWork/worker.ts
+++ b/src/agentWork/worker.ts
@@ -40,6 +40,7 @@ import {
 	type AskJobData,
 	type ReviewJobData,
 	type ReviewWorkPayload,
+	DEFERRED_HEAD_SHA,
 } from "./types.js";
 
 function isTerminalPgBossAttempt(job: JobWithMetadata<ReviewJobData | AskJobData>): boolean {
@@ -153,7 +154,7 @@ async function handleAckJob(cfg: Config, pool: Pool, data: AckJobData): Promise<
 
 	if (data.progress) {
 		const headSha =
-			data.progress.headSha === "deferred-to-worker"
+			data.progress.headSha === DEFERRED_HEAD_SHA
 				? await getPullRequestHeadSha(installation.token, data.owner, data.repo, data.prNumber)
 				: data.progress.headSha;
 		const body = renderReviewProgressComment({
@@ -216,7 +217,7 @@ async function handleReviewJob(
 		}
 
 		const headSha =
-			item.headSha === "deferred-to-worker"
+			item.headSha === DEFERRED_HEAD_SHA
 				? await getPullRequestHeadSha(installation.token, item.owner, item.repo, item.prNumber)
 				: item.headSha;
 		if (!(await updateRunningWorkHeadSha(pool, item.id, headSha))) {


### PR DESCRIPTION
## Summary

- Dead-letter queues now share explicit no-retry options (`retryLimit`/`retryDelay`/`retryBackoff`) and a note that they are archival only (no workers consume them)
- Introduces `DEFERRED_HEAD_SHA` for slash commands that resolve PR head SHA at worker time, replacing scattered `"deferred-to-worker"` string literals
- Documents that automated review superseding applies only to auto-sourced `review` lens work, not slash `/review-security` or `/ask` (per ADR 0009)

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test`