### PR TITLE
Post no-bugs review on repeat runs

### DIFF
--- a/src/agent/publishReview.ts
+++ b/src/agent/publishReview.ts
@@ -11,6 +11,7 @@ import { labelsAlreadySynced, reviewLabelsFromPayload, syncReviewLabels } from "
 import { logWarn, logDebug } from "../evlog.js";
 import {
   renderInlineThreadBody,
+  renderRepeatNoBugsReviewBody,
   renderReviewPointerBody,
   renderReviewSummaryComment,
 } from "./reviewRender.js";
@@ -116,6 +117,28 @@ export async function publishReview(
         event,
         inlineCount: comments.length,
       });
+    } else if (params.shouldLinkToSummary && payload.findings.length === 0) {
+      const body = renderRepeatNoBugsReviewBody(mode, summaryCommentUrl);
+      const review = await createPullRequestReviewWithComments(token, owner, repo, prNumber, {
+        body,
+        event: "COMMENT",
+      });
+      await params.recordPublishStep?.("inline_review", {
+        githubId: review.id,
+        meta: {
+          url: review.url,
+          inlineCount: 0,
+          repeatNoBugs: true,
+          event: "COMMENT",
+        },
+      });
+      logDebug("review_published_repeat_no_bugs", {
+        mode,
+        owner,
+        repo,
+        pr: prNumber,
+        reviewId: review.id,
+      });
     } else {
       logDebug("review_inline_skipped", {
         reason: "no_p0_p2_findings",
@@ -127,7 +150,7 @@ export async function publishReview(
     }
 
     publishState.inlinePublished = true;
-    if (comments.length === 0) {
+    if (comments.length === 0 && !(params.shouldLinkToSummary && payload.findings.length === 0)) {
       await params.recordPublishStep?.("inline_review", {
         meta: { inlineCount: 0, reason: "no_p0_p2_findings" },
       });

--- a/src/agent/reviewRender.ts
+++ b/src/agent/reviewRender.ts
@@ -58,6 +58,17 @@ export function renderReviewPointerLine(mode: ReviewMode, summaryCommentUrl?: st
     : `[View the updated review.](${summaryCommentUrl})`;
 }
 
+export const REPEAT_NO_BUGS_PREFIX = "No bugs found";
+
+export function renderRepeatNoBugsReviewBody(mode: ReviewMode, summaryCommentUrl?: string): string {
+  if (summaryCommentUrl) {
+    return mode === "review-security"
+      ? `${REPEAT_NO_BUGS_PREFIX}, [see the updated security review](${summaryCommentUrl}).`
+      : `${REPEAT_NO_BUGS_PREFIX}, [see the updated review](${summaryCommentUrl}).`;
+  }
+  return `${REPEAT_NO_BUGS_PREFIX}. ${reviewPointerBodyForMode(mode)}`;
+}
+
 export const AGENT_FIX_PROMPT_PREAMBLE =
   "Verify each finding against current code. Fix only still-valid issues, skip the rest with a brief reason, keep changes minimal, and validate.";
 

--- a/test/publishReview.test.ts
+++ b/test/publishReview.test.ts
@@ -361,6 +361,65 @@ describe("publishReview", () => {
     );
   });
 
+  it("posts repeat no-bugs COMMENT review when shouldLinkToSummary and zero findings", async () => {
+    vi.mocked(resolveVerifiedSummaryCommentUrl).mockResolvedValueOnce(
+      "https://github.com/o/r/pull/1#issuecomment-99",
+    );
+    const publishState = { published: false, inlinePublished: false, lastValidationError: null };
+
+    await publishReview({
+      ...baseParams,
+      shouldLinkToSummary: true,
+      summaryCommentIdHint: 99,
+      publishState,
+      payload: { ...payload, findings: [] },
+    });
+
+    expect(createPullRequestReviewWithComments).toHaveBeenCalledTimes(1);
+    expect(createPullRequestReviewWithComments).toHaveBeenCalledWith(
+      "t",
+      "o",
+      "r",
+      1,
+      expect.objectContaining({
+        event: "COMMENT",
+        body: "No bugs found, [see the updated review](https://github.com/o/r/pull/1#issuecomment-99).",
+      }),
+    );
+    const callArgs = vi.mocked(createPullRequestReviewWithComments).mock.calls[0]?.[4];
+    expect(callArgs).not.toHaveProperty("comments");
+    expect(upsertReviewSummaryComment).toHaveBeenCalled();
+    expect(publishState.inlinePublished).toBe(true);
+  });
+
+  it("does not post repeat no-bugs review when shouldLinkToSummary but P3-only findings", async () => {
+    vi.mocked(resolveVerifiedSummaryCommentUrl).mockResolvedValueOnce(
+      "https://github.com/o/r/pull/1#issuecomment-99",
+    );
+
+    await publishReview({
+      ...baseParams,
+      shouldLinkToSummary: true,
+      publishState: { published: false, inlinePublished: false, lastValidationError: null },
+      payload: {
+        ...payload,
+        findings: [
+          {
+            severity: "P3",
+            file: "README.md",
+            startLine: 1,
+            endLine: 1,
+            title: "Typo",
+            detail: "minor",
+          },
+        ],
+      },
+    });
+
+    expect(createPullRequestReviewWithComments).not.toHaveBeenCalled();
+    expect(upsertReviewSummaryComment).toHaveBeenCalled();
+  });
+
   it("does not fail publish when label sync throws", async () => {
     vi.mocked(setPullRequestLabels).mockRejectedValueOnce(new Error("labels forbidden"));
 

--- a/test/reviewRender.test.ts
+++ b/test/reviewRender.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
   AGENT_FIX_PROMPT_ACCORDION_SUMMARY,
+  REPEAT_NO_BUGS_PREFIX,
   REVIEW_POINTER_BODY,
   REVIEW_POINTER_BODY_MAX_CHARS,
   renderAgentFixPrompt,
   renderInlineThreadBody,
+  renderRepeatNoBugsReviewBody,
   renderReviewPointerBody,
   renderReviewSummaryComment,
   SECURITY_REVIEW_POINTER_BODY,
@@ -416,5 +418,29 @@ describe("renderReviewPointerBody", () => {
     expect(truncated).toBe(true);
     expect(body.length).toBeLessThanOrEqual(REVIEW_POINTER_BODY_MAX_CHARS);
     expect(body).toContain("...[truncated; see inline threads and PR summary]");
+  });
+});
+
+describe("renderRepeatNoBugsReviewBody", () => {
+  const url = "https://github.com/acme/widgets/pull/42#issuecomment-123";
+
+  it("links to summary when URL is verified (general)", () => {
+    const body = renderRepeatNoBugsReviewBody("review", url);
+    expect(body).toBe(`${REPEAT_NO_BUGS_PREFIX}, [see the updated review](${url}).`);
+  });
+
+  it("links to summary when URL is verified (security)", () => {
+    const body = renderRepeatNoBugsReviewBody("review-security", url);
+    expect(body).toBe(`${REPEAT_NO_BUGS_PREFIX}, [see the updated security review](${url}).`);
+  });
+
+  it("falls back to plain pointer when URL is missing (general)", () => {
+    const body = renderRepeatNoBugsReviewBody("review");
+    expect(body).toBe(`${REPEAT_NO_BUGS_PREFIX}. ${REVIEW_POINTER_BODY}`);
+  });
+
+  it("falls back to plain pointer when URL is missing (security)", () => {
+    const body = renderRepeatNoBugsReviewBody("review-security");
+    expect(body).toBe(`${REPEAT_NO_BUGS_PREFIX}. ${SECURITY_REVIEW_POINTER_BODY}`);
   });
 });


### PR DESCRIPTION
## Summary

- On repeat review runs (`shouldLinkToSummary`) with zero findings, publish a short Files-tab `COMMENT` review instead of skipping the pull request review entirely
- Add `renderRepeatNoBugsReviewBody` to render the linked “No bugs found, see the updated review” message (with security-lens and plain-text fallbacks)
- Keep first-run zero-finding behavior unchanged and exclude P3-only payloads from the no-bugs message
- Add publish and render tests for the new repeat no-bugs path

## Test plan

- [x] `pnpm test test/reviewRender.test.ts test/publishReview.test.ts`
- [x] `pnpm run check:code`