### PR TITLE
Fix wide-event log explosion and noise

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@
 PORT=7224
 
 LOG_LEVEL=info
+# Max sub-events per wide log line (worker job / webhook request); default 128
+LOG_MAX_WIDE_EVENTS=128
+# Pretty-print logs (default false in production, true in development)
+# LOG_PRETTY=true
 
 # --- GitHub App ---
 GITHUB_APP_ID=123456

--- a/README.md
+++ b/README.md
@@ -100,5 +100,6 @@ PR_AGENT_ENV_FILE=/abs/path/to/.env docker compose up
 
 - Treat `WEBHOOK_SECRET` and app private keys as production secrets.
 - **`/ask`** applies deterministic outbound redaction (tokens, host URLs, PEM blocks) before posting replies; obvious bot-internals probes get an **Ask meta refusal** without an LLM call ([ADR 0010](docs/adr/0010-ask-red-team-hardening.md)). Review publish paths are unchanged.
-- Structured logging uses [evlog](https://www.evlog.dev) with `service: pr-agent`; `LOG_LEVEL` maps to evlog `minLevel`.
-- Production logging should stay at `info` or higher to avoid logging full payloads.
+- Structured logging uses [evlog](https://www.evlog.dev) with `service: pr-agent`; `LOG_LEVEL` maps to evlog `minLevel` (default `info`). At `info`, per-tool-round and rate-limit retry noise stays at `debug` and is omitted from emitted wide events.
+- `LOG_MAX_WIDE_EVENTS` (default `128`) caps sub-events per webhook/worker operation. `LOG_PRETTY` defaults to off in production (JSON lines).
+- Production logging should stay at `info` unless debugging a specific review run (`LOG_LEVEL=debug`).

--- a/src/agent/askRun.ts
+++ b/src/agent/askRun.ts
@@ -2,7 +2,7 @@ import { complete, getModel } from "@earendil-works/pi-ai";
 import type { AssistantMessage, Context, Message, Tool as PiTool, ToolCall } from "@earendil-works/pi-ai";
 import type { Config } from "../config.js";
 import type { ReplyTarget } from "../commands/slashCommandFlow.js";
-import { logInfo, logWarn, logError, logDebug } from "../evlog.js";
+import { logInfo, logWarn, logDebug } from "../evlog.js";
 import { sanitizeLogMessage } from "../security/sanitizeLogMessage.js";
 import { buildAskSystemPrompt } from "./askPrompt.js";
 import { formatAskFailureReply, formatAskReply } from "./formatAskReply.js";
@@ -146,10 +146,10 @@ export async function runAskRun(params: AskRunParams): Promise<AskRunResult> {
 	try {
 		await gh.executors.listPullRequestFiles({});
 		if (pathGate.prChangedPaths.size === 0) {
-			logWarn("ask_path_gate_prime_empty", { owner, repo, pr: prNumber });
+			logDebug("ask_path_gate_prime_empty", { owner, repo, pr: prNumber });
 		}
 	} catch (e) {
-		logWarn("ask_path_gate_prime_failed", {
+		logDebug("ask_path_gate_prime_failed", {
 			owner,
 			repo,
 			pr: prNumber,
@@ -201,7 +201,7 @@ export async function runAskRun(params: AskRunParams): Promise<AskRunResult> {
 			let isError = false;
 
 			if (rateLimitCircuitOpen && githubExecutorNames.has(call.name)) {
-				logInfo("github_tool_circuit_short_circuit", { tool: call.name, mode: "ask" });
+				logDebug("github_tool_circuit_short_circuit", { tool: call.name, mode: "ask" });
 				context.messages.push({
 					role: "toolResult",
 					toolCallId: call.id,
@@ -271,7 +271,7 @@ export async function runAskRun(params: AskRunParams): Promise<AskRunResult> {
 				} else {
 					const raw = e instanceof Error ? e.message : `Error executing ${call.name}: ${String(e)}`;
 					text = raw;
-					logWarn("tool_execute_failed", {
+					logDebug("tool_execute_failed", {
 						tool: call.name,
 						message: sanitizeLogMessage(raw),
 						mode: "ask",
@@ -312,11 +312,11 @@ export async function runAskRun(params: AskRunParams): Promise<AskRunResult> {
 
 			const toolCalls = collectToolCalls(assistant);
 			if (toolCalls.length === 0) {
-				logInfo("ask_round_complete_no_tools", { round, pr: prNumber });
+				logDebug("ask_round_complete_no_tools", { round, pr: prNumber });
 				break;
 			}
 
-			logInfo("ask_tool_round", { round, tools: toolCalls.map((t) => t.name), pr: prNumber });
+			logDebug("ask_tool_round", { round, tools: toolCalls.map((t) => t.name), pr: prNumber });
 			await appendToolResults(toolCalls);
 		}
 	}
@@ -350,7 +350,7 @@ export async function runAskRun(params: AskRunParams): Promise<AskRunResult> {
 
 	if (!summary && !retried) {
 		retried = true;
-		logInfo("ask_retry_nudge", { owner, repo, pr: prNumber });
+		logDebug("ask_retry_nudge", { owner, repo, pr: prNumber });
 		context.messages.push({ role: "user", content: ASK_RETRY_NUDGE, timestamp: Date.now() });
 		stopLoop = false;
 		await runToolLoop(ASK_RETRY_ROUNDS, false);

--- a/src/agent/publishReview.ts
+++ b/src/agent/publishReview.ts
@@ -7,7 +7,7 @@ import {
 	type InlineReviewComment,
 } from "../github/reviewPublish.js";
 import { labelsAlreadySynced, reviewLabelsFromPayload, syncReviewLabels } from "./reviewLabels.js";
-import { logInfo, logWarn, logError, logDebug } from "../evlog.js";
+import { logWarn, logDebug } from "../evlog.js";
 import { renderInlineThreadBody, renderReviewPointerBody, renderReviewSummaryComment } from "./reviewRender.js";
 import {
 	normalizeReviewPayload,
@@ -56,7 +56,7 @@ export async function publishReview(params: ReviewPublishContext & {
 				mode,
 			});
 			if (pointerBody.truncated) {
-				logWarn("agent_fix_prompt_truncated", {
+				logDebug("agent_fix_prompt_truncated", {
 					mode,
 					owner,
 					repo,
@@ -78,7 +78,7 @@ export async function publishReview(params: ReviewPublishContext & {
 				},
 			});
 
-			logInfo("review_published_inline", {
+			logDebug("review_published_inline", {
 				mode,
 				owner,
 				repo,
@@ -88,7 +88,7 @@ export async function publishReview(params: ReviewPublishContext & {
 				inlineCount: comments.length,
 			});
 		} else {
-			logInfo("review_inline_skipped", {
+			logDebug("review_inline_skipped", {
 				reason: "no_p0_p2_findings",
 				mode,
 				owner,
@@ -119,7 +119,7 @@ export async function publishReview(params: ReviewPublishContext & {
 		githubId: summary.id,
 		meta: { updated: summary.updated },
 	});
-	logInfo("review_published_summary", {
+	logDebug("review_published_summary", {
 		mode,
 		owner,
 		repo,
@@ -147,7 +147,7 @@ export async function publishReview(params: ReviewPublishContext & {
 			const next = syncReviewLabels(current, managed);
 			await setPullRequestLabels(token, owner, repo, prNumber, next);
 			await params.recordPublishStep?.("labels", { meta: { labels: next } });
-			logInfo("review_labels_synced", { owner, repo, pr: prNumber, labels: next });
+			logDebug("review_labels_synced", { owner, repo, pr: prNumber, labels: next });
 		} catch (e) {
 			const message = e instanceof Error ? e.message : String(e);
 			logWarn("review_labels_sync_failed", { owner, repo, pr: prNumber, message });

--- a/src/agent/reviewRun.ts
+++ b/src/agent/reviewRun.ts
@@ -1,7 +1,7 @@
 import { complete, getModel } from "@earendil-works/pi-ai";
 import type { AssistantMessage, Context, Message, Tool as PiTool, ToolCall } from "@earendil-works/pi-ai";
 import type { Config } from "../config.js";
-import { logInfo, logWarn, logError, logDebug } from "../evlog.js";
+import { logInfo, logWarn, logDebug } from "../evlog.js";
 import { buildContext7Tools } from "./context7Tools.js";
 import { buildGithubTools } from "./githubTools.js";
 import { upsertReviewSummaryComment } from "../github/reviewPublish.js";
@@ -284,7 +284,7 @@ export async function runFullPrReview(params: {
 				call.name !== "submitReview" &&
 				githubExecutorNames.has(call.name)
 			) {
-				logInfo("github_tool_circuit_short_circuit", { tool: call.name });
+				logDebug("github_tool_circuit_short_circuit", { tool: call.name });
 				context.messages.push({
 					role: "toolResult",
 					toolCallId: call.id,
@@ -299,7 +299,7 @@ export async function runFullPrReview(params: {
 			const isGithubTool = githubExecutorNames.has(call.name);
 
 			if (isGithubTool && isInstallationTokenNearExpiry(tokenExpiresAtTs)) {
-				logWarn("token_expired_before_tool", {
+				logDebug("token_expired_before_tool", {
 					tool: call.name,
 					tokenExpiresInSeconds: Math.max(
 						0,
@@ -365,7 +365,7 @@ export async function runFullPrReview(params: {
 					}
 				} else {
 					text = e instanceof Error ? e.message : `Error executing ${call.name}: ${String(e)}`;
-					logWarn("tool_execute_failed", { tool: call.name, message: text });
+					logDebug("tool_execute_failed", { tool: call.name, message: text.slice(0, 200) });
 				}
 			}
 
@@ -405,7 +405,7 @@ export async function runFullPrReview(params: {
 
 			const toolCalls = collectToolCalls(assistant);
 			if (toolCalls.length === 0) {
-				logInfo("agent_round_complete_no_tools", {
+				logDebug("agent_round_complete_no_tools", {
 					mode: reviewMode,
 					round,
 					summary: assistantReplySummary(assistant).slice(0, 200),
@@ -421,7 +421,7 @@ export async function runFullPrReview(params: {
 				break;
 			}
 
-			logInfo("agent_tool_round", {
+			logDebug("agent_tool_round", {
 				mode: reviewMode,
 				round,
 				tools: toolCalls.map((t) => t.name),
@@ -432,7 +432,7 @@ export async function runFullPrReview(params: {
 
 	async function runValidationRepair() {
 		if (!submitState.published && submitState.lastValidationError) {
-			logInfo("review_payload_repair_attempt", {
+			logDebug("review_payload_repair_attempt", {
 				mode: reviewMode,
 				message: submitState.lastValidationError,
 			});
@@ -449,18 +449,18 @@ export async function runFullPrReview(params: {
 
 	async function runFinalizePasses() {
 		for (let f = 0; f < cfg.maxFinalizeRounds && endsWithToolResults(context.messages) && !stopLoop; f++) {
-			logWarn("agent_finalize_pass", { mode: reviewMode, pass: f });
+			logDebug("agent_finalize_pass", { mode: reviewMode, pass: f });
 			const assistant = await complete(model, context);
 			lastAssistant = assistant;
 			context.messages.push(assistant);
 
 			const toolCalls = collectToolCalls(assistant);
 			if (toolCalls.length === 0) {
-				logInfo("agent_finalize_complete", { mode: reviewMode, pass: f });
+				logDebug("agent_finalize_complete", { mode: reviewMode, pass: f });
 				break;
 			}
 
-			logInfo("agent_finalize_tool_round", {
+			logDebug("agent_finalize_tool_round", {
 				mode: reviewMode,
 				pass: f,
 				tools: toolCalls.map((t) => t.name),

--- a/src/agent/submitReviewTool.ts
+++ b/src/agent/submitReviewTool.ts
@@ -1,7 +1,7 @@
 import type { Tool as PiTool } from "@earendil-works/pi-ai";
 import { z } from "zod";
 import type { Config } from "../config.js";
-import { logInfo, logWarn, logError, logDebug } from "../evlog.js";
+import { logInfo, logWarn, logDebug } from "../evlog.js";
 import { publishReview } from "./publishReview.js";
 import {
 	reviewPayloadSchema,
@@ -66,7 +66,7 @@ export function buildSubmitReviewTool(params: {
 
 	const executor = async (args: Record<string, unknown>) => {
 		if (params.state.published) {
-			logInfo("review_submit_duplicate_ignored", {
+			logDebug("review_submit_duplicate_ignored", {
 				mode,
 				owner: params.ctx.owner,
 				repo: params.ctx.repo,
@@ -79,7 +79,10 @@ export function buildSubmitReviewTool(params: {
 		if (!parsed.success) {
 			const message = parsed.error.message;
 			params.state.lastValidationError = message;
-			logWarn("review_payload_validation_failed", { mode, message });
+			logWarn("review_payload_validation_failed", {
+				mode,
+				message: message.slice(0, 200),
+			});
 			throw new Error(`Review payload validation failed: ${message}`);
 		}
 

--- a/src/agentWork/worker.ts
+++ b/src/agentWork/worker.ts
@@ -14,7 +14,7 @@ import {
 } from "../github/appAuth.js";
 import { INSTALLATION_TOKEN_FALLBACK_TTL_MS } from "../github/githubRequestError.js";
 import { upsertReviewSummaryComment } from "../github/reviewPublish.js";
-import { logInfo, logWarn, logError, runWithOperationLogger } from "../evlog.js";
+import { logInfo, logWarn, logError, logDebug, runWithOperationLogger } from "../evlog.js";
 import { sanitizeLogMessage } from "../security/sanitizeLogMessage.js";
 import {
 	getReviewPublishState,
@@ -164,7 +164,7 @@ async function handleAckJob(cfg: Config, pool: Pool, data: AckJobData): Promise<
 		try {
 			await safeReaction(installation.token, data.owner, data.repo, target);
 		} catch (e) {
-			logWarn("ack_reaction_failed", {
+			logDebug("ack_reaction_failed", {
 				owner: data.owner,
 				repo: data.repo,
 				targetKind: target.kind,
@@ -544,7 +544,7 @@ export const AgentWorkerLive = (cfg: Config, pool: Pool, boss: PgBoss) =>
 					});
 					for (const queue of [ACK_QUEUE, REVIEW_QUEUE, ASK_QUEUE]) {
 						const stats = await boss.getQueueStats(queue);
-						logInfo("agent_queue_stats", {
+						logDebug("agent_queue_stats", {
 							queue,
 							queued: stats.queuedCount,
 							active: stats.activeCount,

--- a/src/commands/slashCommandFlow.ts
+++ b/src/commands/slashCommandFlow.ts
@@ -168,7 +168,7 @@ export function runSlashCommandFlow(
 							catch: (e) => (e instanceof Error ? e : new Error(String(e))),
 						});
 						yield* publishAskAnswer(result.answer).pipe(Effect.uninterruptible);
-						logInfo("ask_reply_delivered", {
+						logDebug("ask_reply_delivered", {
 							owner: ctx.owner,
 							repo: ctx.repo,
 							pr: ctx.replyTarget.prNumber,
@@ -192,7 +192,7 @@ export function runSlashCommandFlow(
 				);
 
 			yield* Effect.forkDaemon(askWork);
-			logInfo("ask_dispatched", {
+			logDebug("ask_dispatched", {
 				owner: ctx.owner,
 				repo: ctx.repo,
 				pr: ctx.replyTarget.prNumber,

--- a/src/config.ts
+++ b/src/config.ts
@@ -184,6 +184,14 @@ export function loadConfig() {
 		throw new Error('LOG_LEVEL must be one of debug, info, warn, error');
 	}
 
+	const logMaxWideEvents = Number(optionalEnv("LOG_MAX_WIDE_EVENTS", "128"));
+	if (!Number.isFinite(logMaxWideEvents) || logMaxWideEvents < 1) {
+		throw new Error("LOG_MAX_WIDE_EVENTS must be a positive number");
+	}
+
+	const logPrettyDefault = process.env.NODE_ENV === "production" ? "false" : "true";
+	const logPretty = optionalEnv("LOG_PRETTY", logPrettyDefault) === "true";
+
 	return {
 		port,
 		githubAppId,
@@ -216,6 +224,8 @@ export function loadConfig() {
 		maxPrFilesListed,
 		maxPrFilesPatchBytes,
 		logLevel,
+		logMaxWideEvents,
+		logPretty,
 	};
 }
 

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -1,7 +1,7 @@
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import type { Pool } from "pg";
-import { logInfo, logWarn, logError, logDebug } from "../evlog.js";
+import { logInfo } from "../evlog.js";
 
 const MIGRATIONS_DIR = path.join(process.cwd(), "migrations");
 

--- a/src/effect/programs/dispatchEffect.ts
+++ b/src/effect/programs/dispatchEffect.ts
@@ -21,7 +21,7 @@ export function dispatchGithubEventEffect(
     const intakeLog = yield* IntakeLogger;
 
     if (!headers.delivery) {
-      recordEvent(intakeLog, "missing_delivery_id_using_body_hash");
+      recordEvent(intakeLog, "missing_delivery_id_using_body_hash", undefined, "warn");
     }
 
     let parsed: ReturnType<typeof parseGithubPayload>;
@@ -29,7 +29,7 @@ export function dispatchGithubEventEffect(
       parsed = parseGithubPayload(event, payload);
     } catch (e) {
       if (e instanceof WebhookParseError) {
-        recordEvent(intakeLog, "webhook_parse_error", { event, message: e.message });
+        recordEvent(intakeLog, "webhook_parse_error", { event, message: e.message }, "warn");
         return;
       }
       return yield* Effect.fail(e instanceof Error ? e : new Error(String(e)));
@@ -37,7 +37,7 @@ export function dispatchGithubEventEffect(
 
     const scheduler = yield* AgentWorkScheduler;
     if (parsed.name === "ignored") {
-      recordEvent(intakeLog, "ignored_event", { event });
+      recordEvent(intakeLog, "ignored_event", { event }, "debug");
       yield* scheduler.recordIgnored(headers, `ignored_event_${event || "missing"}`, intakeLog);
       return;
     }

--- a/src/effect/programs/processWebhookRequestEffect.ts
+++ b/src/effect/programs/processWebhookRequestEffect.ts
@@ -43,7 +43,7 @@ export function processWebhookHttpRequestEffect(
 
     if (req.method === "GET" && path === "/health") {
       const response = { status: 200, body: "ok", contentType: "text/plain; charset=utf-8" } satisfies WebhookResponseLike;
-      recordEvent(intakeLog, "health_check", { status: response.status });
+      recordEvent(intakeLog, "health_check", { status: response.status }, "debug");
       intakeLog.set({ webhook: { status: response.status } });
       yield* Effect.promise(() => emitOperationLogger(intakeLog, { event: "health_check" }));
       return response;
@@ -51,7 +51,7 @@ export function processWebhookHttpRequestEffect(
 
     if (req.method !== "POST" || path !== "/webhooks") {
       const response = { status: 404, body: "" } satisfies WebhookResponseLike;
-      recordEvent(intakeLog, "route_not_found", { status: response.status });
+      recordEvent(intakeLog, "route_not_found", { status: response.status }, "debug");
       intakeLog.set({ webhook: { status: response.status } });
       yield* Effect.promise(() => emitOperationLogger(intakeLog, { event: "route_not_found" }));
       return response;
@@ -59,7 +59,7 @@ export function processWebhookHttpRequestEffect(
 
     const sig = req.headers["x-hub-signature-256"];
     if (!verifyGithubWebhookSignature(cfg.webhookSecret, req.rawBody, sig)) {
-      recordEvent(intakeLog, "invalid_signature");
+      recordEvent(intakeLog, "invalid_signature", undefined, "warn");
       const response = { status: 401, body: "invalid signature" } satisfies WebhookResponseLike;
       intakeLog.set({ webhook: { status: response.status, signatureInvalid: true } });
       yield* Effect.promise(() => emitOperationLogger(intakeLog, { event: "invalid_signature" }));
@@ -70,7 +70,7 @@ export function processWebhookHttpRequestEffect(
     try {
       payload = JSON.parse(req.rawBody.toString("utf8")) as Record<string, unknown>;
     } catch {
-      recordEvent(intakeLog, "invalid_json");
+      recordEvent(intakeLog, "invalid_json", undefined, "warn");
       const response = { status: 400, body: "invalid json" } satisfies WebhookResponseLike;
       intakeLog.set({ webhook: { status: response.status } });
       yield* Effect.promise(() => emitOperationLogger(intakeLog, { event: "invalid_json" }));
@@ -88,11 +88,16 @@ export function processWebhookHttpRequestEffect(
         Effect.map(() => ({ ok: true as const })),
         Effect.catchTag("WebhookHandlerError", (err: WebhookHandlerError) =>
           Effect.sync(() => {
-            recordEvent(intakeLog, "webhook_handler_error", {
-              event: githubEvent,
-              delivery: logDelivery,
-              message: err.message,
-            });
+            recordEvent(
+              intakeLog,
+              "webhook_handler_error",
+              {
+                event: githubEvent,
+                delivery: logDelivery,
+                message: err.message,
+              },
+              "error",
+            );
             return { ok: false as const };
           }),
         ),
@@ -106,7 +111,12 @@ export function processWebhookHttpRequestEffect(
       return response;
     }
 
-    recordEvent(intakeLog, "webhook_handled", { event: githubEvent, delivery: logDelivery, ms: elapsedMs });
+    recordEvent(
+      intakeLog,
+      "webhook_handled",
+      { event: githubEvent, delivery: logDelivery, ms: elapsedMs },
+      "info",
+    );
     intakeLog.set({
       webhook: {
         status: 200,
@@ -116,12 +126,17 @@ export function processWebhookHttpRequestEffect(
       },
     });
     if (elapsedMs > cfg.webhookTimeoutMs) {
-      recordEvent(intakeLog, "webhook_timeout_budget_exceeded", {
-        event: githubEvent,
-        delivery: logDelivery,
-        ms: elapsedMs,
-        budgetMs: cfg.webhookTimeoutMs,
-      });
+      recordEvent(
+        intakeLog,
+        "webhook_timeout_budget_exceeded",
+        {
+          event: githubEvent,
+          delivery: logDelivery,
+          ms: elapsedMs,
+          budgetMs: cfg.webhookTimeoutMs,
+        },
+        "warn",
+      );
     }
     yield* Effect.promise(() => emitOperationLogger(intakeLog, { event: "webhook_handled" }));
     return { status: 200, body: "ok" } satisfies WebhookResponseLike;

--- a/src/effect/services/askQueue.ts
+++ b/src/effect/services/askQueue.ts
@@ -1,6 +1,6 @@
 import { Clock, Context, Effect, Layer } from "effect";
 import type { Config } from "../../config.js";
-import { logInfo, logWarn, logError, logDebug } from "../../evlog.js";
+import { logDebug } from "../../evlog.js";
 
 export class AskQueue extends Context.Tag("AskQueue")<
 	AskQueue,
@@ -27,7 +27,7 @@ export const AskQueueLive = (cfg: Pick<Config, "askConcurrency">) =>
 								const now = yield* Clock.currentTimeMillis;
 								const waitMs = now - queuedAt;
 								if (waitMs > 0) {
-									logInfo("ask_queue_wait", { label, waitMs });
+									logDebug("ask_queue_wait", { label, waitMs });
 								}
 								return yield* task;
 							}),

--- a/src/effect/services/githubInstallationToken.ts
+++ b/src/effect/services/githubInstallationToken.ts
@@ -2,7 +2,7 @@ import { Clock, Context, Deferred, Effect, Layer, Ref } from "effect";
 import type { Config } from "../../config.js";
 import { mintInstallationAuth, type InstallationToken } from "../../github/appAuth.js";
 import { INSTALLATION_TOKEN_FALLBACK_TTL_MS } from "../../github/githubRequestError.js";
-import { logInfo, logWarn, logError, logDebug } from "../../evlog.js";
+import { logDebug } from "../../evlog.js";
 
 const FRESHNESS_BUFFER_MS = 60_000;
 

--- a/src/effect/services/prGithubSurface.ts
+++ b/src/effect/services/prGithubSurface.ts
@@ -1,6 +1,6 @@
 import { Context, Effect, Layer } from "effect";
 import { installationOctokit } from "../../github/appAuth.js";
-import { logInfo, logWarn, logError, logDebug } from "../../evlog.js";
+import { logDebug } from "../../evlog.js";
 
 const EYES = "eyes" as const;
 
@@ -128,7 +128,7 @@ export const PrGithubSurfaceLive = Layer.succeed(
 					comment_id: inReplyToCommentId,
 					body,
 				});
-				logInfo("inline_review_reply_posted", {
+				logDebug("inline_review_reply_posted", {
 					owner,
 					repo,
 					pr: prNumber,

--- a/src/effect/services/reviewQueue.ts
+++ b/src/effect/services/reviewQueue.ts
@@ -1,6 +1,6 @@
 import { Clock, Context, Effect, Layer } from "effect";
 import type { Config } from "../../config.js";
-import { logInfo, logWarn, logError, logDebug } from "../../evlog.js";
+import { logDebug } from "../../evlog.js";
 
 export class ReviewQueue extends Context.Tag("ReviewQueue")<
 	ReviewQueue,
@@ -27,7 +27,7 @@ export const ReviewQueueLive = (cfg: Pick<Config, "reviewConcurrency">) =>
 								const now = yield* Clock.currentTimeMillis;
 								const waitMs = now - queuedAt;
 								if (waitMs > 0) {
-									logInfo("review_queue_wait", { label, waitMs });
+									logDebug("review_queue_wait", { label, waitMs });
 								}
 								return yield* task;
 							}),

--- a/src/evlog.ts
+++ b/src/evlog.ts
@@ -12,9 +12,25 @@ import type { Config } from "./config.js";
 export { createError, parseError, globalLog as log };
 export type { RequestLogger };
 
+export type WideEventLevel = "debug" | "info" | "warn" | "error";
+
+const LEVEL_RANK: Record<WideEventLevel, number> = {
+	debug: 0,
+	info: 1,
+	warn: 2,
+	error: 3,
+};
+
+let globalMinLevel: WideEventLevel = "info";
+let globalMaxWideEvents = 128;
+
 const { storage, useLogger: useLoggerFromStorage } = createLoggerStorage(
 	"evlog: call initEvlog() at boot and run handlers inside runWithOperationLogger()",
 );
+
+export function isLevelEnabled(level: WideEventLevel): boolean {
+	return LEVEL_RANK[level] >= LEVEL_RANK[globalMinLevel];
+}
 
 export function useLogger(): RequestLogger {
 	return useLoggerFromStorage();
@@ -28,57 +44,77 @@ export function tryUseLogger(): RequestLogger | undefined {
 	}
 }
 
+function eventsArray(logger: RequestLogger): Array<Record<string, unknown>> {
+	const ctx = logger.getContext();
+	if (!Array.isArray(ctx.events)) {
+		logger.set({ events: [] });
+	}
+	return logger.getContext().events as Array<Record<string, unknown>>;
+}
+
+function filterEventsInPlace(logger: RequestLogger): void {
+	const events = eventsArray(logger);
+	let write = 0;
+	for (const entry of events) {
+		const level = (entry.level as WideEventLevel | undefined) ?? "info";
+		if (!isLevelEnabled(level)) continue;
+		events[write] = entry;
+		write++;
+	}
+	events.length = write;
+}
+
 /** Append a named sub-event while accumulating one wide event per operation. */
 export function recordEvent(
 	logger: RequestLogger,
 	event: string,
 	fields?: Record<string, unknown>,
+	level: WideEventLevel = "info",
 ): void {
+	if (!isLevelEnabled(level)) return;
+
+	const events = eventsArray(logger);
 	const ctx = logger.getContext();
-	const events = Array.isArray(ctx.events)
-		? [...(ctx.events as Array<Record<string, unknown>>)]
-		: [];
-	events.push({ event, ...(fields ?? {}), at: Date.now() });
-	logger.set({
-		events,
-		lastEvent: event,
-	});
+	const dropped = typeof ctx.eventsDropped === "number" ? ctx.eventsDropped : 0;
+
+	if (events.length >= globalMaxWideEvents) {
+		logger.set({ eventsDropped: dropped + 1, lastEvent: "events_truncated" });
+		return;
+	}
+
+	events.push({ event, level, ...(fields ?? {}), at: Date.now() });
+	logger.set({ lastEvent: event });
+}
+
+function recordOrGlobal(
+	level: WideEventLevel,
+	globalFn: (payload: Record<string, unknown>) => void,
+	event: string,
+	meta?: Record<string, unknown>,
+): void {
+	const logger = tryUseLogger();
+	if (logger) {
+		recordEvent(logger, event, meta, level);
+		return;
+	}
+	if (!isLevelEnabled(level)) return;
+	globalFn({ event, ...(meta ?? {}) });
 }
 
 export function logDebug(event: string, meta?: Record<string, unknown>): void {
-	const logger = tryUseLogger();
-	if (logger) {
-		recordEvent(logger, event, meta);
-		return;
-	}
-	globalLog.debug({ event, ...(meta ?? {}) });
+	recordOrGlobal("debug", (p) => globalLog.debug(p), event, meta);
 }
 
 export function logInfo(event: string, meta?: Record<string, unknown>): void {
-	const logger = tryUseLogger();
-	if (logger) {
-		recordEvent(logger, event, meta);
-		return;
-	}
-	globalLog.info({ event, ...(meta ?? {}) });
+	recordOrGlobal("info", (p) => globalLog.info(p), event, meta);
 }
 
 export function logWarn(event: string, meta?: Record<string, unknown>): void {
-	const logger = tryUseLogger();
-	if (logger) {
-		recordEvent(logger, event, meta);
-		return;
-	}
-	globalLog.warn({ event, ...(meta ?? {}) });
+	recordOrGlobal("warn", (p) => globalLog.warn(p), event, meta);
 }
 
 export function logError(event: string, meta?: Record<string, unknown>): void {
-	const logger = tryUseLogger();
-	if (logger) {
-		recordEvent(logger, event, meta);
-		return;
-	}
-	globalLog.error({ event, ...(meta ?? {}) });
+	recordOrGlobal("error", (p) => globalLog.error(p), event, meta);
 }
 
 export type OperationLoggerMeta = {
@@ -90,16 +126,25 @@ export type OperationLoggerMeta = {
 
 export function initEvlog(
 	logLevel: Config["logLevel"],
-	options?: { silent?: boolean; suppressDrainWarning?: boolean },
+	options?: {
+		silent?: boolean;
+		suppressDrainWarning?: boolean;
+		maxWideEvents?: number;
+		pretty?: boolean;
+	},
 ): void {
+	globalMinLevel = logLevel;
+	if (options?.maxWideEvents != null) globalMaxWideEvents = options.maxWideEvents;
+
+	const isProduction = process.env.NODE_ENV === "production";
 	initLogger({
 		env: {
 			service: "pr-agent",
 			environment: (process.env.NODE_ENV ?? "development") as "development" | "production" | "test",
 		},
 		minLevel: logLevel,
-		pretty: true,
-		redact: process.env.NODE_ENV === "production",
+		pretty: options?.pretty ?? !isProduction,
+		redact: isProduction,
 		silent: options?.silent ?? false,
 		_suppressDrainWarning: options?.suppressDrainWarning ?? false,
 	});
@@ -115,6 +160,15 @@ export function createOperationLogger(meta: OperationLoggerMeta): RequestLogger 
 	return logger;
 }
 
+async function emitPrepared(
+	logger: RequestLogger,
+	overrides?: Record<string, unknown>,
+): Promise<void> {
+	filterEventsInPlace(logger);
+	logger.set({ emitted: true });
+	await logger.emit(overrides);
+}
+
 export async function runWithOperationLogger<T>(
 	meta: OperationLoggerMeta,
 	fn: () => Promise<T>,
@@ -128,7 +182,7 @@ export async function runWithOperationLogger<T>(
 			throw e;
 		} finally {
 			try {
-				await opLog.emit();
+				await emitPrepared(opLog);
 			} catch {
 				// Do not mask the error thrown from fn()
 			}
@@ -140,6 +194,5 @@ export async function emitOperationLogger(
 	logger: RequestLogger,
 	overrides?: Record<string, unknown>,
 ): Promise<void> {
-	logger.set({ emitted: true });
-	await logger.emit(overrides);
+	await emitPrepared(logger, overrides);
 }

--- a/src/evlog.ts
+++ b/src/evlog.ts
@@ -21,8 +21,10 @@ const LEVEL_RANK: Record<WideEventLevel, number> = {
 	error: 3,
 };
 
+export const DEFAULT_MAX_WIDE_EVENTS = 128;
+
 let globalMinLevel: WideEventLevel = "info";
-let globalMaxWideEvents = 128;
+let globalMaxWideEvents = DEFAULT_MAX_WIDE_EVENTS;
 
 const { storage, useLogger: useLoggerFromStorage } = createLoggerStorage(
 	"evlog: call initEvlog() at boot and run handlers inside runWithOperationLogger()",
@@ -134,7 +136,7 @@ export function initEvlog(
 	},
 ): void {
 	globalMinLevel = logLevel;
-	if (options?.maxWideEvents != null) globalMaxWideEvents = options.maxWideEvents;
+	globalMaxWideEvents = options?.maxWideEvents ?? DEFAULT_MAX_WIDE_EVENTS;
 
 	const isProduction = process.env.NODE_ENV === "production";
 	initLogger({

--- a/src/github/appAuth.ts
+++ b/src/github/appAuth.ts
@@ -3,7 +3,7 @@ import { Octokit } from "@octokit/rest";
 import { retry } from "@octokit/plugin-retry";
 import { throttling } from "@octokit/plugin-throttling";
 import type { Config } from "../config.js";
-import { logInfo, logWarn, logError, logDebug } from "../evlog.js";
+import { logDebug } from "../evlog.js";
 import { onRateLimit, onSecondaryRateLimit } from "./octokitThrottle.js";
 
 // @ts-expect-error — nested @octokit/core versions between rest, retry, and throttling plugins

--- a/src/github/githubRequestError.ts
+++ b/src/github/githubRequestError.ts
@@ -1,6 +1,6 @@
 import { RequestError } from "@octokit/request-error";
 import type { ResponseHeaders } from "@octokit/types";
-import { logInfo, logWarn, logError, logDebug } from "../evlog.js";
+import { logWarn, logDebug } from "../evlog.js";
 
 export type GithubToolErrorClassification =
 	| "token_expired"
@@ -307,6 +307,11 @@ export function bumpRateLimitConsecutiveFailures(
 export const TOKEN_EXPIRED_TOOL_MESSAGE =
 	"Installation token is near expiry; cannot call GitHub tools for this review run. Call submitReview with your current analysis if possible.";
 
+function logGithubToolRequestErrorPayload(payload: Record<string, unknown>, classification: GithubToolErrorClassification): void {
+	const log = isRateLimitClassification(classification) ? logDebug : logWarn;
+	log("github_tool_request_error", payload);
+}
+
 export function logGithubToolRequestError(
 	tool: string,
 	err: unknown,
@@ -330,55 +335,67 @@ export function logGithubToolRequestError(
 
 	if (isGithubRequestError(err)) {
 		const meta = extractGithubResponseMeta(err);
-		logWarn("github_tool_request_error", {
-			...base,
-			status: meta.status,
-			message: meta.message,
-			method: meta.method,
-			url: meta.url,
-			githubRequestId: meta.githubRequestId,
-			rateLimitResource: meta.rateLimitResource,
-			rateLimitRemaining: meta.rateLimitRemaining,
-			rateLimitLimit: meta.rateLimitLimit,
-			rateLimitReset: meta.rateLimitReset,
-			rateLimitUsed: meta.rateLimitUsed,
-			retryAfterHeader: meta.retryAfterHeader,
-			octokitRetryCount: meta.octokitRetryCount,
-		});
+		logGithubToolRequestErrorPayload(
+			{
+				...base,
+				status: meta.status,
+				message: meta.message,
+				method: meta.method,
+				url: meta.url?.slice(0, 200),
+				githubRequestId: meta.githubRequestId,
+				rateLimitResource: meta.rateLimitResource,
+				rateLimitRemaining: meta.rateLimitRemaining,
+				rateLimitLimit: meta.rateLimitLimit,
+				rateLimitReset: meta.rateLimitReset,
+				rateLimitUsed: meta.rateLimitUsed,
+				retryAfterHeader: meta.retryAfterHeader,
+				octokitRetryCount: meta.octokitRetryCount,
+			},
+			classified.classification,
+		);
 		return;
 	}
 
 	if (isGraphqlRateLimitError(err)) {
-		logWarn("github_tool_request_error", {
-			...base,
-			status: 0,
-			message: err instanceof Error ? err.message.slice(0, MESSAGE_TRUNCATE) : String(err),
-		});
+		logGithubToolRequestErrorPayload(
+			{
+				...base,
+				status: 0,
+				message: err instanceof Error ? err.message.slice(0, MESSAGE_TRUNCATE) : String(err),
+			},
+			"rate_limit",
+		);
 		return;
 	}
 
 	if (classified.classification === "token_expired") {
-		logWarn("github_tool_request_error", {
+		logGithubToolRequestErrorPayload(
+			{
+				...base,
+				status: 0,
+				message:
+					err instanceof Error
+						? err.message.slice(0, MESSAGE_TRUNCATE)
+						: err == null
+							? "token near expiry guard"
+							: String(err),
+			},
+			classified.classification,
+		);
+		return;
+	}
+
+	logGithubToolRequestErrorPayload(
+		{
 			...base,
 			status: 0,
 			message:
 				err instanceof Error
 					? err.message.slice(0, MESSAGE_TRUNCATE)
-					: err == null
-						? "token near expiry guard"
-						: String(err),
-		});
-		return;
-	}
-
-	logWarn("github_tool_request_error", {
-		...base,
-		status: 0,
-		message:
-			err instanceof Error
-				? err.message.slice(0, MESSAGE_TRUNCATE)
-				: String(err),
-	});
+					: String(err),
+		},
+		classified.classification,
+	);
 }
 
 export function formatToolErrorMessage(

--- a/src/github/octokitThrottle.ts
+++ b/src/github/octokitThrottle.ts
@@ -1,6 +1,6 @@
 import type { Octokit } from "@octokit/core";
 import type { EndpointDefaults } from "@octokit/types";
-import { logInfo, logWarn, logError, logDebug } from "../evlog.js";
+import { logDebug } from "../evlog.js";
 
 export const PRIMARY_RATE_LIMIT_MAX_RETRIES = 2;
 
@@ -11,7 +11,7 @@ export function onRateLimit(
 	retryCount: number,
 ): boolean {
 	const willRetry = retryCount < PRIMARY_RATE_LIMIT_MAX_RETRIES;
-	logWarn("octokit_on_rate_limit", {
+	logDebug("octokit_on_rate_limit", {
 		method: options.method,
 		url: options.url,
 		retryAfter,
@@ -28,7 +28,7 @@ export function onSecondaryRateLimit(
 	retryCount: number,
 ): boolean {
 	const willRetry = retryAfter > 0 && retryCount === 0;
-	logWarn("octokit_on_secondary_rate_limit", {
+	logDebug("octokit_on_secondary_rate_limit", {
 		method: options.method,
 		url: options.url,
 		retryAfter,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { loadConfig, type Config } from "./config.js";
-import { initEvlog, logInfo } from "./evlog.js";
+import { initEvlog, logDebug, logInfo } from "./evlog.js";
 import { startEffectWebhookServer } from "./effect/server.js";
 import { startAgentWorker } from "./worker.js";
 
@@ -13,14 +13,14 @@ function main() {
     return;
   }
 
-  initEvlog(cfg.logLevel);
+  initEvlog(cfg.logLevel, { maxWideEvents: cfg.logMaxWideEvents, pretty: cfg.logPretty });
   logInfo("boot", {
     role: cfg.role,
     provider: cfg.piProvider,
     model: cfg.piModel,
     context7_enabled: cfg.context7ApiKey.length > 0,
   });
-  logInfo("runtime_selected", { runtime: "effect" });
+  logDebug("runtime_selected", { runtime: "effect" });
   if (cfg.role === "worker") {
     startAgentWorker(cfg);
     return;

--- a/test/evlog.test.ts
+++ b/test/evlog.test.ts
@@ -1,7 +1,63 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import * as evlog from "../src/evlog.js";
 
+describe("evlog wide events", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		evlog.initEvlog("error", { silent: true, suppressDrainWarning: true });
+	});
+
+	it("recordEvent appends linearly without array-merge duplication", () => {
+		evlog.initEvlog("debug", { silent: true, suppressDrainWarning: true, maxWideEvents: 128 });
+		const logger = evlog.createOperationLogger({ method: "JOB", path: "/test" });
+		for (let i = 0; i < 50; i++) {
+			evlog.recordEvent(logger, `evt_${i}`, { i }, "info");
+		}
+		const events = logger.getContext().events as Array<Record<string, unknown>>;
+		expect(events).toHaveLength(50);
+		expect(events[49]?.event).toBe("evt_49");
+	});
+
+	it("drops debug sub-events when LOG_LEVEL is info", async () => {
+		evlog.initEvlog("info", { silent: true, suppressDrainWarning: true });
+		const logger = evlog.createOperationLogger({ method: "JOB", path: "/test" });
+		evlog.recordEvent(logger, "debug_evt", {}, "debug");
+		evlog.recordEvent(logger, "info_evt", {}, "info");
+		vi.spyOn(logger, "emit").mockResolvedValue(null);
+		await evlog.emitOperationLogger(logger);
+		const names = (logger.getContext().events as Array<Record<string, unknown>>).map((e) => e.event);
+		expect(names).toEqual(["info_evt"]);
+	});
+
+	it("caps sub-events at LOG_MAX_WIDE_EVENTS", () => {
+		evlog.initEvlog("debug", { silent: true, suppressDrainWarning: true, maxWideEvents: 5 });
+		const logger = evlog.createOperationLogger({ method: "JOB", path: "/test" });
+		for (let i = 0; i < 7; i++) {
+			evlog.recordEvent(logger, `evt_${i}`, {}, "info");
+		}
+		const ctx = logger.getContext();
+		expect((ctx.events as unknown[]).length).toBe(5);
+		expect(ctx.eventsDropped).toBe(2);
+	});
+
+	it("recordEvent skips debug-level entries when LOG_LEVEL is info", () => {
+		evlog.initEvlog("info", { silent: true, suppressDrainWarning: true });
+		const logger = evlog.createOperationLogger({ method: "JOB", path: "/test" });
+		evlog.recordEvent(logger, "skipped", {}, "debug");
+		expect((logger.getContext().events as unknown[] | undefined)?.length ?? 0).toBe(0);
+		evlog.recordEvent(logger, "kept", {}, "info");
+		expect((logger.getContext().events as Array<Record<string, unknown>>).map((e) => e.event)).toEqual([
+			"kept",
+		]);
+	});
+});
+
 describe("runWithOperationLogger", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		evlog.initEvlog("error", { silent: true, suppressDrainWarning: true });
+	});
+
 	it("propagates fn error when emit throws", async () => {
 		const realCreate = evlog.createOperationLogger;
 		vi.spyOn(evlog, "createOperationLogger").mockImplementation((meta) => {
@@ -10,14 +66,10 @@ describe("runWithOperationLogger", () => {
 			return logger;
 		});
 
-		try {
-			await expect(
-				evlog.runWithOperationLogger({ method: "GET", path: "/test" }, async () => {
-					throw new Error("original");
-				}),
-			).rejects.toThrow("original");
-		} finally {
-			vi.restoreAllMocks();
-		}
+		await expect(
+			evlog.runWithOperationLogger({ method: "GET", path: "/test" }, async () => {
+				throw new Error("original");
+			}),
+		).rejects.toThrow("original");
 	});
 });

--- a/test/evlog.test.ts
+++ b/test/evlog.test.ts
@@ -40,6 +40,16 @@ describe("evlog wide events", () => {
 		expect(ctx.eventsDropped).toBe(2);
 	});
 
+	it("resets maxWideEvents when re-initialized without option", () => {
+		evlog.initEvlog("debug", { silent: true, suppressDrainWarning: true, maxWideEvents: 5 });
+		evlog.initEvlog("debug", { silent: true, suppressDrainWarning: true });
+		const logger = evlog.createOperationLogger({ method: "JOB", path: "/test" });
+		for (let i = 0; i < 10; i++) {
+			evlog.recordEvent(logger, `evt_${i}`, {}, "info");
+		}
+		expect((logger.getContext().events as unknown[]).length).toBe(10);
+	});
+
 	it("recordEvent skips debug-level entries when LOG_LEVEL is info", () => {
 		evlog.initEvlog("info", { silent: true, suppressDrainWarning: true });
 		const logger = evlog.createOperationLogger({ method: "JOB", path: "/test" });

--- a/test/reviewRun.test.ts
+++ b/test/reviewRun.test.ts
@@ -178,7 +178,7 @@ describe("runFullPrReview mode", () => {
 			timestamp: Date.now(),
 		}));
 
-		const infoSpy = vi.spyOn(evlog, "logInfo");
+		const debugSpy = vi.spyOn(evlog, "logDebug");
 		await runFullPrReview(
 			reviewParams({
 				cfg: { ...cfg, maxReviewPublishAttempts: 1, maxToolRounds: 1 },
@@ -186,7 +186,7 @@ describe("runFullPrReview mode", () => {
 			}),
 		);
 
-		expect(infoSpy).toHaveBeenCalledWith(
+		expect(debugSpy).toHaveBeenCalledWith(
 			"agent_tool_round",
 			expect.objectContaining({ mode: "review-security" }),
 		);


### PR DESCRIPTION
## Summary
- Fix `recordEvent` interacting with evlog’s array merge so sub-events append linearly instead of doubling on every log call (root cause of multi‑MB single-line production logs)
- Add level-aware wide events: at `LOG_LEVEL=info`, debug sub-events are not recorded and are filtered on emit; cap timeline with `LOG_MAX_WIDE_EVENTS` (default 128) and reset cap on each `initEvlog`
- Demote high-volume operational noise to `debug` (tool rounds, Octokit throttle retries, rate-limit class GitHub tool errors, publish substeps, health/route-not-found webhooks)
- Keep info/warn/error for job lifecycle, publish outcomes, circuits, webhook security/failures, and intake enqueue/dedupe
- Add `LOG_PRETTY` (off in production by default) and document logging env vars in `.env.example` and README

## Test plan
- [x] `pnpm test`
- [x] `pnpm typecheck`
- [ ] Deploy worker/web; confirm one review job emits a single modest wide log line at `LOG_LEVEL=info`