### PR TITLE
Add Cursor SDK provider for pr-agent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,8 @@ WEBHOOK_SECRET=replace-with-a-strong-secret
 # --- LLM (@earendil-works/pi-ai) ---
 PI_PROVIDER=openai
 PI_MODEL=gpt-4o-mini
+# Cursor provider (PI_PROVIDER=cursor): required when using Cursor models
+CURSOR_API_KEY=
 
 # --- Review agent ---
 MAX_TOOL_ROUNDS=24

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Durable agent work (Postgres intake + pg-boss workers) is described in [docs/adr
 - **Worker concurrency:** review, ask, and acknowledgement jobs are capped per process by **`REVIEW_CONCURRENCY`** (default `2`), **`ASK_CONCURRENCY`** (default `1`), and **`ACK_CONCURRENCY`** (default `2`) via pg-boss worker `localConcurrency` ([`src/agentWork/worker.ts`](src/agentWork/worker.ts)). Multi-replica deployments remain **at-least-once** at the worker layer.
 - **GitHub tools:** **11** investigation tools in [`src/agent/githubTools.ts`](src/agent/githubTools.ts), plus **2** Context7 doc tools; the server publishes only via **`submitReview`** (no agent-callable comment/review delivery tools). See [docs/adr/0004-native-pi-ai-toolset.md](docs/adr/0004-native-pi-ai-toolset.md).
 - **Library docs lookup:** review and ask agents get two Context7 tools (`resolveLibraryId`, `getLibraryDocs`) that hit `https://context7.com/api` to verify upstream API claims. Anonymous calls work for public libraries with rate limits; set **`CONTEXT7_API_KEY`** for higher limits and private repos. See [docs/adr/0003-context7-docs-tool.md](docs/adr/0003-context7-docs-tool.md).
+- **Cursor provider:** set **`PI_PROVIDER=cursor`**, **`CURSOR_API_KEY`**, and **`PI_MODEL`** (e.g. `composer-2.5`). Worker registers pi-ai api `cursor-sdk` and runs Cursor local agents with an HTTP MCP bridge to pr-agent's GitHub/Context7/submitReview tools. See [docs/adr/0013-cursor-sdk-provider.md](docs/adr/0013-cursor-sdk-provider.md).
 - **Bot identity** for self-suppression is cached **per `GITHUB_APP_ID`**, so multiple GitHub Apps in one process do not share the same cache entry.
 - **`WEBHOOK_TIMEOUT_MS`** (default `10000`) is a **logging-only** budget on webhook intake duration; it does not cancel worker jobs.
 - **`/review-security`** — trigger-only deep security review (DeepSec-adapted prompt; see [NOTICES.md](NOTICES.md)). Never runs on `pull_request` webhooks. Uses the same review worker lane and **`MAX_TOOL_ROUNDS`** as `/review`; large PRs may need a higher `MAX_TOOL_ROUNDS`. Posts a separate summary comment (`## PR Agent Security Review`) that can coexist with the general review summary.
@@ -82,7 +83,7 @@ Tunnel webhooks (e.g. [smee.io](https://smee.io)) to your local `PORT`, then poi
 - **Health:** `GET /health` returns `200` and plain `ok` (used by `HEALTHCHECK` in the image and by Compose).
 - **Webhook URL** (when Compose maps default ports): **`http://<host>:7224/webhooks`** — same path as bare Node.
 - **`DATABASE_URL`** is set in Compose for both app services (`postgres://pr_agent:pr_agent@postgres:5432/pr_agent`).
-- **Provider API keys** (for example **`OPENAI_API_KEY`**) are **not** read by [`src/config.ts`](src/config.ts); Pi AI loads them from the environment. Set them in `.env` beside the GitHub fields or reviews fail at runtime in the worker.
+- **Provider API keys** (for example **`OPENAI_API_KEY`** or **`CURSOR_API_KEY`** when `PI_PROVIDER=cursor`) are **not** fully read by [`src/config.ts`](src/config.ts) except `CURSOR_API_KEY` when the Cursor provider is selected; other Pi AI secrets load from the environment. Set them in `.env` beside the GitHub fields or reviews fail at runtime in the worker.
 - **Secrets:** never commit `.env`; keep Compose files off public pastebins.
 
 ```bash

--- a/docs/adr/0013-cursor-sdk-provider.md
+++ b/docs/adr/0013-cursor-sdk-provider.md
@@ -1,0 +1,33 @@
+# ADR 0013: Cursor SDK provider
+
+## Status
+
+Accepted
+
+## Context
+
+pr-agent uses `@earendil-works/pi-ai` (`complete()`, tool loop) for review and ask runs. Users want Cursor models via `CURSOR_API_KEY` without forking pi-ai upstream.
+
+[pi-cursor-sdk](https://github.com/fitchmultz/pi-cursor-sdk) implements a Cursor provider for **pi-coding-agent** (extension host + pi tool registry). pr-agent uses raw pi-ai in worker fibers with per-call GitHub/Context7/submitReview tools — not the coding-agent extension model.
+
+## Decision
+
+1. **Inline adapter** under `src/agent/cursor/`, registered at worker boot via pi-ai `registerApiProvider({ api: "cursor-sdk", ... })`.
+2. **`PI_PROVIDER=cursor`** + required **`CURSOR_API_KEY`** in `loadConfig()`.
+3. **Cursor owns the tool loop** for cursor runs: one `complete()` call; review/ask skip multi-round pi-ai scaffolding.
+4. **HTTP loopback MCP bridge** per run (`StreamableHTTPServerTransport` on `127.0.0.1`, bearer token) exposes pr-agent tools to Cursor's local agent. stdio MCP rejected (stdout conflict with evlog; in-process).
+5. **`local.settingSources: []`** — worker `cwd` is pr-agent source, not target repo; GitHub investigation tools are the repo signal.
+6. **Installation token refresh** in bridge `refreshBeforeTool` for long Cursor runs.
+
+## Consequences
+
+- No rate-limit circuit, validation repair, or publish-recovery loops on cursor runs (Cursor internal loop + MCP `submitReview`).
+- Usage metrics are approximate (char/4), not Cursor SDK cumulative counters.
+- Cursor cloud mode out of scope (would clone repo; conflicts with GitHub-API-only design).
+- No session/agent reuse across runs (single-shot worker jobs).
+
+## Alternatives considered
+
+- **Fork pi-ai** — heavier maintenance.
+- **Fork pi-cursor-sdk** — targets coding-agent; wrong integration surface.
+- **stdio MCP** — unusable in worker process (peer review).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,8 +26,9 @@ Import convention: `import { … } from "../settings/index.js"` for constants; `
 | App private key | `GITHUB_APP_PRIVATE_KEY` | — | required PEM |
 | Webhook HMAC secret | `WEBHOOK_SECRET` | — | required |
 | Postgres URL | `DATABASE_URL` | — | required |
-| LLM provider | `PI_PROVIDER` | `openai` | pi-ai registry id |
-| LLM model | `PI_MODEL` | `gpt-4o-mini` | |
+| LLM provider | `PI_PROVIDER` | `openai` | pi-ai registry id; use `cursor` for Cursor SDK |
+| LLM model | `PI_MODEL` | `gpt-4o-mini` | For `cursor`, e.g. `composer-2.5`, `auto` |
+| Cursor API key | `CURSOR_API_KEY` | empty | required when `PI_PROVIDER=cursor` |
 | Review tool rounds | `MAX_TOOL_ROUNDS` | `24` | per review run |
 | Publish recovery attempts | `MAX_REVIEW_PUBLISH_ATTEMPTS` | `3` | when submitReview never succeeds |
 | Publish execution budget | `MAX_REVIEW_PUBLISH_CALLS` | `2` | valid submitReview publishes per run |
@@ -140,6 +141,16 @@ These are related but not wired together on INSERT today.
 | `PRIMARY_RATE_LIMIT_MAX_RETRIES` | 2 |
 | `COMMENTS_PAGE_SIZE` | 100 |
 | `GITHUB_REACTION_EYES` | eyes |
+
+### Cursor SDK bridge
+
+| Symbol | Default |
+|--------|---------|
+| `CURSOR_MCP_BIND_HOST` | 127.0.0.1 |
+| `CURSOR_MCP_TOKEN_BYTES` | 32 |
+| `CURSOR_MCP_SERVER_START_TIMEOUT_MS` | 5000 |
+| `CURSOR_MAX_PORT_RETRIES` | 5 |
+| `CURSOR_MCP_SERVER_NAME` | pr-agent |
 
 ### Other
 

--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
     "check:effect-versions": "node scripts/check-effect-versions.mjs"
   },
   "dependencies": {
+    "@cursor/sdk": "^1.0.13",
     "@earendil-works/pi-ai": "^0.74.0",
     "@effect/platform": "0.96.1",
     "@effect/platform-node": "0.106.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@octokit/auth-app": "^8.1.2",
     "@octokit/core": "^7.0.0",
     "@octokit/plugin-retry": "^8.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,15 +8,21 @@ importers:
 
   .:
     dependencies:
+      '@cursor/sdk':
+        specifier: ^1.0.13
+        version: 1.0.13
       '@earendil-works/pi-ai':
         specifier: ^0.74.0
-        version: 0.74.0(ws@8.20.0)(zod@4.4.3)
+        version: 0.74.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.0)(zod@4.4.3)
       '@effect/platform':
         specifier: 0.96.1
         version: 0.96.1(effect@3.21.2)
       '@effect/platform-node':
         specifier: 0.106.0
         version: 0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
       '@octokit/auth-app':
         specifier: ^8.1.2
         version: 8.2.0
@@ -43,7 +49,7 @@ importers:
         version: 3.21.2
       evlog:
         specifier: ^2.17.0
-        version: 2.17.0(vite@7.3.3(@types/node@22.19.18)(tsx@4.21.0))
+        version: 2.17.0(express@5.2.1)(hono@4.12.19)(vite@7.3.3(@types/node@22.19.18)(tsx@4.21.0))
       pg:
         specifier: ^8.21.0
         version: 8.21.0
@@ -242,6 +248,50 @@ packages:
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
+
+  '@bufbuild/protobuf@1.10.0':
+    resolution: {integrity: sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==}
+
+  '@connectrpc/connect-node@1.7.0':
+    resolution: {integrity: sha512-6vaPIkG/NyhxlYgytLoR9KYbPhczEboFB2OYWkA9qvUz1K7efXfeGrlRxoLtpa+r8VxyIOw73w5ktNe743nD+A==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@bufbuild/protobuf': ^1.10.0
+      '@connectrpc/connect': 1.7.0
+
+  '@connectrpc/connect@1.7.0':
+    resolution: {integrity: sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^1.10.0
+
+  '@cursor/sdk-darwin-arm64@1.0.13':
+    resolution: {integrity: sha512-zHRTNtVRHw4KSAEFmtO0Av7jv9D60DrB+pygVNWGyKtRR44fcwtRHuLAJmO4HThxQw7MMvUJuAaNmCQxzHtPDQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cursor/sdk-darwin-x64@1.0.13':
+    resolution: {integrity: sha512-7XsIkMKp6h/4W9zBx02Py1euJLAJVxlkwmm9GSoUjc+3hfFvHY/R/WTbX2TFgF4g1vOAq/HM7GmXBXq+e4M4+w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cursor/sdk-linux-arm64@1.0.13':
+    resolution: {integrity: sha512-bDgfPPgc84gUn3k+Iiq5OLZozzM0UYZdKbQ821pbZy1OPWTFaSkjXsoAB6xqf9wALWyW1eQxOC4RprPBLoy+yA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cursor/sdk-linux-x64@1.0.13':
+    resolution: {integrity: sha512-BTccnB5hVqK8Y0778oql6gbk7kIIlzQrBqt5QNLJpwBidjjde/mlvAajVB9hB3a29jelOwm0gJjMsLfqTkEPdw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@cursor/sdk-win32-x64@1.0.13':
+    resolution: {integrity: sha512-GxWlwj4G513EfGmvPVBa4y+vNn9B5Cj+npu8fVcJ0P+U9sruhgo4pvqGbWxkn5EIKbpGoraLq9QB4nFeoT1uRQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@cursor/sdk@1.0.13':
+    resolution: {integrity: sha512-w6MWkgOTL6yb6GV/4Odx7QcamQgqhzX/CzcMBkqiiOPTPuEWItWrgA0qdivchm5YJXTt+LZkFSEQ/Ti44hVbfg==}
+    engines: {node: '>=18'}
 
   '@earendil-works/pi-ai@0.74.0':
     resolution: {integrity: sha512-7M7qcrZY/KEkH4wFkX3eqzvmKru4O88wezNKoN0KD2m4aAOmp9tdW2xCmUgSTSWlKB7b2Xw9QtAgrzHtg6t6iw==}
@@ -470,6 +520,13 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
+
+  '@gar/promisify@1.1.3':
+    resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
+
   '@google/genai@1.52.0':
     resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
     engines: {node: '>=20.0.0'}
@@ -479,11 +536,27 @@ packages:
       '@modelcontextprotocol/sdk':
         optional: true
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
   '@mistralai/mistralai@2.2.1':
     resolution: {integrity: sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
@@ -517,6 +590,14 @@ packages:
 
   '@nodable/entities@2.1.0':
     resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
+
+  '@npmcli/fs@1.1.1':
+    resolution: {integrity: sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==}
+
+  '@npmcli/move-file@1.1.2':
+    resolution: {integrity: sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==}
+    engines: {node: '>=10'}
+    deprecated: This functionality has been moved to @npmcli/fs
 
   '@octokit/auth-app@8.2.0':
     resolution: {integrity: sha512-vVjdtQQwomrZ4V46B9LaCsxsySxGoHsyw6IYBov/TqJVROrlYdyNgw5q6tQbB7KZt53v1l1W53RiqTvpzL907g==}
@@ -1336,6 +1417,16 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@statsig/client-core@3.31.0':
+    resolution: {integrity: sha512-SuxQD6TmVszPG7FoMKwTk/uyBuVFk7XnxI3T/E0uyb7PL7GNjONtfsoh+NqBBVUJVse0CUeSFfgJPoZy1ZOslQ==}
+
+  '@statsig/js-client@3.31.0':
+    resolution: {integrity: sha512-LFa5E0LjT6sTfZv3sNGoyRLSZ1078+agdgOA+Vm1ecjG+KbSOfBLTW7hMwimrJ29slRwbYDzbtKaPJo/R37N2g==}
+
+  '@tootallnate/once@1.1.2':
+    resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
+    engines: {node: '>= 6'}
+
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
@@ -1389,9 +1480,51 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  abbrev@1.1.1:
+    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
+
+  aggregate-error@3.1.0:
+    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
+    engines: {node: '>=8'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  aproba@2.1.0:
+    resolution: {integrity: sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==}
+
+  are-we-there-yet@3.0.1:
+    resolution: {integrity: sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -1400,6 +1533,9 @@ packages:
   ast-types@0.13.4:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -1417,18 +1553,50 @@ packages:
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  cacache@15.3.0:
+    resolution: {integrity: sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==}
+    engines: {node: '>= 10'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -1442,9 +1610,58 @@ packages:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  chownr@2.0.0:
+    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
+    engines: {node: '>=10'}
+
+  clean-stack@2.2.0:
+    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
+    engines: {node: '>=6'}
+
+  color-support@1.1.3:
+    resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
+    hasBin: true
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  console-control-strings@1.1.0:
+    resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
+
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
   cron-parser@5.5.0:
     resolution: {integrity: sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww==}
     engines: {node: '>=18'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -1463,31 +1680,88 @@ packages:
       supports-color:
         optional: true
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
 
   degenerator@5.0.1:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
     engines: {node: '>= 14'}
 
+  delegates@1.0.0:
+    resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
   effect@3.21.2:
     resolution: {integrity: sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==}
 
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  encoding@0.1.13:
+    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
+  err-code@2.0.3:
+    resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escodegen@2.1.0:
     resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
@@ -1509,6 +1783,18 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
 
   evlog@2.17.0:
     resolution: {integrity: sha512-v6PWFV0SAEB04l70vENByG6o4r2v8KXIUNroeqYQ6uXb2xEzRRgRCxiAsAntb+Tqd4xPKenX+X67v/KyM6ar5g==}
@@ -1563,9 +1849,23 @@ packages:
       vite:
         optional: true
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -1579,6 +1879,12 @@ packages:
 
   fast-content-type-parse@3.0.0:
     resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-xml-builder@1.2.0:
     resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
@@ -1600,6 +1906,13 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-my-way-ts@0.1.6:
     resolution: {integrity: sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==}
 
@@ -1607,10 +1920,36 @@ packages:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
+  fs-minipass@2.1.0:
+    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
+    engines: {node: '>= 8'}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gauge@4.0.4:
+    resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
 
   gaxios@7.1.4:
     resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
@@ -1620,12 +1959,27 @@ packages:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
     engines: {node: '>=18'}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
   get-uri@6.0.5:
     resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
     engines: {node: '>= 14'}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   google-auth-library@10.6.2:
     resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
@@ -1635,25 +1989,117 @@ packages:
     resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-unicode@2.0.1:
+    resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  hono@4.12.19:
+    resolution: {integrity: sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==}
+    engines: {node: '>=16.9.0'}
+
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  http-proxy-agent@4.0.1:
+    resolution: {integrity: sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==}
+    engines: {node: '>= 6'}
+
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
+  infer-owner@1.0.4:
+    resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
   ip-address@10.2.0:
     resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-lambda@1.0.1:
+    resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
@@ -1664,6 +2110,12 @@ packages:
   json-schema-to-ts@3.1.1:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
     engines: {node: '>=16'}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-with-bigint@3.5.8:
     resolution: {integrity: sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==}
@@ -1683,6 +2135,10 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
@@ -1694,9 +2150,83 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  make-fetch-happen@9.1.0:
+    resolution: {integrity: sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==}
+    engines: {node: '>= 10'}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
   mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
     engines: {node: '>=10.0.0'}
+    hasBin: true
+
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass-collect@1.0.2:
+    resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
+    engines: {node: '>= 8'}
+
+  minipass-fetch@1.4.1:
+    resolution: {integrity: sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==}
+    engines: {node: '>=8'}
+
+  minipass-flush@1.0.7:
+    resolution: {integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==}
+    engines: {node: '>= 8'}
+
+  minipass-pipeline@1.2.4:
+    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
+    engines: {node: '>=8'}
+
+  minipass-sized@1.0.3:
+    resolution: {integrity: sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==}
+    engines: {node: '>=8'}
+
+  minipass@3.3.6:
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
+
+  minipass@5.0.0:
+    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
+    engines: {node: '>=8'}
+
+  minizlib@2.1.2:
+    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
+    engines: {node: '>= 8'}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
     hasBin: true
 
   ms@2.1.3:
@@ -1717,9 +2247,24 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
+  negotiator@0.6.4:
+    resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
+    engines: {node: '>= 0.6'}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   netmask@2.1.1:
     resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
     engines: {node: '>= 0.4.0'}
+
+  node-abi@3.92.0:
+    resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
+    engines: {node: '>=10'}
 
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
@@ -1737,9 +2282,39 @@ packages:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
     hasBin: true
 
+  node-gyp@8.4.1:
+    resolution: {integrity: sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==}
+    engines: {node: '>= 10.12.0'}
+    hasBin: true
+
   non-error@0.1.0:
     resolution: {integrity: sha512-TMB1uHiGsHRGv1uYclfhivcnf0/PdFp2pNqRxXjncaAsjYMoisaQJI+SSZCqRq+VliwRTC8tsMQfmrWjDMhkPQ==}
     engines: {node: '>=20'}
+
+  nopt@5.0.0:
+    resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  npmlog@6.0.2:
+    resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   openai@6.26.0:
     resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
@@ -1777,6 +2352,10 @@ packages:
       oxlint-tsgolint:
         optional: true
 
+  p-map@4.0.0:
+    resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
+    engines: {node: '>=10'}
+
   p-retry@4.6.2:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
     engines: {node: '>=8'}
@@ -1789,12 +2368,27 @@ packages:
     resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
     engines: {node: '>= 14'}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   partial-json@0.1.7:
     resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
 
   path-expression-matcher@1.5.0:
     resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
     engines: {node: '>=14.0.0'}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1849,6 +2443,10 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1869,9 +2467,31 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
+  promise-inflight@1.0.1:
+    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
+    peerDependencies:
+      bluebird: '*'
+    peerDependenciesMeta:
+      bluebird:
+        optional: true
+
+  promise-retry@2.0.1:
+    resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
+    engines: {node: '>=10'}
+
   protobufjs@7.5.6:
     resolution: {integrity: sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==}
     engines: {node: '>=12.0.0'}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
 
   proxy-agent@6.5.0:
     resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
@@ -1880,34 +2500,133 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
+
+  rimraf@3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
 
   rollup@4.60.3:
     resolution: {integrity: sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
 
   serialize-error@13.0.1:
     resolution: {integrity: sha512-bBZaRwLH9PN5HbLCjPId4dP5bNGEtumcErgOX952IsvOhVPrm3/AeK1y0UHA/QaPG701eg0yEnOKsCOC6X/kaA==}
     engines: {node: '>=20'}
 
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks-proxy-agent@6.2.1:
+    resolution: {integrity: sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==}
+    engines: {node: '>= 10'}
 
   socks-proxy-agent@8.0.5:
     resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
@@ -1929,11 +2648,37 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  sqlite3@5.1.7:
+    resolution: {integrity: sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==}
+
+  ssri@8.0.1:
+    resolution: {integrity: sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==}
+    engines: {node: '>= 8'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
@@ -1944,6 +2689,18 @@ packages:
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
+  tar@6.2.1:
+    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
+    engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1975,6 +2732,10 @@ packages:
     resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
     engines: {node: '>=12'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
@@ -1986,9 +2747,16 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
   type-fest@5.6.0:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
     engines: {node: '>=20'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typebox@1.1.38:
     resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
@@ -2001,9 +2769,19 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
+    engines: {node: '>=14.0'}
+
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
+
+  unique-filename@1.1.1:
+    resolution: {integrity: sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==}
+
+  unique-slug@2.0.2:
+    resolution: {integrity: sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==}
 
   universal-github-app-jwt@2.2.2:
     resolution: {integrity: sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw==}
@@ -2011,9 +2789,20 @@ packages:
   universal-user-agent@7.0.3:
     resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
   uuid@11.1.1:
     resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -2092,10 +2881,21 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wide-align@1.1.5:
+    resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
@@ -2117,10 +2917,16 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
       zod: ^3.25.28 || ^4
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -2556,11 +3362,56 @@ snapshots:
 
   '@babel/runtime@7.29.2': {}
 
-  '@earendil-works/pi-ai@0.74.0(ws@8.20.0)(zod@4.4.3)':
+  '@bufbuild/protobuf@1.10.0': {}
+
+  '@connectrpc/connect-node@1.7.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0))':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.0
+      '@connectrpc/connect': 1.7.0(@bufbuild/protobuf@1.10.0)
+      undici: 5.29.0
+
+  '@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0)':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.0
+
+  '@cursor/sdk-darwin-arm64@1.0.13':
+    optional: true
+
+  '@cursor/sdk-darwin-x64@1.0.13':
+    optional: true
+
+  '@cursor/sdk-linux-arm64@1.0.13':
+    optional: true
+
+  '@cursor/sdk-linux-x64@1.0.13':
+    optional: true
+
+  '@cursor/sdk-win32-x64@1.0.13':
+    optional: true
+
+  '@cursor/sdk@1.0.13':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.0
+      '@connectrpc/connect': 1.7.0(@bufbuild/protobuf@1.10.0)
+      '@connectrpc/connect-node': 1.7.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0))
+      '@statsig/js-client': 3.31.0
+      sqlite3: 5.1.7
+      zod: 3.25.76
+    optionalDependencies:
+      '@cursor/sdk-darwin-arm64': 1.0.13
+      '@cursor/sdk-darwin-x64': 1.0.13
+      '@cursor/sdk-linux-arm64': 1.0.13
+      '@cursor/sdk-linux-x64': 1.0.13
+      '@cursor/sdk-win32-x64': 1.0.13
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+
+  '@earendil-works/pi-ai@0.74.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1045.0
-      '@google/genai': 1.52.0
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
       '@mistralai/mistralai': 2.2.1
       chalk: 5.6.2
       openai: 6.26.0(ws@8.20.0)(zod@4.4.3)
@@ -2727,16 +3578,27 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@google/genai@1.52.0':
+  '@fastify/busboy@2.1.1': {}
+
+  '@gar/promisify@1.1.3':
+    optional: true
+
+  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
     dependencies:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
       protobufjs: 7.5.6
       ws: 8.20.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  '@hono/node-server@1.19.14(hono@4.12.19)':
+    dependencies:
+      hono: 4.12.19
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -2748,6 +3610,28 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.19)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.19
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     optional: true
@@ -2768,6 +3652,18 @@ snapshots:
     optional: true
 
   '@nodable/entities@2.1.0': {}
+
+  '@npmcli/fs@1.1.1':
+    dependencies:
+      '@gar/promisify': 1.1.3
+      semver: 7.8.0
+    optional: true
+
+  '@npmcli/move-file@1.1.2':
+    dependencies:
+      mkdirp: 1.0.4
+      rimraf: 3.0.2
+    optional: true
 
   '@octokit/auth-app@8.2.0':
     dependencies:
@@ -3431,6 +4327,15 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@statsig/client-core@3.31.0': {}
+
+  '@statsig/js-client@3.31.0':
+    dependencies:
+      '@statsig/client-core': 3.31.0
+
+  '@tootallnate/once@1.1.2':
+    optional: true
+
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
   '@types/chai@5.2.3':
@@ -3498,13 +4403,65 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  abbrev@1.1.1:
+    optional: true
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   agent-base@7.1.4: {}
+
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
+    optional: true
+
+  aggregate-error@3.1.0:
+    dependencies:
+      clean-stack: 2.2.0
+      indent-string: 4.0.0
+    optional: true
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  ansi-regex@5.0.1:
+    optional: true
+
+  aproba@2.1.0:
+    optional: true
+
+  are-we-there-yet@3.0.1:
+    dependencies:
+      delegates: 1.0.0
+      readable-stream: 3.6.2
+    optional: true
 
   assertion-error@2.0.1: {}
 
   ast-types@0.13.4:
     dependencies:
       tslib: 2.8.1
+
+  balanced-match@1.0.2:
+    optional: true
 
   base64-js@1.5.1: {}
 
@@ -3516,13 +4473,84 @@ snapshots:
 
   bignumber.js@9.3.1: {}
 
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   bottleneck@2.19.5: {}
 
   bowser@2.14.1: {}
 
+  brace-expansion@1.1.14:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+    optional: true
+
   buffer-equal-constant-time@1.0.1: {}
 
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  bytes@3.1.2: {}
+
   cac@6.7.14: {}
+
+  cacache@15.3.0:
+    dependencies:
+      '@npmcli/fs': 1.1.1
+      '@npmcli/move-file': 1.1.2
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      glob: 7.2.3
+      infer-owner: 1.0.4
+      lru-cache: 6.0.0
+      minipass: 3.3.6
+      minipass-collect: 1.0.2
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      mkdirp: 1.0.4
+      p-map: 4.0.0
+      promise-inflight: 1.0.1
+      rimraf: 3.0.2
+      ssri: 8.0.1
+      tar: 6.2.1
+      unique-filename: 1.1.1
+    transitivePeerDependencies:
+      - bluebird
+    optional: true
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   chai@5.3.3:
     dependencies:
@@ -3536,9 +4564,46 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  chownr@1.1.4: {}
+
+  chownr@2.0.0: {}
+
+  clean-stack@2.2.0:
+    optional: true
+
+  color-support@1.1.3:
+    optional: true
+
+  concat-map@0.0.1:
+    optional: true
+
+  console-control-strings@1.1.0:
+    optional: true
+
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
   cron-parser@5.5.0:
     dependencies:
       luxon: 3.7.2
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   data-uri-to-buffer@4.0.1: {}
 
@@ -3548,7 +4613,13 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   deep-eql@5.0.2: {}
+
+  deep-extend@0.6.0: {}
 
   degenerator@5.0.1:
     dependencies:
@@ -3556,18 +4627,59 @@ snapshots:
       escodegen: 2.1.0
       esprima: 4.0.1
 
+  delegates@1.0.0:
+    optional: true
+
+  depd@2.0.0: {}
+
   detect-libc@2.1.2: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
+
+  ee-first@1.1.1: {}
 
   effect@3.21.2:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
 
+  emoji-regex@8.0.0:
+    optional: true
+
+  encodeurl@2.0.0: {}
+
+  encoding@0.1.13:
+    dependencies:
+      iconv-lite: 0.6.3
+    optional: true
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
+  env-paths@2.2.1:
+    optional: true
+
+  err-code@2.0.3:
+    optional: true
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -3598,6 +4710,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
 
+  escape-html@1.0.3: {}
+
   escodegen@2.1.0:
     dependencies:
       esprima: 4.0.1
@@ -3616,11 +4730,61 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  evlog@2.17.0(vite@7.3.3(@types/node@22.19.18)(tsx@4.21.0)):
+  etag@1.8.1: {}
+
+  eventsource-parser@3.0.8: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
+
+  evlog@2.17.0(express@5.2.1)(hono@4.12.19)(vite@7.3.3(@types/node@22.19.18)(tsx@4.21.0)):
     optionalDependencies:
+      express: 5.2.1
+      hono: 4.12.19
       vite: 7.3.3(@types/node@22.19.18)(tsx@4.21.0)
 
+  expand-template@2.0.3: {}
+
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extend@3.0.2: {}
 
@@ -3631,6 +4795,10 @@ snapshots:
   fast-content-type-parse@2.0.1: {}
 
   fast-content-type-parse@3.0.0: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.2: {}
 
   fast-xml-builder@1.2.0:
     dependencies:
@@ -3653,13 +4821,53 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
+  file-uri-to-path@1.0.0: {}
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-my-way-ts@0.1.6: {}
 
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
 
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
+  fs-constants@1.0.0: {}
+
+  fs-minipass@2.1.0:
+    dependencies:
+      minipass: 3.3.6
+
+  fs.realpath@1.0.0:
+    optional: true
+
   fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  gauge@4.0.4:
+    dependencies:
+      aproba: 2.1.0
+      color-support: 1.1.3
+      console-control-strings: 1.1.0
+      has-unicode: 2.0.1
+      signal-exit: 3.0.7
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wide-align: 1.1.5
     optional: true
 
   gaxios@7.1.4:
@@ -3678,6 +4886,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
@@ -3689,6 +4915,18 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  github-from-package@0.0.0: {}
+
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+    optional: true
 
   google-auth-library@10.6.2:
     dependencies:
@@ -3703,12 +4941,56 @@ snapshots:
 
   google-logging-utils@1.1.3: {}
 
+  gopd@1.2.0: {}
+
+  graceful-fs@4.2.11:
+    optional: true
+
+  has-symbols@1.1.0: {}
+
+  has-unicode@2.0.1:
+    optional: true
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  hono@4.12.19: {}
+
+  http-cache-semantics@4.2.0:
+    optional: true
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  http-proxy-agent@4.0.1:
+    dependencies:
+      '@tootallnate/once': 1.1.2
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -3717,13 +4999,62 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
+    optional: true
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+    optional: true
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  ieee754@1.2.1: {}
+
+  imurmurhash@0.1.4:
+    optional: true
+
+  indent-string@4.0.0:
+    optional: true
+
+  infer-owner@1.0.4:
+    optional: true
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+    optional: true
+
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
+
   ip-address@10.2.0: {}
 
+  ipaddr.js@1.9.1: {}
+
   is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0:
+    optional: true
 
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-lambda@1.0.1:
+    optional: true
+
+  is-promise@4.0.0: {}
+
+  isexe@2.0.0: {}
+
+  jose@6.2.3: {}
 
   js-tokens@9.0.1: {}
 
@@ -3735,6 +5066,10 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.2
       ts-algebra: 2.0.0
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-with-bigint@3.5.8: {}
 
@@ -3755,6 +5090,11 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
+    optional: true
+
   lru-cache@7.18.3: {}
 
   luxon@3.7.2: {}
@@ -3763,7 +5103,95 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  make-fetch-happen@9.1.0:
+    dependencies:
+      agentkeepalive: 4.6.0
+      cacache: 15.3.0
+      http-cache-semantics: 4.2.0
+      http-proxy-agent: 4.0.1
+      https-proxy-agent: 5.0.1
+      is-lambda: 1.0.1
+      lru-cache: 6.0.0
+      minipass: 3.3.6
+      minipass-collect: 1.0.2
+      minipass-fetch: 1.4.1
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      negotiator: 0.6.4
+      promise-retry: 2.0.1
+      socks-proxy-agent: 6.2.1
+      ssri: 8.0.1
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+    optional: true
+
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
   mime@3.0.0: {}
+
+  mimic-response@3.1.0: {}
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.14
+    optional: true
+
+  minimist@1.2.8: {}
+
+  minipass-collect@1.0.2:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
+
+  minipass-fetch@1.4.1:
+    dependencies:
+      minipass: 3.3.6
+      minipass-sized: 1.0.3
+      minizlib: 2.1.2
+    optionalDependencies:
+      encoding: 0.1.13
+    optional: true
+
+  minipass-flush@1.0.7:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
+
+  minipass-pipeline@1.2.4:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
+
+  minipass-sized@1.0.3:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
+
+  minipass@3.3.6:
+    dependencies:
+      yallist: 4.0.0
+
+  minipass@5.0.0: {}
+
+  minizlib@2.1.2:
+    dependencies:
+      minipass: 3.3.6
+      yallist: 4.0.0
+
+  mkdirp-classic@0.5.3: {}
+
+  mkdirp@1.0.4: {}
 
   ms@2.1.3: {}
 
@@ -3787,7 +5215,18 @@ snapshots:
 
   nanoid@3.3.12: {}
 
+  napi-build-utils@2.0.0: {}
+
+  negotiator@0.6.4:
+    optional: true
+
+  negotiator@1.0.0: {}
+
   netmask@2.1.1: {}
+
+  node-abi@3.92.0:
+    dependencies:
+      semver: 7.8.0
 
   node-addon-api@7.1.1: {}
 
@@ -3804,7 +5243,49 @@ snapshots:
       detect-libc: 2.1.2
     optional: true
 
+  node-gyp@8.4.1:
+    dependencies:
+      env-paths: 2.2.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      make-fetch-happen: 9.1.0
+      nopt: 5.0.0
+      npmlog: 6.0.2
+      rimraf: 3.0.2
+      semver: 7.8.0
+      tar: 6.2.1
+      which: 2.0.2
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+    optional: true
+
   non-error@0.1.0: {}
+
+  nopt@5.0.0:
+    dependencies:
+      abbrev: 1.1.1
+    optional: true
+
+  npmlog@6.0.2:
+    dependencies:
+      are-we-there-yet: 3.0.1
+      console-control-strings: 1.1.0
+      gauge: 4.0.4
+      set-blocking: 2.0.0
+    optional: true
+
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   openai@6.26.0(ws@8.20.0)(zod@4.4.3):
     optionalDependencies:
@@ -3867,6 +5348,11 @@ snapshots:
       '@oxlint/binding-win32-x64-msvc': 1.64.0
       oxlint-tsgolint: 0.22.1
 
+  p-map@4.0.0:
+    dependencies:
+      aggregate-error: 3.1.0
+    optional: true
+
   p-retry@4.6.2:
     dependencies:
       '@types/retry': 0.12.0
@@ -3890,9 +5376,18 @@ snapshots:
       degenerator: 5.0.1
       netmask: 2.1.1
 
+  parseurl@1.3.3: {}
+
   partial-json@0.1.7: {}
 
   path-expression-matcher@1.5.0: {}
+
+  path-is-absolute@1.0.1:
+    optional: true
+
+  path-key@3.1.1: {}
+
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -3945,6 +5440,8 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  pkce-challenge@5.0.1: {}
+
   postcss@8.5.14:
     dependencies:
       nanoid: 3.3.12
@@ -3961,6 +5458,30 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.92.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
+  promise-inflight@1.0.1:
+    optional: true
+
+  promise-retry@2.0.1:
+    dependencies:
+      err-code: 2.0.3
+      retry: 0.12.0
+    optional: true
+
   protobufjs@7.5.6:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -3975,6 +5496,11 @@ snapshots:
       '@protobufjs/utf8': 1.1.1
       '@types/node': 22.19.18
       long: 5.3.2
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
 
   proxy-agent@6.5.0:
     dependencies:
@@ -3991,11 +5517,52 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   pure-rand@6.1.0: {}
+
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  require-from-string@2.0.2: {}
 
   resolve-pkg-maps@1.0.0: {}
 
+  retry@0.12.0:
+    optional: true
+
   retry@0.13.1: {}
+
+  rimraf@3.0.2:
+    dependencies:
+      glob: 7.2.3
+    optional: true
 
   rollup@4.60.3:
     dependencies:
@@ -4028,16 +5595,114 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.3
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
+
+  semver@7.8.0: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   serialize-error@13.0.1:
     dependencies:
       non-error: 0.1.0
       type-fest: 5.6.0
 
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  set-blocking@2.0.0:
+    optional: true
+
+  setprototypeof@1.2.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
 
+  signal-exit@3.0.7:
+    optional: true
+
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   smart-buffer@4.2.0: {}
+
+  socks-proxy-agent@6.2.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+      socks: 2.8.9
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   socks-proxy-agent@8.0.5:
     dependencies:
@@ -4059,9 +5724,46 @@ snapshots:
 
   split2@4.2.0: {}
 
+  sqlite3@5.1.7:
+    dependencies:
+      bindings: 1.5.0
+      node-addon-api: 7.1.1
+      prebuild-install: 7.1.3
+      tar: 6.2.1
+    optionalDependencies:
+      node-gyp: 8.4.1
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+
+  ssri@8.0.1:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
+
   stackback@0.0.2: {}
 
+  statuses@2.0.2: {}
+
   std-env@3.10.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+    optional: true
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+    optional: true
+
+  strip-json-comments@2.0.1: {}
 
   strip-literal@3.1.0:
     dependencies:
@@ -4070,6 +5772,30 @@ snapshots:
   strnum@2.3.0: {}
 
   tagged-tag@1.0.0: {}
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  tar@6.2.1:
+    dependencies:
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      minipass: 5.0.0
+      minizlib: 2.1.2
+      mkdirp: 1.0.4
+      yallist: 4.0.0
 
   tinybench@2.9.0: {}
 
@@ -4090,6 +5816,8 @@ snapshots:
 
   toad-cache@3.7.0: {}
 
+  toidentifier@1.0.1: {}
+
   ts-algebra@2.0.0: {}
 
   tslib@2.8.1: {}
@@ -4101,9 +5829,19 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   type-fest@5.6.0:
     dependencies:
       tagged-tag: 1.0.0
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typebox@1.1.38: {}
 
@@ -4111,13 +5849,33 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici@5.29.0:
+    dependencies:
+      '@fastify/busboy': 2.1.1
+
   undici@7.25.0: {}
+
+  unique-filename@1.1.1:
+    dependencies:
+      unique-slug: 2.0.2
+    optional: true
+
+  unique-slug@2.0.2:
+    dependencies:
+      imurmurhash: 0.1.4
+    optional: true
 
   universal-github-app-jwt@2.2.2: {}
 
   universal-user-agent@7.0.3: {}
 
+  unpipe@1.0.0: {}
+
+  util-deprecate@1.0.2: {}
+
   uuid@11.1.1: {}
+
+  vary@1.1.2: {}
 
   vite-node@3.2.4(@types/node@22.19.18)(tsx@4.21.0):
     dependencies:
@@ -4196,10 +5954,21 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wide-align@1.1.5:
+    dependencies:
+      string-width: 4.2.3
+    optional: true
+
+  wrappy@1.0.2: {}
 
   ws@8.20.0: {}
 
@@ -4207,8 +5976,12 @@ snapshots:
 
   xtend@4.0.2: {}
 
+  yallist@4.0.0: {}
+
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
+
+  zod@3.25.76: {}
 
   zod@4.4.3: {}

--- a/src/agent/askRun.ts
+++ b/src/agent/askRun.ts
@@ -13,6 +13,7 @@ import { sanitizeLogMessage } from "../security/sanitizeLogMessage.js";
 import { buildAskSystemPrompt } from "./askPrompt.js";
 import { formatAskFailureReply, formatAskReply } from "./formatAskReply.js";
 import { buildContext7Tools } from "./context7Tools.js";
+import { isCursorProvider } from "./cursor/models.js";
 import {
   ASK_META_REFUSAL,
   buildAskGithubTools,
@@ -58,6 +59,7 @@ export type AskRunParams = {
   question: string;
   replyTarget: ReplyTarget;
   codeAnchor?: CodeAnchor;
+  refreshInstallationToken?: () => Promise<{ token: string; expiresAtTs: number }>;
 };
 
 export type AskRunResult = {
@@ -130,6 +132,11 @@ export async function runAskRun(params: AskRunParams): Promise<AskRunResult> {
   }
   if (!Number.isFinite(tokenTtlMs) || tokenTtlMs <= 0) {
     throw new Error("tokenTtlMs must be a positive finite duration in milliseconds");
+  }
+
+  if (isCursorProvider(cfg.piProvider)) {
+    const { runCursorAskRun } = await import("./cursor/askRunCursor.js");
+    return runCursorAskRun(params);
   }
 
   const pathGate = createAskPathGate();

--- a/src/agent/askRun.ts
+++ b/src/agent/askRun.ts
@@ -13,7 +13,6 @@ import { sanitizeLogMessage } from "../security/sanitizeLogMessage.js";
 import { buildAskSystemPrompt } from "./askPrompt.js";
 import { formatAskFailureReply, formatAskReply } from "./formatAskReply.js";
 import { buildContext7Tools } from "./context7Tools.js";
-import { isCursorProvider } from "./cursor/models.js";
 import {
   ASK_META_REFUSAL,
   buildAskGithubTools,
@@ -83,7 +82,7 @@ function endsWithToolResults(messages: Message[]): boolean {
   return messages[messages.length - 1]?.role === "toolResult";
 }
 
-function buildUserContent(params: AskRunParams): string {
+export function buildAskUserContent(params: AskRunParams): string {
   const blocks = [
     wrapTrustedContext([
       `Repository: ${params.owner}/${params.repo}`,
@@ -134,7 +133,7 @@ export async function runAskRun(params: AskRunParams): Promise<AskRunResult> {
     throw new Error("tokenTtlMs must be a positive finite duration in milliseconds");
   }
 
-  if (isCursorProvider(cfg.piProvider)) {
+  if (cfg.piProvider === "cursor") {
     const { runCursorAskRun } = await import("./cursor/askRunCursor.js");
     return runCursorAskRun(params);
   }
@@ -179,7 +178,7 @@ export async function runAskRun(params: AskRunParams): Promise<AskRunResult> {
     messages: [
       {
         role: "user",
-        content: buildUserContent(params),
+        content: buildAskUserContent(params),
         timestamp: Date.now(),
       },
     ],

--- a/src/agent/cursor/askRunCursor.ts
+++ b/src/agent/cursor/askRunCursor.ts
@@ -50,7 +50,8 @@ export async function runCursorAskRun(params: AskRunParams): Promise<AskRunResul
 
   const ctx7 = buildContext7Tools({ apiKey: cfg.context7ApiKey });
   const piTools: PiTool[] = [...refreshableGh.bundle.piTools, ...ctx7.piTools];
-  const executors = { ...refreshableGh.bundle.executors, ...ctx7.executors };
+  const executors = refreshableGh.bundle.executors;
+  Object.assign(executors, ctx7.executors);
   const model = getCursorModel(cfg.piModel);
 
   const context: Context = {

--- a/src/agent/cursor/askRunCursor.ts
+++ b/src/agent/cursor/askRunCursor.ts
@@ -1,56 +1,15 @@
-import type { Config } from "../../config.js";
 import { logDebug, logInfo } from "../../evlog.js";
 import { complete } from "@earendil-works/pi-ai";
 import type { AssistantMessage, Context, Tool as PiTool } from "@earendil-works/pi-ai";
-import type { ReplyTarget } from "../../commands/replyTarget.js";
 import { buildAskSystemPrompt } from "../askPrompt.js";
 import { formatAskFailureReply, formatAskReply } from "../formatAskReply.js";
 import { buildContext7Tools } from "../context7Tools.js";
-import {
-  buildAskGithubTools,
-  createAskPathGate,
-  wrapTrustedContext,
-  wrapUntrustedBlock,
-} from "../askSafety.js";
+import { buildAskGithubTools, createAskPathGate } from "../askSafety.js";
 import { ASK_FAILURE_MESSAGE } from "../../settings/index.js";
-import type { AskRunParams, AskRunResult, CodeAnchor } from "../askRun.js";
-import {
-  attachCursorRunContext,
-  detachCursorRunContext,
-  getCursorModel,
-} from "./index.js";
+import { buildAskUserContent, type AskRunParams, type AskRunResult } from "../askRun.js";
+import { attachCursorRunContext, getCursorModel } from "./index.js";
 import { createRefreshableToolExecutors } from "./refreshableGithubTools.js";
 import { sanitizeLogMessage } from "../../security/sanitizeLogMessage.js";
-
-function buildUserContent(params: AskRunParams): string {
-  const blocks = [
-    wrapTrustedContext([
-      `Repository: ${params.owner}/${params.repo}`,
-      `Pull request: #${params.prNumber}`,
-      `Head commit SHA: ${params.headSha}`,
-    ]),
-    wrapUntrustedBlock("user_question", params.question),
-  ];
-  if (params.codeAnchor) {
-    const { path, line, startLine, side, diffHunk } = params.codeAnchor;
-    const range =
-      startLine != null && startLine !== line ? `lines ${startLine}-${line}` : `line ${line}`;
-    const anchorLines = [`File: ${path}`, `${range}${side ? ` (${side} side of diff)` : ""}`];
-    if (diffHunk?.trim()) {
-      anchorLines.push("", "Diff hunk:", "```diff", diffHunk.trim(), "```");
-    }
-    anchorLines.push(
-      "",
-      "Start from this anchor, then use tools to trace symbols and surrounding context.",
-    );
-    blocks.push(wrapUntrustedBlock("code_anchor", anchorLines.join("\n")));
-  } else {
-    blocks.push(
-      "Use GitHub tools to inspect the PR diff and related files, then answer the question in user_question.",
-    );
-  }
-  return blocks.join("\n\n");
-}
 
 export async function runCursorAskRun(params: AskRunParams): Promise<AskRunResult> {
   const { cfg, token, tokenExpiresAtTs, owner, repo, prNumber, question, replyTarget } = params;
@@ -99,7 +58,7 @@ export async function runCursorAskRun(params: AskRunParams): Promise<AskRunResul
     messages: [
       {
         role: "user",
-        content: buildUserContent(params),
+        content: buildAskUserContent(params),
         timestamp: Date.now(),
       },
     ],
@@ -114,12 +73,9 @@ export async function runCursorAskRun(params: AskRunParams): Promise<AskRunResul
 
   logInfo("cursor_ask_started", { owner, repo, pr: prNumber, model: model.id });
 
-  let lastAssistant: AssistantMessage;
-  try {
-    lastAssistant = await complete(model, context, { apiKey: cfg.cursorApiKey });
-  } finally {
-    detachCursorRunContext(context);
-  }
+  const lastAssistant: AssistantMessage = await complete(model, context, {
+    apiKey: cfg.cursorApiKey,
+  });
 
   const summary = lastAssistant.content
     .filter((p): p is { type: "text"; text: string } => p.type === "text")

--- a/src/agent/cursor/askRunCursor.ts
+++ b/src/agent/cursor/askRunCursor.ts
@@ -1,0 +1,144 @@
+import type { Config } from "../../config.js";
+import { logDebug, logInfo } from "../../evlog.js";
+import { complete } from "@earendil-works/pi-ai";
+import type { AssistantMessage, Context, Tool as PiTool } from "@earendil-works/pi-ai";
+import type { ReplyTarget } from "../../commands/replyTarget.js";
+import { buildAskSystemPrompt } from "../askPrompt.js";
+import { formatAskFailureReply, formatAskReply } from "../formatAskReply.js";
+import { buildContext7Tools } from "../context7Tools.js";
+import {
+  buildAskGithubTools,
+  createAskPathGate,
+  wrapTrustedContext,
+  wrapUntrustedBlock,
+} from "../askSafety.js";
+import { ASK_FAILURE_MESSAGE } from "../../settings/index.js";
+import type { AskRunParams, AskRunResult, CodeAnchor } from "../askRun.js";
+import {
+  attachCursorRunContext,
+  detachCursorRunContext,
+  getCursorModel,
+} from "./index.js";
+import { createRefreshableToolExecutors } from "./refreshableGithubTools.js";
+import { sanitizeLogMessage } from "../../security/sanitizeLogMessage.js";
+
+function buildUserContent(params: AskRunParams): string {
+  const blocks = [
+    wrapTrustedContext([
+      `Repository: ${params.owner}/${params.repo}`,
+      `Pull request: #${params.prNumber}`,
+      `Head commit SHA: ${params.headSha}`,
+    ]),
+    wrapUntrustedBlock("user_question", params.question),
+  ];
+  if (params.codeAnchor) {
+    const { path, line, startLine, side, diffHunk } = params.codeAnchor;
+    const range =
+      startLine != null && startLine !== line ? `lines ${startLine}-${line}` : `line ${line}`;
+    const anchorLines = [`File: ${path}`, `${range}${side ? ` (${side} side of diff)` : ""}`];
+    if (diffHunk?.trim()) {
+      anchorLines.push("", "Diff hunk:", "```diff", diffHunk.trim(), "```");
+    }
+    anchorLines.push(
+      "",
+      "Start from this anchor, then use tools to trace symbols and surrounding context.",
+    );
+    blocks.push(wrapUntrustedBlock("code_anchor", anchorLines.join("\n")));
+  } else {
+    blocks.push(
+      "Use GitHub tools to inspect the PR diff and related files, then answer the question in user_question.",
+    );
+  }
+  return blocks.join("\n\n");
+}
+
+export async function runCursorAskRun(params: AskRunParams): Promise<AskRunResult> {
+  const { cfg, token, tokenExpiresAtTs, owner, repo, prNumber, question, replyTarget } = params;
+
+  const pathGate = createAskPathGate();
+  if (params.codeAnchor?.path) {
+    pathGate.addPaths([params.codeAnchor.path]);
+  }
+
+  const refreshableGh = createRefreshableToolExecutors({
+    initialToken: token,
+    tokenExpiresAtTs,
+    refreshInstallationToken: params.refreshInstallationToken,
+    build: (activeToken) => {
+      const gh = buildAskGithubTools(
+        activeToken,
+        { owner, repo, prNumber, headSha: params.headSha },
+        {
+          maxPrFilesListed: cfg.maxPrFilesListed,
+          maxPrFilesPatchBytes: cfg.maxPrFilesPatchBytes,
+        },
+        pathGate,
+      );
+      return { piTools: gh.piTools, executors: gh.executors };
+    },
+  });
+
+  try {
+    await refreshableGh.bundle.executors.listPullRequestFiles?.({});
+  } catch (e) {
+    logDebug("ask_path_gate_prime_failed", {
+      owner,
+      repo,
+      pr: prNumber,
+      message: sanitizeLogMessage(e instanceof Error ? e.message : String(e)),
+    });
+  }
+
+  const ctx7 = buildContext7Tools({ apiKey: cfg.context7ApiKey });
+  const piTools: PiTool[] = [...refreshableGh.bundle.piTools, ...ctx7.piTools];
+  const executors = { ...refreshableGh.bundle.executors, ...ctx7.executors };
+  const model = getCursorModel(cfg.piModel);
+
+  const context: Context = {
+    systemPrompt: buildAskSystemPrompt(),
+    messages: [
+      {
+        role: "user",
+        content: buildUserContent(params),
+        timestamp: Date.now(),
+      },
+    ],
+    tools: piTools,
+  };
+
+  attachCursorRunContext(context, {
+    executors,
+    apiKey: cfg.cursorApiKey,
+    refreshBeforeTool: refreshableGh.refreshBeforeTool,
+  });
+
+  logInfo("cursor_ask_started", { owner, repo, pr: prNumber, model: model.id });
+
+  let lastAssistant: AssistantMessage;
+  try {
+    lastAssistant = await complete(model, context, { apiKey: cfg.cursorApiKey });
+  } finally {
+    detachCursorRunContext(context);
+  }
+
+  const summary = lastAssistant.content
+    .filter((p): p is { type: "text"; text: string } => p.type === "text")
+    .map((p) => p.text)
+    .join("\n")
+    .trim();
+
+  const answerText =
+    summary.length > 0
+      ? formatAskReply({ question, answer: summary, replyTarget })
+      : formatAskFailureReply({ question, message: ASK_FAILURE_MESSAGE, replyTarget });
+
+  logInfo("cursor_ask_completed", {
+    owner,
+    repo,
+    pr: prNumber,
+    hasAnswer: summary.length > 0,
+    stopReason: lastAssistant.stopReason,
+  });
+
+  return { answer: answerText, replied: true };
+}

--- a/src/agent/cursor/errors.ts
+++ b/src/agent/cursor/errors.ts
@@ -1,0 +1,27 @@
+export const CURSOR_STARTUP_ERROR_PREFIX = "cursor_startup_error:";
+export const CURSOR_RUN_ERROR_PREFIX = "cursor_run_error:";
+
+export type CursorStartupErrorLike = Error & {
+  readonly isRetryable?: boolean;
+};
+
+export function isCursorStartupErrorLike(err: unknown): err is CursorStartupErrorLike {
+  return err instanceof Error && err.name === "CursorAgentError";
+}
+
+export function formatCursorStartupError(err: CursorStartupErrorLike): string {
+  const retryable = err.isRetryable ? " retryable=true" : " retryable=false";
+  return `${CURSOR_STARTUP_ERROR_PREFIX} ${err.message}${retryable}`;
+}
+
+export function formatCursorRunError(runId: string): string {
+  return `${CURSOR_RUN_ERROR_PREFIX} ${runId}`;
+}
+
+export function isCursorStartupError(message: string | undefined): boolean {
+  return message?.startsWith(CURSOR_STARTUP_ERROR_PREFIX) ?? false;
+}
+
+export function isCursorRunError(message: string | undefined): boolean {
+  return message?.startsWith(CURSOR_RUN_ERROR_PREFIX) ?? false;
+}

--- a/src/agent/cursor/index.ts
+++ b/src/agent/cursor/index.ts
@@ -1,5 +1,12 @@
 export { registerCursorProvider, isCursorProviderRegistered } from "./register.js";
-export { getCursorModel, isCursorProvider, listCursorModelIds, CURSOR_API, CURSOR_PROVIDER } from "./models.js";
+export {
+  assertCursorModelId,
+  getCursorModel,
+  isCursorProvider,
+  listCursorModelIds,
+  CURSOR_API,
+  CURSOR_PROVIDER,
+} from "./models.js";
 export {
   attachCursorRunContext,
   detachCursorRunContext,

--- a/src/agent/cursor/index.ts
+++ b/src/agent/cursor/index.ts
@@ -1,0 +1,15 @@
+export { registerCursorProvider, isCursorProviderRegistered } from "./register.js";
+export { getCursorModel, isCursorProvider, listCursorModelIds, CURSOR_API, CURSOR_PROVIDER } from "./models.js";
+export {
+  attachCursorRunContext,
+  detachCursorRunContext,
+  getCursorRunContext,
+  type CursorRunContext,
+  type CursorExecutor,
+} from "./runContext.js";
+export {
+  isCursorRunError,
+  isCursorStartupError,
+  CURSOR_RUN_ERROR_PREFIX,
+  CURSOR_STARTUP_ERROR_PREFIX,
+} from "./errors.js";

--- a/src/agent/cursor/mcpBridge.ts
+++ b/src/agent/cursor/mcpBridge.ts
@@ -1,0 +1,237 @@
+import crypto from "node:crypto";
+import { createServer, type IncomingMessage, type Server as HttpServer, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { McpServerConfig } from "@cursor/sdk";
+import type { Tool as PiTool } from "@earendil-works/pi-ai";
+import { Server as McpProtocolServer } from "@modelcontextprotocol/sdk/server/index.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  type CallToolResult,
+  type Tool as McpTool,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  CURSOR_MCP_BIND_HOST,
+  CURSOR_MCP_SERVER_NAME,
+  CURSOR_MCP_SERVER_START_TIMEOUT_MS,
+  CURSOR_MCP_TOKEN_BYTES,
+  CURSOR_MAX_PORT_RETRIES,
+} from "../../settings/index.js";
+import type { CursorExecutor } from "./runContext.js";
+
+export type McpBridgeOptions = {
+  readonly tools: readonly PiTool[];
+  readonly executors: Record<string, CursorExecutor>;
+  readonly signal?: AbortSignal;
+  readonly submitReviewPublished?: () => boolean;
+  readonly refreshBeforeTool?: (toolName: string) => Promise<void>;
+};
+
+export type McpBridgeHandle = {
+  readonly mcpServers: Record<string, McpServerConfig>;
+  readonly dispose: () => Promise<void>;
+};
+
+export function checkMcpBearerAuth(
+  authorizationHeader: string | undefined,
+  token: string,
+): boolean {
+  if (!authorizationHeader) return false;
+  const [scheme, value] = authorizationHeader.split(" ", 2);
+  return scheme?.toLowerCase() === "bearer" && value === token;
+}
+
+export function resolveSubmitReviewToolResult(
+  alreadyPublished: boolean,
+  execute: () => Promise<unknown>,
+): Promise<unknown> {
+  if (alreadyPublished) {
+    return Promise.resolve({
+      ok: true,
+      alreadyPublished: true,
+      message: SUBMIT_REVIEW_ALREADY_PUBLISHED_MESSAGE,
+    });
+  }
+  return execute();
+}
+
+const SUBMIT_REVIEW_ALREADY_PUBLISHED_MESSAGE =
+  "Stop further investigation; the review has been published.";
+
+function piToolToMcpTool(tool: PiTool): McpTool {
+  return {
+    name: tool.name,
+    description: tool.description,
+    inputSchema: tool.parameters as McpTool["inputSchema"],
+  };
+}
+
+function executorResultToMcp(result: unknown, isError = false): CallToolResult {
+  const text = typeof result === "string" ? result : JSON.stringify(result, null, 2);
+  return {
+    content: [{ type: "text", text }],
+    isError: isError || undefined,
+  };
+}
+
+function checkBearerAuth(req: IncomingMessage, token: string): boolean {
+  const header = req.headers.authorization;
+  return checkMcpBearerAuth(Array.isArray(header) ? header[0] : header, token);
+}
+
+function listenOnEphemeralPort(server: HttpServer, attempt: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (error: NodeJS.ErrnoException) => {
+      server.off("listening", onListening);
+      if (error.code === "EADDRINUSE" && attempt < CURSOR_MAX_PORT_RETRIES) {
+        listenOnEphemeralPort(server, attempt + 1).then(resolve).catch(reject);
+        return;
+      }
+      reject(error);
+    };
+    const onListening = () => {
+      server.off("error", onError);
+      resolve();
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(0, CURSOR_MCP_BIND_HOST);
+  });
+}
+
+export async function createMcpBridge(options: McpBridgeOptions): Promise<McpBridgeHandle> {
+  const bearerToken = crypto.randomBytes(CURSOR_MCP_TOKEN_BYTES).toString("hex");
+  const endpointPath = `/mcp/${crypto.randomUUID()}`;
+  const pendingCalls = new Set<AbortController>();
+  let disposed = false;
+
+  const mcpServer = new McpProtocolServer(
+    { name: "pr-agent-tool-bridge", version: "1.0.0" },
+    { capabilities: { tools: {} } },
+  );
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: () => crypto.randomUUID(),
+  });
+
+  mcpServer.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: options.tools.map(piToolToMcpTool),
+  }));
+
+  mcpServer.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
+    if (disposed) {
+      return {
+        content: [{ type: "text", text: "MCP bridge disposed" }],
+        isError: true,
+      };
+    }
+
+    const toolName = request.params.name;
+    const exec = options.executors[toolName];
+    if (!exec) {
+      return {
+        content: [{ type: "text", text: `Unknown tool: ${toolName}` }],
+        isError: true,
+      };
+    }
+
+    if (toolName === "submitReview" && options.submitReviewPublished?.()) {
+      return executorResultToMcp(
+        await resolveSubmitReviewToolResult(true, async () => ({ ok: true })),
+      );
+    }
+
+    const abortController = new AbortController();
+    pendingCalls.add(abortController);
+    const linkAbort = (): void => abortController.abort();
+    extra.signal?.addEventListener("abort", linkAbort, { once: true });
+    options.signal?.addEventListener("abort", linkAbort, { once: true });
+
+    try {
+      if (abortController.signal.aborted) {
+        throw new Error("MCP tool call aborted");
+      }
+      if (options.refreshBeforeTool) {
+        await options.refreshBeforeTool(toolName);
+      }
+      const args =
+        request.params.arguments && typeof request.params.arguments === "object"
+          ? (request.params.arguments as Record<string, unknown>)
+          : {};
+      const out = await exec(args);
+      return executorResultToMcp(out);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      return executorResultToMcp(message, true);
+    } finally {
+      extra.signal?.removeEventListener("abort", linkAbort);
+      options.signal?.removeEventListener("abort", linkAbort);
+      pendingCalls.delete(abortController);
+    }
+  });
+
+  await mcpServer.connect(transport);
+
+  const httpServer = createServer((req, res) => {
+    if (!checkBearerAuth(req, bearerToken)) {
+      res.writeHead(401, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "Unauthorized" }));
+      return;
+    }
+    const url = req.url ?? "";
+    if (!url.startsWith(endpointPath)) {
+      res.writeHead(404, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "Not found" }));
+      return;
+    }
+    void transport.handleRequest(req, res);
+  });
+
+  const startTimeout = new Promise<void>((_, reject) => {
+    setTimeout(
+      () => reject(new Error(`MCP bridge HTTP server did not start within ${CURSOR_MCP_SERVER_START_TIMEOUT_MS}ms`)),
+      CURSOR_MCP_SERVER_START_TIMEOUT_MS,
+    );
+  });
+  await Promise.race([listenOnEphemeralPort(httpServer, 0), startTimeout]);
+
+  const address = httpServer.address() as AddressInfo | null;
+  if (!address?.port) {
+    throw new Error("MCP bridge HTTP server failed to bind");
+  }
+
+  const endpointUrl = `http://${CURSOR_MCP_BIND_HOST}:${address.port}${endpointPath}`;
+  const mcpServers: Record<string, McpServerConfig> = {
+    [CURSOR_MCP_SERVER_NAME]: {
+      type: "http",
+      url: endpointUrl,
+      headers: { Authorization: `Bearer ${bearerToken}` },
+    },
+  };
+
+  const dispose = async (): Promise<void> => {
+    if (disposed) return;
+    disposed = true;
+    for (const controller of pendingCalls) {
+      controller.abort();
+    }
+    pendingCalls.clear();
+    await Promise.allSettled([transport.close(), mcpServer.close()]);
+    await new Promise<void>((resolve, reject) => {
+      httpServer.close((err) => (err ? reject(err) : resolve()));
+      httpServer.closeIdleConnections?.();
+    });
+  };
+
+  options.signal?.addEventListener(
+    "abort",
+    () => {
+      void dispose();
+    },
+    { once: true },
+  );
+
+  return { mcpServers, dispose };
+}
+
+export { SUBMIT_REVIEW_ALREADY_PUBLISHED_MESSAGE };

--- a/src/agent/cursor/mcpBridge.ts
+++ b/src/agent/cursor/mcpBridge.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import { createServer, type IncomingMessage, type Server as HttpServer, type ServerResponse } from "node:http";
+import { createServer, type IncomingMessage, type Server as HttpServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import type { McpServerConfig } from "@cursor/sdk";
 import type { Tool as PiTool } from "@earendil-works/pi-ai";
@@ -24,7 +24,6 @@ export type McpBridgeOptions = {
   readonly tools: readonly PiTool[];
   readonly executors: Record<string, CursorExecutor>;
   readonly signal?: AbortSignal;
-  readonly submitReviewPublished?: () => boolean;
   readonly refreshBeforeTool?: (toolName: string) => Promise<void>;
 };
 
@@ -41,23 +40,6 @@ export function checkMcpBearerAuth(
   const [scheme, value] = authorizationHeader.split(" ", 2);
   return scheme?.toLowerCase() === "bearer" && value === token;
 }
-
-export function resolveSubmitReviewToolResult(
-  alreadyPublished: boolean,
-  execute: () => Promise<unknown>,
-): Promise<unknown> {
-  if (alreadyPublished) {
-    return Promise.resolve({
-      ok: true,
-      alreadyPublished: true,
-      message: SUBMIT_REVIEW_ALREADY_PUBLISHED_MESSAGE,
-    });
-  }
-  return execute();
-}
-
-const SUBMIT_REVIEW_ALREADY_PUBLISHED_MESSAGE =
-  "Stop further investigation; the review has been published.";
 
 function piToolToMcpTool(tool: PiTool): McpTool {
   return {
@@ -84,6 +66,7 @@ function listenOnEphemeralPort(server: HttpServer, attempt: number): Promise<voi
   return new Promise((resolve, reject) => {
     const onError = (error: NodeJS.ErrnoException) => {
       server.off("listening", onListening);
+      server.off("error", onError);
       if (error.code === "EADDRINUSE" && attempt < CURSOR_MAX_PORT_RETRIES) {
         listenOnEphemeralPort(server, attempt + 1).then(resolve).catch(reject);
         return;
@@ -92,6 +75,7 @@ function listenOnEphemeralPort(server: HttpServer, attempt: number): Promise<voi
     };
     const onListening = () => {
       server.off("error", onError);
+      server.off("listening", onListening);
       resolve();
     };
     server.once("error", onError);
@@ -133,12 +117,6 @@ export async function createMcpBridge(options: McpBridgeOptions): Promise<McpBri
         content: [{ type: "text", text: `Unknown tool: ${toolName}` }],
         isError: true,
       };
-    }
-
-    if (toolName === "submitReview" && options.submitReviewPublished?.()) {
-      return executorResultToMcp(
-        await resolveSubmitReviewToolResult(true, async () => ({ ok: true })),
-      );
     }
 
     const abortController = new AbortController();
@@ -184,16 +162,26 @@ export async function createMcpBridge(options: McpBridgeOptions): Promise<McpBri
       res.end(JSON.stringify({ error: "Not found" }));
       return;
     }
-    void transport.handleRequest(req, res);
+    void transport.handleRequest(req, res).catch(() => undefined);
   });
 
+  let startTimeoutId: ReturnType<typeof setTimeout> | undefined;
   const startTimeout = new Promise<void>((_, reject) => {
-    setTimeout(
-      () => reject(new Error(`MCP bridge HTTP server did not start within ${CURSOR_MCP_SERVER_START_TIMEOUT_MS}ms`)),
+    startTimeoutId = setTimeout(
+      () =>
+        reject(
+          new Error(
+            `MCP bridge HTTP server did not start within ${CURSOR_MCP_SERVER_START_TIMEOUT_MS}ms`,
+          ),
+        ),
       CURSOR_MCP_SERVER_START_TIMEOUT_MS,
     );
   });
-  await Promise.race([listenOnEphemeralPort(httpServer, 0), startTimeout]);
+  try {
+    await Promise.race([listenOnEphemeralPort(httpServer, 0), startTimeout]);
+  } finally {
+    if (startTimeoutId !== undefined) clearTimeout(startTimeoutId);
+  }
 
   const address = httpServer.address() as AddressInfo | null;
   if (!address?.port) {
@@ -233,5 +221,3 @@ export async function createMcpBridge(options: McpBridgeOptions): Promise<McpBri
 
   return { mcpServers, dispose };
 }
-
-export { SUBMIT_REVIEW_ALREADY_PUBLISHED_MESSAGE };

--- a/src/agent/cursor/mcpBridge.ts
+++ b/src/agent/cursor/mcpBridge.ts
@@ -62,13 +62,37 @@ function checkBearerAuth(req: IncomingMessage, token: string): boolean {
   return checkMcpBearerAuth(Array.isArray(header) ? header[0] : header, token);
 }
 
+function closeHttpServer(server: HttpServer): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+    server.closeIdleConnections?.();
+  });
+}
+
+async function runWithAbortSignal<T>(run: () => Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) {
+    throw new Error("MCP tool call aborted");
+  }
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = (): void => {
+      reject(new Error("MCP tool call aborted"));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    void run()
+      .then(resolve, reject)
+      .finally(() => signal.removeEventListener("abort", onAbort));
+  });
+}
+
 function listenOnEphemeralPort(server: HttpServer, attempt: number): Promise<void> {
   return new Promise((resolve, reject) => {
     const onError = (error: NodeJS.ErrnoException) => {
       server.off("listening", onListening);
       server.off("error", onError);
       if (error.code === "EADDRINUSE" && attempt < CURSOR_MAX_PORT_RETRIES) {
-        listenOnEphemeralPort(server, attempt + 1).then(resolve).catch(reject);
+        void closeHttpServer(server)
+          .then(() => listenOnEphemeralPort(server, attempt + 1))
+          .then(resolve, reject);
         return;
       }
       reject(error);
@@ -111,13 +135,6 @@ export async function createMcpBridge(options: McpBridgeOptions): Promise<McpBri
     }
 
     const toolName = request.params.name;
-    const exec = options.executors[toolName];
-    if (!exec) {
-      return {
-        content: [{ type: "text", text: `Unknown tool: ${toolName}` }],
-        isError: true,
-      };
-    }
 
     const abortController = new AbortController();
     pendingCalls.add(abortController);
@@ -130,13 +147,23 @@ export async function createMcpBridge(options: McpBridgeOptions): Promise<McpBri
         throw new Error("MCP tool call aborted");
       }
       if (options.refreshBeforeTool) {
-        await options.refreshBeforeTool(toolName);
+        await runWithAbortSignal(
+          () => options.refreshBeforeTool!(toolName),
+          abortController.signal,
+        );
+      }
+      const exec = options.executors[toolName];
+      if (!exec) {
+        return {
+          content: [{ type: "text", text: `Unknown tool: ${toolName}` }],
+          isError: true,
+        };
       }
       const args =
         request.params.arguments && typeof request.params.arguments === "object"
           ? (request.params.arguments as Record<string, unknown>)
           : {};
-      const out = await exec(args);
+      const out = await runWithAbortSignal(() => exec(args), abortController.signal);
       return executorResultToMcp(out);
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);

--- a/src/agent/cursor/mcpBridge.ts
+++ b/src/agent/cursor/mcpBridge.ts
@@ -84,17 +84,11 @@ async function runWithAbortSignal<T>(run: () => Promise<T>, signal: AbortSignal)
   });
 }
 
-function listenOnEphemeralPort(server: HttpServer, attempt: number): Promise<void> {
+function listenOnEphemeralPort(server: HttpServer): Promise<void> {
   return new Promise((resolve, reject) => {
     const onError = (error: NodeJS.ErrnoException) => {
       server.off("listening", onListening);
       server.off("error", onError);
-      if (error.code === "EADDRINUSE" && attempt < CURSOR_MAX_PORT_RETRIES) {
-        void closeHttpServer(server)
-          .then(() => listenOnEphemeralPort(server, attempt + 1))
-          .then(resolve, reject);
-        return;
-      }
       reject(error);
     };
     const onListening = () => {
@@ -106,6 +100,24 @@ function listenOnEphemeralPort(server: HttpServer, attempt: number): Promise<voi
     server.once("listening", onListening);
     server.listen(0, CURSOR_MCP_BIND_HOST);
   });
+}
+
+async function bindEphemeralHttpServer(
+  createServerInstance: () => HttpServer,
+  attempt = 0,
+): Promise<HttpServer> {
+  const server = createServerInstance();
+  try {
+    await listenOnEphemeralPort(server);
+    return server;
+  } catch (error) {
+    await closeHttpServer(server).catch(() => undefined);
+    const errno = error as NodeJS.ErrnoException;
+    if (errno.code === "EADDRINUSE" && attempt < CURSOR_MAX_PORT_RETRIES) {
+      return bindEphemeralHttpServer(createServerInstance, attempt + 1);
+    }
+    throw error;
+  }
 }
 
 export async function createMcpBridge(options: McpBridgeOptions): Promise<McpBridgeHandle> {
@@ -177,23 +189,24 @@ export async function createMcpBridge(options: McpBridgeOptions): Promise<McpBri
 
   await mcpServer.connect(transport);
 
-  const httpServer = createServer((req, res) => {
-    if (!checkBearerAuth(req, bearerToken)) {
-      res.writeHead(401, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: "Unauthorized" }));
-      return;
-    }
-    const url = req.url ?? "";
-    if (!url.startsWith(endpointPath)) {
-      res.writeHead(404, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: "Not found" }));
-      return;
-    }
-    void transport.handleRequest(req, res).catch(() => undefined);
-  });
+  const createHttpServer = (): HttpServer =>
+    createServer((req, res) => {
+      if (!checkBearerAuth(req, bearerToken)) {
+        res.writeHead(401, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "Unauthorized" }));
+        return;
+      }
+      const url = req.url ?? "";
+      if (!url.startsWith(endpointPath)) {
+        res.writeHead(404, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "Not found" }));
+        return;
+      }
+      void transport.handleRequest(req, res).catch(() => undefined);
+    });
 
   let startTimeoutId: ReturnType<typeof setTimeout> | undefined;
-  const startTimeout = new Promise<void>((_, reject) => {
+  const startDeadline = new Promise<never>((_, reject) => {
     startTimeoutId = setTimeout(
       () =>
         reject(
@@ -204,8 +217,9 @@ export async function createMcpBridge(options: McpBridgeOptions): Promise<McpBri
       CURSOR_MCP_SERVER_START_TIMEOUT_MS,
     );
   });
+  let httpServer: HttpServer;
   try {
-    await Promise.race([listenOnEphemeralPort(httpServer, 0), startTimeout]);
+    httpServer = await Promise.race([bindEphemeralHttpServer(createHttpServer), startDeadline]);
   } finally {
     if (startTimeoutId !== undefined) clearTimeout(startTimeoutId);
   }

--- a/src/agent/cursor/models.ts
+++ b/src/agent/cursor/models.ts
@@ -19,8 +19,6 @@ const CURSOR_MODEL_CATALOG: readonly CursorCatalogEntry[] = [
   { id: "auto", contextWindow: 200_000, maxTokens: 16_384 },
 ] as const;
 
-const DEFAULT_CURSOR_MODEL_ID = "composer-2.5";
-
 function buildCursorModel(entry: CursorCatalogEntry): Model<typeof CURSOR_API> {
   return {
     id: entry.id,
@@ -40,12 +38,26 @@ const catalogById = new Map<string, Model<typeof CURSOR_API>>(
   CURSOR_MODEL_CATALOG.map((entry) => [entry.id, buildCursorModel(entry)]),
 );
 
-export function getCursorModel(modelId: string): Model<typeof CURSOR_API> {
-  return catalogById.get(modelId) ?? catalogById.get(DEFAULT_CURSOR_MODEL_ID)!;
-}
-
 export function listCursorModelIds(): string[] {
   return [...catalogById.keys()];
+}
+
+export function assertCursorModelId(modelId: string): void {
+  const id = modelId.trim();
+  if (!catalogById.has(id)) {
+    throw new Error(
+      `PI_MODEL "${modelId}" is not a supported Cursor model. Supported: ${listCursorModelIds().join(", ")}`,
+    );
+  }
+}
+
+export function getCursorModel(modelId: string): Model<typeof CURSOR_API> {
+  const id = modelId.trim();
+  const model = catalogById.get(id);
+  if (!model) {
+    throw new Error(`Unknown Cursor model id: ${id}`);
+  }
+  return model;
 }
 
 export function isCursorProvider(provider: string): boolean {

--- a/src/agent/cursor/models.ts
+++ b/src/agent/cursor/models.ts
@@ -1,0 +1,53 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+
+export const CURSOR_PROVIDER = "cursor";
+export const CURSOR_API = "cursor-sdk" as const satisfies Api;
+
+const ZERO_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+
+type CursorCatalogEntry = {
+  readonly id: string;
+  readonly contextWindow: number;
+  readonly maxTokens: number;
+};
+
+const CURSOR_MODEL_CATALOG: readonly CursorCatalogEntry[] = [
+  { id: "composer-2.5", contextWindow: 200_000, maxTokens: 16_384 },
+  { id: "composer-2", contextWindow: 200_000, maxTokens: 16_384 },
+  { id: "gpt-5.5", contextWindow: 272_000, maxTokens: 16_384 },
+  { id: "claude-opus-4-7", contextWindow: 200_000, maxTokens: 16_384 },
+  { id: "auto", contextWindow: 200_000, maxTokens: 16_384 },
+] as const;
+
+const DEFAULT_CURSOR_MODEL_ID = "composer-2.5";
+
+function buildCursorModel(entry: CursorCatalogEntry): Model<typeof CURSOR_API> {
+  return {
+    id: entry.id,
+    name: entry.id,
+    api: CURSOR_API,
+    provider: CURSOR_PROVIDER,
+    baseUrl: "https://cursor.com",
+    reasoning: false,
+    input: ["text"],
+    cost: ZERO_COST,
+    contextWindow: entry.contextWindow,
+    maxTokens: entry.maxTokens,
+  };
+}
+
+const catalogById = new Map<string, Model<typeof CURSOR_API>>(
+  CURSOR_MODEL_CATALOG.map((entry) => [entry.id, buildCursorModel(entry)]),
+);
+
+export function getCursorModel(modelId: string): Model<typeof CURSOR_API> {
+  return catalogById.get(modelId) ?? catalogById.get(DEFAULT_CURSOR_MODEL_ID)!;
+}
+
+export function listCursorModelIds(): string[] {
+  return [...catalogById.keys()];
+}
+
+export function isCursorProvider(provider: string): boolean {
+  return provider === CURSOR_PROVIDER;
+}

--- a/src/agent/cursor/promptBuilder.ts
+++ b/src/agent/cursor/promptBuilder.ts
@@ -1,0 +1,60 @@
+import type { Context, Message } from "@earendil-works/pi-ai";
+
+export const CURSOR_APPROX_CHARS_PER_TOKEN = 4;
+
+function formatMessageContent(content: Message["content"]): string {
+  if (typeof content === "string") return content;
+  return content
+    .map((block) => {
+      if (block.type === "text") return block.text;
+      if (block.type === "image") return "[image omitted from transcript]";
+      if (block.type === "toolCall") {
+        return `Tool call (${block.name}, id ${block.id}): ${JSON.stringify(block.arguments)}`;
+      }
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function formatMessage(message: Message): string {
+  switch (message.role) {
+    case "user":
+      return `User:\n${formatMessageContent(message.content)}`;
+    case "assistant":
+      return `Assistant:\n${formatMessageContent(message.content)}`;
+    case "toolResult": {
+      const text = message.content
+        .map((block) => (block.type === "text" ? block.text : ""))
+        .filter(Boolean)
+        .join("\n");
+      const prefix = message.isError ? "Tool error" : "Tool result";
+      return `${prefix} (${message.toolName}):\n${text}`;
+    }
+    default:
+      return "";
+  }
+}
+
+export function buildCursorPrompt(context: Context): { text: string; inputChars: number } {
+  const sections: string[] = [];
+  if (context.systemPrompt?.trim()) {
+    sections.push(`System:\n${context.systemPrompt.trim()}`);
+  }
+  for (const message of context.messages) {
+    const formatted = formatMessage(message);
+    if (formatted.trim()) sections.push(formatted);
+  }
+  const text = sections.join("\n\n");
+  return { text, inputChars: text.length };
+}
+
+export function approximateCursorUsage(inputChars: number, outputChars: number): {
+  input: number;
+  output: number;
+  totalTokens: number;
+} {
+  const input = Math.ceil(inputChars / CURSOR_APPROX_CHARS_PER_TOKEN);
+  const output = Math.ceil(outputChars / CURSOR_APPROX_CHARS_PER_TOKEN);
+  return { input, output, totalTokens: input + output };
+}

--- a/src/agent/cursor/refreshableGithubTools.ts
+++ b/src/agent/cursor/refreshableGithubTools.ts
@@ -1,0 +1,62 @@
+import type { Tool as PiTool } from "@earendil-works/pi-ai";
+import { isInstallationTokenNearExpiry } from "../../github/githubRequestError.js";
+import type { CursorExecutor } from "./runContext.js";
+
+export type ToolExecutorBundle = {
+  readonly piTools: PiTool[];
+  readonly executors: Record<string, CursorExecutor>;
+};
+
+export type RefreshableToolExecutors = {
+  readonly bundle: ToolExecutorBundle;
+  readonly githubExecutorNames: ReadonlySet<string>;
+  readonly refreshBeforeTool: (toolName: string) => Promise<void>;
+  readonly getToken: () => string;
+};
+
+export function createRefreshableToolExecutors(params: {
+  initialToken: string;
+  tokenExpiresAtTs: number;
+  build: (token: string) => ToolExecutorBundle;
+  refreshInstallationToken?: () => Promise<{ token: string; expiresAtTs: number }>;
+  githubToolNames?: ReadonlySet<string>;
+}): RefreshableToolExecutors {
+  let activeToken = params.initialToken;
+  let activeExpiresAtTs = params.tokenExpiresAtTs;
+  let built = params.build(activeToken);
+  const executorStore: Record<string, CursorExecutor> = { ...built.executors };
+  let bundle: ToolExecutorBundle = { piTools: built.piTools, executors: executorStore };
+  const githubExecutorNames =
+    params.githubToolNames ?? new Set(Object.keys(executorStore));
+
+  const refreshBeforeTool = async (toolName: string): Promise<void> => {
+    if (!githubExecutorNames.has(toolName)) return;
+    if (!params.refreshInstallationToken) return;
+    if (!isInstallationTokenNearExpiry(activeExpiresAtTs)) return;
+    const fresh = await params.refreshInstallationToken();
+    activeToken = fresh.token;
+    activeExpiresAtTs = fresh.expiresAtTs;
+    built = params.build(activeToken);
+    Object.assign(executorStore, built.executors);
+    bundle = { piTools: built.piTools, executors: executorStore };
+  };
+
+  return {
+    get bundle() {
+      return bundle;
+    },
+    githubExecutorNames,
+    refreshBeforeTool,
+    getToken: () => activeToken,
+  };
+}
+
+export function patchExecutor(
+  executors: Record<string, CursorExecutor>,
+  name: string,
+  wrap: (original: CursorExecutor) => CursorExecutor,
+): void {
+  const original = executors[name];
+  if (!original) return;
+  executors[name] = wrap(original);
+}

--- a/src/agent/cursor/register.ts
+++ b/src/agent/cursor/register.ts
@@ -1,0 +1,22 @@
+import { getApiProvider, registerApiProvider } from "@earendil-works/pi-ai";
+import { streamCursor, streamSimpleCursor } from "./streamCursor.js";
+
+let registered = false;
+
+export function registerCursorProvider(): void {
+  if (registered) return;
+  registerApiProvider({
+    api: "cursor-sdk",
+    stream: streamCursor,
+    streamSimple: streamSimpleCursor,
+  });
+  registered = true;
+}
+
+export function isCursorProviderRegistered(): boolean {
+  return registered && getApiProvider("cursor-sdk") !== undefined;
+}
+
+export function resetCursorProviderRegistrationForTests(): void {
+  registered = false;
+}

--- a/src/agent/cursor/reviewRunCursor.ts
+++ b/src/agent/cursor/reviewRunCursor.ts
@@ -94,19 +94,17 @@ export async function runCursorFullPrReview(params: {
     });
 
   let submitBundle = buildSubmit();
-  const executors: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
-    ...refreshableGh.bundle.executors,
-    ...ctx7.executors,
-    submitReview: async (args) => {
-      if (submitState.published) {
-        return {
-          ok: true,
-          alreadyPublished: true,
-          message: "Stop further investigation; the review has been published.",
-        };
-      }
-      return submitBundle.executor(args);
-    },
+  const executors = refreshableGh.bundle.executors;
+  Object.assign(executors, ctx7.executors);
+  executors.submitReview = async (args) => {
+    if (submitState.published) {
+      return {
+        ok: true,
+        alreadyPublished: true,
+        message: "Stop further investigation; the review has been published.",
+      };
+    }
+    return submitBundle.executor(args);
   };
 
   const piTools: PiTool[] = [

--- a/src/agent/cursor/reviewRunCursor.ts
+++ b/src/agent/cursor/reviewRunCursor.ts
@@ -8,8 +8,8 @@ import { buildContext7Tools } from "../context7Tools.js";
 import { buildGithubTools } from "../githubTools.js";
 import {
   createCachedPrDiffIndex,
-  ingestListPullRequestFilesResult,
   type CachedPrDiffIndex,
+  wrapListPullRequestFilesDiffIngestion,
 } from "../reviewLocationValidation.js";
 import { automatedSecuritySystemPrompt } from "../securityPrompt.js";
 import { buildAutomatedSystemPrompt } from "../reviewSystemPrompt.js";
@@ -20,15 +20,8 @@ import {
 } from "../submitReviewTool.js";
 import { reviewSummarySentinelForMode, type ReviewMode } from "../reviewSchema.js";
 import type { ReviewRunResult } from "../reviewRun.js";
-import {
-  attachCursorRunContext,
-  detachCursorRunContext,
-  getCursorModel,
-} from "./index.js";
-import {
-  createRefreshableToolExecutors,
-  patchExecutor,
-} from "./refreshableGithubTools.js";
+import { attachCursorRunContext, getCursorModel } from "./index.js";
+import { createRefreshableToolExecutors } from "./refreshableGithubTools.js";
 
 export async function runCursorFullPrReview(params: {
   cfg: Config;
@@ -78,22 +71,10 @@ export async function runCursorFullPrReview(params: {
         maxPrFilesListed: cfg.maxPrFilesListed,
         maxPrFilesPatchBytes: cfg.maxPrFilesPatchBytes,
       });
-      return { piTools: gh.piTools, executors: gh.executors };
+      const executors = { ...gh.executors };
+      wrapListPullRequestFilesDiffIngestion(executors, cachedDiffIndex);
+      return { piTools: gh.piTools, executors };
     },
-  });
-
-  patchExecutor(refreshableGh.bundle.executors, "listPullRequestFiles", (original) => async (args) => {
-    const out = await original(args);
-    if (out && typeof out === "object") {
-      ingestListPullRequestFilesResult(
-        cachedDiffIndex,
-        out as {
-          truncated?: boolean;
-          files?: Array<{ filename: string; patch?: string; patchOmitted?: boolean }>;
-        },
-      );
-    }
-    return out;
   });
 
   const ctx7 = buildContext7Tools({ apiKey: cfg.context7ApiKey });
@@ -164,7 +145,6 @@ export async function runCursorFullPrReview(params: {
   attachCursorRunContext(context, {
     executors,
     apiKey: cfg.cursorApiKey,
-    submitReviewPublished: () => submitState.published,
     refreshBeforeTool: async (toolName) => {
       if (refreshableGh.githubExecutorNames.has(toolName) || toolName === "submitReview") {
         await refreshableGh.refreshBeforeTool("getPullRequest");
@@ -177,12 +157,7 @@ export async function runCursorFullPrReview(params: {
 
   logInfo("cursor_review_started", { owner, repo, pr: prNumber, mode: reviewMode, model: model.id });
 
-  let lastAssistant: AssistantMessage;
-  try {
-    lastAssistant = await complete(model, context, { apiKey: cfg.cursorApiKey });
-  } finally {
-    detachCursorRunContext(context);
-  }
+  const lastAssistant = await complete(model, context, { apiKey: cfg.cursorApiKey });
 
   if (!submitState.published) {
     logWarn("cursor_review_not_published", {

--- a/src/agent/cursor/reviewRunCursor.ts
+++ b/src/agent/cursor/reviewRunCursor.ts
@@ -1,0 +1,218 @@
+import type { Config } from "../../config.js";
+import { logInfo, logWarn } from "../../evlog.js";
+import { upsertReviewSummaryComment } from "../../github/reviewPublish.js";
+import { renderReviewFailureNotice } from "../../agentWork/progressComment.js";
+import { complete } from "@earendil-works/pi-ai";
+import type { AssistantMessage, Context, Tool as PiTool } from "@earendil-works/pi-ai";
+import { buildContext7Tools } from "../context7Tools.js";
+import { buildGithubTools } from "../githubTools.js";
+import {
+  createCachedPrDiffIndex,
+  ingestListPullRequestFilesResult,
+  type CachedPrDiffIndex,
+} from "../reviewLocationValidation.js";
+import { automatedSecuritySystemPrompt } from "../securityPrompt.js";
+import { buildAutomatedSystemPrompt } from "../reviewSystemPrompt.js";
+import {
+  buildSubmitReviewTool,
+  createSubmitReviewState,
+  type SubmitReviewState,
+} from "../submitReviewTool.js";
+import { reviewSummarySentinelForMode, type ReviewMode } from "../reviewSchema.js";
+import type { ReviewRunResult } from "../reviewRun.js";
+import {
+  attachCursorRunContext,
+  detachCursorRunContext,
+  getCursorModel,
+} from "./index.js";
+import {
+  createRefreshableToolExecutors,
+  patchExecutor,
+} from "./refreshableGithubTools.js";
+
+export async function runCursorFullPrReview(params: {
+  cfg: Config;
+  token: string;
+  tokenExpiresAtTs: number;
+  owner: string;
+  repo: string;
+  prNumber: number;
+  headSha: string;
+  reviewMode: ReviewMode;
+  userSupplement?: string;
+  shouldLinkToSummary?: boolean;
+  summaryCommentIdHint?: number | null;
+  initialPublishState?: { published?: boolean; inlinePublished?: boolean };
+  recordPublishStep?: (
+    step: "inline_review" | "summary_comment" | "labels",
+    detail?: { githubId?: string | number; meta?: Record<string, unknown> },
+  ) => Promise<void>;
+  shouldAbortPublish?: () => Promise<boolean>;
+  refreshInstallationToken?: () => Promise<{ token: string; expiresAtTs: number }>;
+}): Promise<ReviewRunResult> {
+  const {
+    cfg,
+    token,
+    tokenExpiresAtTs,
+    owner,
+    repo,
+    prNumber,
+    headSha,
+    reviewMode,
+    userSupplement,
+  } = params;
+
+  let cachedDiffIndex: CachedPrDiffIndex = createCachedPrDiffIndex();
+  const submitState: SubmitReviewState = createSubmitReviewState({
+    published: params.initialPublishState?.published,
+    inlinePublished: params.initialPublishState?.inlinePublished,
+  });
+  const publishCtx = { owner, repo, prNumber, headSha };
+
+  const refreshableGh = createRefreshableToolExecutors({
+    initialToken: token,
+    tokenExpiresAtTs,
+    refreshInstallationToken: params.refreshInstallationToken,
+    build: (activeToken) => {
+      const gh = buildGithubTools(activeToken, {
+        maxPrFilesListed: cfg.maxPrFilesListed,
+        maxPrFilesPatchBytes: cfg.maxPrFilesPatchBytes,
+      });
+      return { piTools: gh.piTools, executors: gh.executors };
+    },
+  });
+
+  patchExecutor(refreshableGh.bundle.executors, "listPullRequestFiles", (original) => async (args) => {
+    const out = await original(args);
+    if (out && typeof out === "object") {
+      ingestListPullRequestFilesResult(
+        cachedDiffIndex,
+        out as {
+          truncated?: boolean;
+          files?: Array<{ filename: string; patch?: string; patchOmitted?: boolean }>;
+        },
+      );
+    }
+    return out;
+  });
+
+  const ctx7 = buildContext7Tools({ apiKey: cfg.context7ApiKey });
+
+  const buildSubmit = () =>
+    buildSubmitReviewTool({
+      cfg,
+      token: refreshableGh.getToken(),
+      ctx: publishCtx,
+      mode: reviewMode,
+      state: submitState,
+      cachedDiffIndex,
+      shouldLinkToSummary: params.shouldLinkToSummary,
+      summaryCommentIdHint: params.summaryCommentIdHint,
+      recordPublishStep: params.recordPublishStep,
+      shouldAbortPublish: params.shouldAbortPublish,
+    });
+
+  let submitBundle = buildSubmit();
+  const executors: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
+    ...refreshableGh.bundle.executors,
+    ...ctx7.executors,
+    submitReview: async (args) => {
+      if (submitState.published) {
+        return {
+          ok: true,
+          alreadyPublished: true,
+          message: "Stop further investigation; the review has been published.",
+        };
+      }
+      return submitBundle.executor(args);
+    },
+  };
+
+  const piTools: PiTool[] = [
+    ...refreshableGh.bundle.piTools,
+    ...ctx7.piTools,
+    submitBundle.piTool,
+  ];
+  const model = getCursorModel(cfg.piModel);
+
+  const userContent = [
+    `Target repository: ${owner}/${repo}`,
+    `Pull request #: ${prNumber}`,
+    `Head commit SHA: ${headSha}`,
+    userSupplement ? `\nAdditional instruction:\n${userSupplement}\n` : "",
+    "",
+    reviewMode === "review-security"
+      ? "Perform a deep security review of the PR diff using investigation tools, then call submitReview exactly once with a complete ReviewPayload."
+      : "Perform a full review using investigation tools, then call submitReview exactly once with a complete ReviewPayload.",
+  ].join("\n");
+
+  const context: Context = {
+    systemPrompt:
+      reviewMode === "review-security"
+        ? automatedSecuritySystemPrompt
+        : buildAutomatedSystemPrompt(),
+    messages: [
+      {
+        role: "user",
+        content: userContent,
+        timestamp: Date.now(),
+      },
+    ],
+    tools: piTools,
+  };
+
+  attachCursorRunContext(context, {
+    executors,
+    apiKey: cfg.cursorApiKey,
+    submitReviewPublished: () => submitState.published,
+    refreshBeforeTool: async (toolName) => {
+      if (refreshableGh.githubExecutorNames.has(toolName) || toolName === "submitReview") {
+        await refreshableGh.refreshBeforeTool("getPullRequest");
+        if (toolName === "submitReview") {
+          submitBundle = buildSubmit();
+        }
+      }
+    },
+  });
+
+  logInfo("cursor_review_started", { owner, repo, pr: prNumber, mode: reviewMode, model: model.id });
+
+  let lastAssistant: AssistantMessage;
+  try {
+    lastAssistant = await complete(model, context, { apiKey: cfg.cursorApiKey });
+  } finally {
+    detachCursorRunContext(context);
+  }
+
+  if (!submitState.published) {
+    logWarn("cursor_review_not_published", {
+      mode: reviewMode,
+      owner,
+      repo,
+      pr: prNumber,
+      stopReason: lastAssistant.stopReason,
+      errorMessage: lastAssistant.errorMessage,
+    });
+    const retryCommand = reviewMode === "review-security" ? "/review-security" : "/review";
+    const body = renderReviewFailureNotice({ mode: reviewMode, retryCommand });
+    try {
+      await upsertReviewSummaryComment(
+        refreshableGh.getToken(),
+        owner,
+        repo,
+        prNumber,
+        body,
+        reviewSummarySentinelForMode(reviewMode),
+      );
+    } catch (e) {
+      logWarn("cursor_review_failure_notice_failed", {
+        owner,
+        repo,
+        pr: prNumber,
+        message: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  return { lastAssistant, published: submitState.published, publishAttempts: 1 };
+}

--- a/src/agent/cursor/reviewRunCursor.ts
+++ b/src/agent/cursor/reviewRunCursor.ts
@@ -55,6 +55,10 @@ export async function runCursorFullPrReview(params: {
     userSupplement,
   } = params;
 
+  if (!Number.isFinite(tokenExpiresAtTs)) {
+    throw new Error("tokenExpiresAtTs must be a finite timestamp in milliseconds");
+  }
+
   let cachedDiffIndex: CachedPrDiffIndex = createCachedPrDiffIndex();
   const submitState: SubmitReviewState = createSubmitReviewState({
     published: params.initialPublishState?.published,
@@ -83,6 +87,7 @@ export async function runCursorFullPrReview(params: {
     buildSubmitReviewTool({
       cfg,
       token: refreshableGh.getToken(),
+      getToken: () => refreshableGh.getToken(),
       ctx: publishCtx,
       mode: reviewMode,
       state: submitState,

--- a/src/agent/cursor/runContext.ts
+++ b/src/agent/cursor/runContext.ts
@@ -1,0 +1,24 @@
+import type { Context } from "@earendil-works/pi-ai";
+
+export type CursorExecutor = (args: Record<string, unknown>) => Promise<unknown>;
+
+export type CursorRunContext = {
+  readonly executors: Record<string, CursorExecutor>;
+  readonly apiKey: string;
+  readonly submitReviewPublished?: () => boolean;
+  readonly refreshBeforeTool?: (toolName: string) => Promise<void>;
+};
+
+const cursorRunContexts = new WeakMap<Context, CursorRunContext>();
+
+export function attachCursorRunContext(context: Context, bundle: CursorRunContext): void {
+  cursorRunContexts.set(context, bundle);
+}
+
+export function getCursorRunContext(context: Context): CursorRunContext | undefined {
+  return cursorRunContexts.get(context);
+}
+
+export function detachCursorRunContext(context: Context): void {
+  cursorRunContexts.delete(context);
+}

--- a/src/agent/cursor/runContext.ts
+++ b/src/agent/cursor/runContext.ts
@@ -5,7 +5,6 @@ export type CursorExecutor = (args: Record<string, unknown>) => Promise<unknown>
 export type CursorRunContext = {
   readonly executors: Record<string, CursorExecutor>;
   readonly apiKey: string;
-  readonly submitReviewPublished?: () => boolean;
   readonly refreshBeforeTool?: (toolName: string) => Promise<void>;
 };
 

--- a/src/agent/cursor/streamCursor.ts
+++ b/src/agent/cursor/streamCursor.ts
@@ -83,7 +83,6 @@ export const streamCursor: StreamFunction<"cursor-sdk", StreamOptions> = (
         tools: context.tools ?? [],
         executors: runContext.executors,
         signal: options?.signal,
-        submitReviewPublished: runContext.submitReviewPublished,
         refreshBeforeTool: runContext.refreshBeforeTool,
       });
       bridgeDispose = bridge.dispose;

--- a/src/agent/cursor/streamCursor.ts
+++ b/src/agent/cursor/streamCursor.ts
@@ -1,0 +1,196 @@
+import {
+  type Api,
+  type AssistantMessage,
+  type AssistantMessageEventStream,
+  type Context,
+  createAssistantMessageEventStream,
+  type Model,
+  type SimpleStreamOptions,
+  type StreamFunction,
+  type StreamOptions,
+} from "@earendil-works/pi-ai";
+import { Agent, CursorAgentError } from "@cursor/sdk";
+import { approximateCursorUsage, buildCursorPrompt } from "./promptBuilder.js";
+import { createMcpBridge } from "./mcpBridge.js";
+import { detachCursorRunContext, getCursorRunContext } from "./runContext.js";
+import {
+  formatCursorRunError,
+  formatCursorStartupError,
+} from "./errors.js";
+
+function makeInitialMessage(model: Model<Api>): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: Date.now(),
+  };
+}
+
+function applyApproximateUsage(
+  partial: AssistantMessage,
+  inputChars: number,
+  outputText: string,
+): void {
+  const approx = approximateCursorUsage(inputChars, outputText.length);
+  partial.usage.input = approx.input;
+  partial.usage.output = approx.output;
+  partial.usage.totalTokens = approx.totalTokens;
+}
+
+function extractFinalText(result: unknown, streamedText: string): string {
+  if (typeof result === "string" && result.trim()) return result.trim();
+  if (streamedText.trim()) return streamedText.trim();
+  return "";
+}
+
+export const streamCursor: StreamFunction<"cursor-sdk", StreamOptions> = (
+  model,
+  context,
+  options,
+) => {
+  const stream = createAssistantMessageEventStream();
+
+  void (async () => {
+    const partial = makeInitialMessage(model);
+    const runContext = getCursorRunContext(context);
+    let bridgeDispose: (() => Promise<void>) | undefined;
+
+    try {
+      stream.push({ type: "start", partial });
+
+      if (!runContext) {
+        throw new Error("Cursor run context missing; attach executors before calling complete()");
+      }
+
+      const apiKey = options?.apiKey?.trim() || runContext.apiKey;
+      if (!apiKey) {
+        throw new Error("CURSOR_API_KEY is required for Cursor provider runs");
+      }
+
+      const bridge = await createMcpBridge({
+        tools: context.tools ?? [],
+        executors: runContext.executors,
+        signal: options?.signal,
+        submitReviewPublished: runContext.submitReviewPublished,
+        refreshBeforeTool: runContext.refreshBeforeTool,
+      });
+      bridgeDispose = bridge.dispose;
+
+      const { text: promptText, inputChars } = buildCursorPrompt(context);
+      const textDeltas: string[] = [];
+      let abortListener: (() => void) | undefined;
+
+      await using agent = await Agent.create({
+        apiKey,
+        model: { id: model.id },
+        local: {
+          cwd: process.cwd(),
+          settingSources: [],
+        },
+        mcpServers: bridge.mcpServers,
+      });
+
+      let run: Awaited<ReturnType<typeof agent.send>> | null = null;
+      abortListener = () => {
+        void run?.cancel().catch(() => undefined);
+      };
+      options?.signal?.addEventListener("abort", abortListener, { once: true });
+
+      if (options?.signal?.aborted) {
+        partial.stopReason = "aborted";
+        stream.push({ type: "error", reason: "aborted", error: partial });
+        return;
+      }
+
+      run = await agent.send(
+        { text: promptText },
+        {
+          onDelta: ({ update }) => {
+            if (update.type === "text-delta" && "text" in update && update.text) {
+              const delta = update.text;
+              textDeltas.push(delta);
+              const index = partial.content.findIndex(
+                (block) => block.type === "text",
+              );
+              if (index >= 0 && partial.content[index]?.type === "text") {
+                partial.content[index].text += delta;
+              } else {
+                partial.content.push({ type: "text", text: delta });
+              }
+              stream.push({
+                type: "text_delta",
+                contentIndex: index >= 0 ? index : partial.content.length - 1,
+                delta,
+                partial,
+              });
+            }
+          },
+        },
+      );
+
+      const result = await run.wait();
+      const streamedText = textDeltas.join("");
+      const finalText = extractFinalText(result.result, streamedText);
+
+      if (result.status === "cancelled" || options?.signal?.aborted) {
+        partial.stopReason = "aborted";
+        stream.push({ type: "error", reason: "aborted", error: partial });
+        return;
+      }
+
+      if (result.status === "error") {
+        partial.stopReason = "error";
+        partial.errorMessage = formatCursorRunError(result.id);
+        stream.push({ type: "error", reason: "error", error: partial });
+        return;
+      }
+
+      if (finalText) {
+        const textIndex = partial.content.findIndex((block) => block.type === "text");
+        if (textIndex >= 0 && partial.content[textIndex]?.type === "text") {
+          partial.content[textIndex].text = finalText;
+        } else {
+          partial.content.push({ type: "text", text: finalText });
+        }
+      }
+
+      applyApproximateUsage(partial, inputChars, finalText);
+      partial.stopReason = "stop";
+      stream.push({ type: "done", reason: "stop", message: partial });
+    } catch (error) {
+      partial.stopReason = "error";
+      if (error instanceof CursorAgentError) {
+        partial.errorMessage = formatCursorStartupError(error);
+      } else {
+        partial.errorMessage = error instanceof Error ? error.message : String(error);
+      }
+      stream.push({ type: "error", reason: "error", error: partial });
+    } finally {
+      detachCursorRunContext(context);
+      if (bridgeDispose) {
+        await bridgeDispose().catch(() => undefined);
+      }
+      stream.end();
+    }
+  })();
+
+  return stream;
+};
+
+export const streamSimpleCursor: StreamFunction<"cursor-sdk", SimpleStreamOptions> = streamCursor;
+
+export function registerCursorStreamProvider(): void {
+  // re-export hook for tests
+}

--- a/src/agent/cursor/streamCursor.ts
+++ b/src/agent/cursor/streamCursor.ts
@@ -66,6 +66,7 @@ export const streamCursor: StreamFunction<"cursor-sdk", StreamOptions> = (
     const partial = makeInitialMessage(model);
     const runContext = getCursorRunContext(context);
     let bridgeDispose: (() => Promise<void>) | undefined;
+    let agent: Awaited<ReturnType<typeof Agent.create>> | undefined;
 
     try {
       stream.push({ type: "start", partial });
@@ -91,7 +92,7 @@ export const streamCursor: StreamFunction<"cursor-sdk", StreamOptions> = (
       const textDeltas: string[] = [];
       let abortListener: (() => void) | undefined;
 
-      await using agent = await Agent.create({
+      agent = await Agent.create({
         apiKey,
         model: { id: model.id },
         local: {
@@ -178,6 +179,12 @@ export const streamCursor: StreamFunction<"cursor-sdk", StreamOptions> = (
       stream.push({ type: "error", reason: "error", error: partial });
     } finally {
       detachCursorRunContext(context);
+      if (agent) {
+        const dispose = agent[Symbol.asyncDispose];
+        if (typeof dispose === "function") {
+          await Promise.resolve(dispose.call(agent)).catch(() => undefined);
+        }
+      }
       if (bridgeDispose) {
         await bridgeDispose().catch(() => undefined);
       }

--- a/src/agent/reviewDiffIndex.ts
+++ b/src/agent/reviewDiffIndex.ts
@@ -69,16 +69,18 @@ function compressLineRanges(sortedLines: number[]): CommentableRightLineRanges {
   return ranges;
 }
 
+export type ListPullRequestFilesToolResult = {
+  truncated?: boolean;
+  files?: Array<{
+    filename: string;
+    patch?: string;
+    patchOmitted?: boolean;
+  }>;
+};
+
 export function ingestListPullRequestFilesResult(
   index: CachedPrDiffIndex,
-  result: {
-    truncated?: boolean;
-    files?: Array<{
-      filename: string;
-      patch?: string;
-      patchOmitted?: boolean;
-    }>;
-  },
+  result: ListPullRequestFilesToolResult,
 ): void {
   if (result.truncated) {
     index.truncated = true;
@@ -89,6 +91,21 @@ export function ingestListPullRequestFilesResult(
       !patchOmitted && file.patch ? parseCommentableRightLineRanges(file.patch) : [];
     index.files.set(file.filename, { patchOmitted, commentableRightLineRanges });
   }
+}
+
+export function wrapListPullRequestFilesDiffIngestion(
+  executors: Record<string, (args: Record<string, unknown>) => Promise<unknown>>,
+  cachedDiffIndex: CachedPrDiffIndex,
+): void {
+  const original = executors.listPullRequestFiles;
+  if (!original) return;
+  executors.listPullRequestFiles = async (args) => {
+    const out = await original(args);
+    if (out && typeof out === "object") {
+      ingestListPullRequestFilesResult(cachedDiffIndex, out as ListPullRequestFilesToolResult);
+    }
+    return out;
+  };
 }
 
 function lineInRanges(line: number, ranges: CommentableRightLineRanges): boolean {

--- a/src/agent/reviewLocationValidation.ts
+++ b/src/agent/reviewLocationValidation.ts
@@ -4,6 +4,7 @@ import {
   createCachedPrDiffIndex,
   ingestListPullRequestFilesResult,
   resolveInlineAnchorLine,
+  wrapListPullRequestFilesDiffIngestion,
   type CachedPrDiffIndex,
 } from "./reviewDiffIndex.js";
 
@@ -14,7 +15,12 @@ export type InlinePlacement = {
   readonly inlineCapEligible: boolean;
 };
 
-export { createCachedPrDiffIndex, ingestListPullRequestFilesResult, type CachedPrDiffIndex };
+export {
+  createCachedPrDiffIndex,
+  ingestListPullRequestFilesResult,
+  wrapListPullRequestFilesDiffIngestion,
+  type CachedPrDiffIndex,
+};
 
 export function planInlinePlacements(
   findings: ReviewFinding[],

--- a/src/agent/reviewRun.ts
+++ b/src/agent/reviewRun.ts
@@ -12,11 +12,10 @@ import { buildContext7Tools } from "./context7Tools.js";
 import { buildGithubTools } from "./githubTools.js";
 import { upsertReviewSummaryComment } from "../github/reviewPublish.js";
 import { renderReviewFailureNotice } from "../agentWork/progressComment.js";
-import { isCursorProvider } from "./cursor/models.js";
 import {
   createCachedPrDiffIndex,
-  ingestListPullRequestFilesResult,
   type CachedPrDiffIndex,
+  wrapListPullRequestFilesDiffIngestion,
 } from "./reviewLocationValidation.js";
 import { automatedSecuritySystemPrompt } from "./securityPrompt.js";
 import { buildAutomatedSystemPrompt } from "./reviewSystemPrompt.js";
@@ -115,7 +114,7 @@ export async function runFullPrReview(params: {
   }
   const reviewMode = params.mode ?? "review";
 
-  if (isCursorProvider(cfg.piProvider)) {
+  if (cfg.piProvider === "cursor") {
     const { runCursorFullPrReview } = await import("./cursor/reviewRunCursor.js");
     return runCursorFullPrReview({ ...params, reviewMode });
   }
@@ -145,22 +144,7 @@ export async function runFullPrReview(params: {
   });
 
   const reviewGithubExecutors = { ...gh.executors };
-  if (reviewGithubExecutors.listPullRequestFiles) {
-    const originalListFiles = reviewGithubExecutors.listPullRequestFiles;
-    reviewGithubExecutors.listPullRequestFiles = async (args) => {
-      const out = await originalListFiles(args);
-      if (out && typeof out === "object") {
-        ingestListPullRequestFilesResult(
-          cachedDiffIndex,
-          out as {
-            truncated?: boolean;
-            files?: Array<{ filename: string; patch?: string; patchOmitted?: boolean }>;
-          },
-        );
-      }
-      return out;
-    };
-  }
+  wrapListPullRequestFilesDiffIngestion(reviewGithubExecutors, cachedDiffIndex);
 
   const piTools: PiTool[] = [...gh.piTools, ...ctx7.piTools, submitTool];
   const executors: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {

--- a/src/agent/reviewRun.ts
+++ b/src/agent/reviewRun.ts
@@ -12,6 +12,7 @@ import { buildContext7Tools } from "./context7Tools.js";
 import { buildGithubTools } from "./githubTools.js";
 import { upsertReviewSummaryComment } from "../github/reviewPublish.js";
 import { renderReviewFailureNotice } from "../agentWork/progressComment.js";
+import { isCursorProvider } from "./cursor/models.js";
 import {
   createCachedPrDiffIndex,
   ingestListPullRequestFilesResult,
@@ -93,6 +94,7 @@ export async function runFullPrReview(params: {
     detail?: { githubId?: string | number; meta?: Record<string, unknown> },
   ) => Promise<void>;
   shouldAbortPublish?: () => Promise<boolean>;
+  refreshInstallationToken?: () => Promise<{ token: string; expiresAtTs: number }>;
 }): Promise<ReviewRunResult> {
   const {
     cfg,
@@ -112,6 +114,11 @@ export async function runFullPrReview(params: {
     throw new Error("tokenTtlMs must be a positive finite duration in milliseconds");
   }
   const reviewMode = params.mode ?? "review";
+
+  if (isCursorProvider(cfg.piProvider)) {
+    const { runCursorFullPrReview } = await import("./cursor/reviewRunCursor.js");
+    return runCursorFullPrReview({ ...params, reviewMode });
+  }
 
   const gh = buildGithubTools(token, {
     maxPrFilesListed: cfg.maxPrFilesListed,

--- a/src/agent/submitReviewTool.ts
+++ b/src/agent/submitReviewTool.ts
@@ -41,6 +41,7 @@ export function createSubmitReviewState(
 export function buildSubmitReviewTool(params: {
   cfg: Config;
   token: string;
+  getToken?: () => string;
   ctx: ReviewPublishContext;
   mode?: ReviewMode;
   state: SubmitReviewState;
@@ -147,7 +148,7 @@ export function buildSubmitReviewTool(params: {
 
     try {
       await publishReview({
-        token: params.token,
+        token: params.getToken?.() ?? params.token,
         mode,
         cfg: params.cfg,
         ...params.ctx,

--- a/src/agentWork/worker.ts
+++ b/src/agentWork/worker.ts
@@ -199,7 +199,7 @@ async function handleReviewJob(
       item.headSha === DEFERRED_HEAD_SHA
         ? getPullRequestHeadSha(token, item.owner, item.repo, item.prNumber)
         : Promise.resolve(item.headSha),
-    execute: async (item, { installation, headSha }) => {
+    execute: async (item, env) => {
       const reviewLens = item.reviewLens!;
       const payload = item.payload as ReviewWorkPayload;
       const publishState = await getReviewPublishState(pool, item.id, item.resourceKey, reviewLens);
@@ -212,6 +212,8 @@ async function handleReviewJob(
       const summaryCommentIdHint = shouldLinkToSummary
         ? await getSummaryCommentGithubId(pool, item.resourceKey, reviewLens)
         : null;
+      let installation = env.installation;
+      const headSha = env.headSha;
       const result = await runFullPrReview({
         cfg,
         token: installation.token,
@@ -239,6 +241,11 @@ async function handleReviewJob(
             detail: detail?.meta,
           }),
         shouldAbortPublish: () => shouldSkipWork(pool, item),
+        refreshInstallationToken: async () => {
+          const fresh = await mintInstallationToken(cfg, item.installationId);
+          installation = fresh;
+          return { token: fresh.token, expiresAtTs: fresh.expiresAtTs };
+        },
       });
       if (!result.published) {
         logWarn("review_not_published", {
@@ -322,7 +329,9 @@ async function handleAskJob(
     type: "ask",
     resolveHeadSha: (token, item) =>
       getPullRequestHeadSha(token, item.owner, item.repo, item.prNumber),
-    execute: async (item, { installation, headSha }) => {
+    execute: async (item, env) => {
+      let installation = env.installation;
+      const headSha = env.headSha;
       const payload = item.payload as AskWorkPayload;
       const result = await runAskRun({
         cfg,
@@ -336,6 +345,11 @@ async function handleAskJob(
         question: payload.question,
         replyTarget: payload.replyTarget,
         codeAnchor: payload.codeAnchor,
+        refreshInstallationToken: async () => {
+          const fresh = await mintInstallationToken(cfg, item.installationId);
+          installation = fresh;
+          return { token: fresh.token, expiresAtTs: fresh.expiresAtTs };
+        },
       });
       await publishAskAnswer(installation.token, item, result.answer);
       return {};

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import { getProviders, type KnownProvider } from "@earendil-works/pi-ai";
+import { assertCursorModelId } from "./agent/cursor/models.js";
 import {
   DEFAULT_ACK_CONCURRENCY,
   DEFAULT_ASK_CONCURRENCY,
@@ -112,12 +113,16 @@ export function loadConfig() {
     );
   }
   // Extension provider registered at worker boot via registerApiProvider (cursor-sdk api).
-  const piProvider = piProviderRaw as KnownProvider;
+  const piProvider = piProviderRaw as KnownProvider | "cursor";
 
-  const cursorApiKey = optionalEnv(ENV.CURSOR_API_KEY, DEFAULT_CURSOR_API_KEY);
-  if (isCursorProvider && !cursorApiKey.trim()) {
+  const cursorApiKeyRaw = optionalEnv(ENV.CURSOR_API_KEY, DEFAULT_CURSOR_API_KEY);
+  if (isCursorProvider && !cursorApiKeyRaw.trim()) {
     throw new Error(`Missing required environment variable: ${ENV.CURSOR_API_KEY}`);
   }
+  if (isCursorProvider) {
+    assertCursorModelId(piModel);
+  }
+  const cursorApiKey = isCursorProvider ? cursorApiKeyRaw.trim() : cursorApiKeyRaw;
 
   const maxToolRounds = Number(optionalEnv(ENV.MAX_TOOL_ROUNDS, String(DEFAULT_MAX_TOOL_ROUNDS)));
   if (!Number.isFinite(maxToolRounds) || maxToolRounds < 1) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_ACK_CONCURRENCY,
   DEFAULT_ASK_CONCURRENCY,
   DEFAULT_CONTEXT7_API_KEY,
+  DEFAULT_CURSOR_API_KEY,
   DEFAULT_ENABLE_REVIEW_LABELS_EFFORT,
   DEFAULT_ENABLE_REVIEW_LABELS_SECURITY,
   DEFAULT_INSTALLATION_GROUP_CONCURRENCY,
@@ -104,12 +105,19 @@ export function loadConfig() {
   const piProviderRaw = optionalEnv(ENV.PI_PROVIDER, DEFAULT_PI_PROVIDER);
   const piModel = optionalEnv(ENV.PI_MODEL, DEFAULT_PI_MODEL);
   const providers = getProviders() as readonly string[];
-  if (!providers.includes(piProviderRaw)) {
+  const isCursorProvider = piProviderRaw === "cursor";
+  if (!isCursorProvider && !providers.includes(piProviderRaw)) {
     throw new Error(
       `PI_PROVIDER "${piProviderRaw}" is unknown. Pick one of: ${providers.slice(0, 12).join(", ")}…`,
     );
   }
+  // Extension provider registered at worker boot via registerApiProvider (cursor-sdk api).
   const piProvider = piProviderRaw as KnownProvider;
+
+  const cursorApiKey = optionalEnv(ENV.CURSOR_API_KEY, DEFAULT_CURSOR_API_KEY);
+  if (isCursorProvider && !cursorApiKey.trim()) {
+    throw new Error(`Missing required environment variable: ${ENV.CURSOR_API_KEY}`);
+  }
 
   const maxToolRounds = Number(optionalEnv(ENV.MAX_TOOL_ROUNDS, String(DEFAULT_MAX_TOOL_ROUNDS)));
   if (!Number.isFinite(maxToolRounds) || maxToolRounds < 1) {
@@ -298,6 +306,7 @@ export function loadConfig() {
     maxAskFinalizeRounds,
     webhookTimeoutMs,
     context7ApiKey,
+    cursorApiKey,
     maxReviewFindings,
     enableReviewLabelsEffort,
     enableReviewLabelsSecurity,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,6 @@ import { loadConfig, type Config } from "./config.js";
 import { initEvlog, logDebug, logInfo } from "./evlog.js";
 import { startEffectWebhookServer } from "./effect/server.js";
 import { startAgentWorker } from "./worker.js";
-import { isCursorProvider } from "./agent/cursor/models.js";
-
 async function main() {
   let cfg: Config;
   try {
@@ -20,11 +18,11 @@ async function main() {
     provider: cfg.piProvider,
     model: cfg.piModel,
     context7_enabled: cfg.context7ApiKey.length > 0,
-    cursor_enabled: isCursorProvider(cfg.piProvider),
+    cursor_enabled: cfg.piProvider === "cursor",
   });
   logDebug("runtime_selected", { runtime: "effect" });
   if (cfg.role === "worker") {
-    if (isCursorProvider(cfg.piProvider)) {
+    if (cfg.piProvider === "cursor") {
       const { registerCursorProvider } = await import("./agent/cursor/register.js");
       registerCursorProvider();
       logInfo("cursor_provider_registered", { api: "cursor-sdk" });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,9 @@ import { loadConfig, type Config } from "./config.js";
 import { initEvlog, logDebug, logInfo } from "./evlog.js";
 import { startEffectWebhookServer } from "./effect/server.js";
 import { startAgentWorker } from "./worker.js";
+import { isCursorProvider } from "./agent/cursor/models.js";
 
-function main() {
+async function main() {
   let cfg: Config;
   try {
     cfg = loadConfig();
@@ -19,13 +20,19 @@ function main() {
     provider: cfg.piProvider,
     model: cfg.piModel,
     context7_enabled: cfg.context7ApiKey.length > 0,
+    cursor_enabled: isCursorProvider(cfg.piProvider),
   });
   logDebug("runtime_selected", { runtime: "effect" });
   if (cfg.role === "worker") {
+    if (isCursorProvider(cfg.piProvider)) {
+      const { registerCursorProvider } = await import("./agent/cursor/register.js");
+      registerCursorProvider();
+      logInfo("cursor_provider_registered", { api: "cursor-sdk" });
+    }
     startAgentWorker(cfg);
     return;
   }
   startEffectWebhookServer(cfg);
 }
 
-main();
+void main();

--- a/src/settings/constants.ts
+++ b/src/settings/constants.ts
@@ -161,6 +161,13 @@ export const GITHUB_REACTION_EYES = "eyes" as const;
 /** Context7 integration. */
 export const CONTEXT7_BASE_URL = "https://context7.com/api";
 
+/** Cursor SDK MCP bridge (inline provider). */
+export const CURSOR_MCP_BIND_HOST = "127.0.0.1";
+export const CURSOR_MCP_TOKEN_BYTES = 32;
+export const CURSOR_MCP_SERVER_START_TIMEOUT_MS = 5_000;
+export const CURSOR_MAX_PORT_RETRIES = 5;
+export const CURSOR_MCP_SERVER_NAME = "pr-agent";
+
 /** Public-output sanitizer. */
 export const PUBLIC_OUTPUT_BANNED_PATTERNS: RegExp[] = [
   /\bsystem prompt\b/i,

--- a/src/settings/defaults.ts
+++ b/src/settings/defaults.ts
@@ -29,6 +29,7 @@ export const DEFAULT_MAX_ASK_FINALIZE_ROUNDS = 2;
 export const DEFAULT_WEBHOOK_TIMEOUT_MS = 10_000;
 
 export const DEFAULT_CONTEXT7_API_KEY = "";
+export const DEFAULT_CURSOR_API_KEY = "";
 
 export const DEFAULT_MAX_REVIEW_FINDINGS = 8;
 export const DEFAULT_ENABLE_REVIEW_LABELS_EFFORT = true;

--- a/src/settings/envKeys.ts
+++ b/src/settings/envKeys.ts
@@ -34,6 +34,7 @@ export const ENV = {
   LOG_LEVEL: "LOG_LEVEL",
   LOG_MAX_WIDE_EVENTS: "LOG_MAX_WIDE_EVENTS",
   LOG_PRETTY: "LOG_PRETTY",
+  CURSOR_API_KEY: "CURSOR_API_KEY",
 } as const;
 
 /** Pi-ai provider secrets (read by `@earendil-works/pi-ai`, not `loadConfig()`). */

--- a/test/askRun.cursor.test.ts
+++ b/test/askRun.cursor.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { Config } from "../src/config.js";
+
+vi.mock("../src/agent/askSafety.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/agent/askSafety.js")>();
+  return {
+    ...actual,
+    buildAskGithubTools: vi.fn(() => ({
+      piTools: [
+        {
+          name: "listPullRequestFiles",
+          description: "d",
+          parameters: { type: "object", properties: {} },
+        },
+      ],
+      executors: {
+        listPullRequestFiles: vi.fn(async () => ({ files: [] })),
+      },
+    })),
+  };
+});
+
+vi.mock("../src/agent/context7Tools.js", () => ({
+  buildContext7Tools: vi.fn(() => ({ piTools: [], executors: {} })),
+}));
+
+vi.mock("@earendil-works/pi-ai", () => ({
+  getModel: vi.fn(),
+  complete: vi.fn(async () => ({
+    role: "assistant" as const,
+    content: [{ type: "text" as const, text: "The function validates input before use." }],
+    api: "cursor-sdk",
+    provider: "cursor",
+    model: "composer-2.5",
+    usage: {
+      input: 8,
+      output: 4,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 12,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop" as const,
+    timestamp: Date.now(),
+  })),
+}));
+
+import { complete } from "@earendil-works/pi-ai";
+import { runAskRun } from "../src/agent/askRun.js";
+
+const cursorCfg = {
+  port: 0,
+  githubAppId: "1",
+  githubAppPrivateKey: "k",
+  webhookSecret: "s",
+  piProvider: "cursor",
+  piModel: "composer-2.5",
+  cursorApiKey: "cursor_test_key",
+  maxToolRounds: 2,
+  maxReviewPublishAttempts: 3,
+  maxReviewPublishCalls: 2,
+  reviewConcurrency: 1,
+  askConcurrency: 3,
+  maxAskToolRounds: 12,
+  maxAskFinalizeRounds: 2,
+  webhookTimeoutMs: 10_000,
+  logLevel: "error",
+  maxReviewFindings: 8,
+  enableReviewLabelsEffort: false,
+  enableReviewLabelsSecurity: false,
+  maxPrFilesListed: 300,
+  maxPrFilesPatchBytes: 500_000,
+} satisfies Config;
+
+describe("runAskRun cursor provider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns assistant text from a single complete call", async () => {
+    const result = await runAskRun({
+      cfg: cursorCfg,
+      token: "t",
+      tokenExpiresAtTs: Date.now() + 3_600_000,
+      tokenTtlMs: 3_600_000,
+      owner: "o",
+      repo: "r",
+      prNumber: 1,
+      headSha: "sha",
+      question: "What does this function do?",
+      replyTarget: { kind: "issue_comment", commentId: 42 },
+    });
+
+    expect(vi.mocked(complete)).toHaveBeenCalledTimes(1);
+    expect(result.replied).toBe(true);
+    expect(result.answer).toContain("validates input");
+  });
+});

--- a/test/configCursor.test.ts
+++ b/test/configCursor.test.ts
@@ -25,12 +25,25 @@ describe("loadConfig cursor provider", () => {
       ...BASE_ENV,
       GITHUB_APP_PRIVATE_KEY: testPrivateKeyPem(),
       PI_PROVIDER: "cursor",
+      PI_MODEL: "composer-2.5",
       CURSOR_API_KEY: "cursor_test_key",
     };
     const { loadConfig } = await import("../src/config.js");
     const cfg = loadConfig();
     expect(cfg.piProvider).toBe("cursor");
     expect(cfg.cursorApiKey).toBe("cursor_test_key");
+  });
+
+  it("rejects unknown PI_MODEL when PI_PROVIDER=cursor", async () => {
+    process.env = {
+      ...BASE_ENV,
+      GITHUB_APP_PRIVATE_KEY: testPrivateKeyPem(),
+      PI_PROVIDER: "cursor",
+      PI_MODEL: "not-a-real-model",
+      CURSOR_API_KEY: "cursor_test_key",
+    };
+    const { loadConfig } = await import("../src/config.js");
+    expect(() => loadConfig()).toThrow(/not a supported Cursor model/);
   });
 
   it("rejects PI_PROVIDER=cursor without CURSOR_API_KEY", async () => {

--- a/test/configCursor.test.ts
+++ b/test/configCursor.test.ts
@@ -1,0 +1,46 @@
+import crypto from "node:crypto";
+import { afterEach, describe, expect, it } from "vitest";
+
+function testPrivateKeyPem(): string {
+  const { privateKey } = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
+  return privateKey.export({ type: "pkcs1", format: "pem" }).toString();
+}
+
+const BASE_ENV = {
+  GITHUB_APP_ID: "1",
+  GITHUB_APP_PRIVATE_KEY: "",
+  WEBHOOK_SECRET: "secret",
+  DATABASE_URL: "postgres://u:p@localhost/db",
+};
+
+describe("loadConfig cursor provider", () => {
+  const saved = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...saved };
+  });
+
+  it("accepts PI_PROVIDER=cursor when CURSOR_API_KEY is set", async () => {
+    process.env = {
+      ...BASE_ENV,
+      GITHUB_APP_PRIVATE_KEY: testPrivateKeyPem(),
+      PI_PROVIDER: "cursor",
+      CURSOR_API_KEY: "cursor_test_key",
+    };
+    const { loadConfig } = await import("../src/config.js");
+    const cfg = loadConfig();
+    expect(cfg.piProvider).toBe("cursor");
+    expect(cfg.cursorApiKey).toBe("cursor_test_key");
+  });
+
+  it("rejects PI_PROVIDER=cursor without CURSOR_API_KEY", async () => {
+    process.env = {
+      ...BASE_ENV,
+      GITHUB_APP_PRIVATE_KEY: testPrivateKeyPem(),
+      PI_PROVIDER: "cursor",
+      CURSOR_API_KEY: "",
+    };
+    const { loadConfig } = await import("../src/config.js");
+    expect(() => loadConfig()).toThrow(/CURSOR_API_KEY/);
+  });
+});

--- a/test/cursorErrors.test.ts
+++ b/test/cursorErrors.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import {
+  CURSOR_RUN_ERROR_PREFIX,
+  CURSOR_STARTUP_ERROR_PREFIX,
+  formatCursorRunError,
+  formatCursorStartupError,
+  isCursorRunError,
+  isCursorStartupError,
+} from "../src/agent/cursor/errors.js";
+
+describe("cursor error formatting", () => {
+  it("formats startup and run errors with distinct prefixes", () => {
+    const startup = formatCursorStartupError(
+      Object.assign(new Error("auth failed"), { name: "CursorAgentError", isRetryable: true }),
+    );
+    expect(startup).toContain(CURSOR_STARTUP_ERROR_PREFIX);
+    expect(isCursorStartupError(startup)).toBe(true);
+
+    const run = formatCursorRunError("run-123");
+    expect(run).toBe(`${CURSOR_RUN_ERROR_PREFIX} run-123`);
+    expect(isCursorRunError(run)).toBe(true);
+  });
+});

--- a/test/cursorMcpBridge.test.ts
+++ b/test/cursorMcpBridge.test.ts
@@ -1,29 +1,11 @@
 import { describe, expect, it } from "vitest";
-import {
-  checkMcpBearerAuth,
-  createMcpBridge,
-  resolveSubmitReviewToolResult,
-} from "../src/agent/cursor/mcpBridge.js";
+import { checkMcpBearerAuth, createMcpBridge } from "../src/agent/cursor/mcpBridge.js";
 
 describe("checkMcpBearerAuth", () => {
   it("accepts matching bearer token", () => {
     expect(checkMcpBearerAuth("Bearer abc123", "abc123")).toBe(true);
     expect(checkMcpBearerAuth("Bearer wrong", "abc123")).toBe(false);
     expect(checkMcpBearerAuth(undefined, "abc123")).toBe(false);
-  });
-});
-
-describe("resolveSubmitReviewToolResult", () => {
-  it("short-circuits when already published", async () => {
-    const result = await resolveSubmitReviewToolResult(true, async () => {
-      throw new Error("should not run");
-    });
-    expect(result).toMatchObject({ alreadyPublished: true });
-  });
-
-  it("runs executor when not yet published", async () => {
-    const result = await resolveSubmitReviewToolResult(false, async () => ({ ok: true }));
-    expect(result).toEqual({ ok: true });
   });
 });
 

--- a/test/cursorMcpBridge.test.ts
+++ b/test/cursorMcpBridge.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  checkMcpBearerAuth,
+  createMcpBridge,
+  resolveSubmitReviewToolResult,
+} from "../src/agent/cursor/mcpBridge.js";
+
+describe("checkMcpBearerAuth", () => {
+  it("accepts matching bearer token", () => {
+    expect(checkMcpBearerAuth("Bearer abc123", "abc123")).toBe(true);
+    expect(checkMcpBearerAuth("Bearer wrong", "abc123")).toBe(false);
+    expect(checkMcpBearerAuth(undefined, "abc123")).toBe(false);
+  });
+});
+
+describe("resolveSubmitReviewToolResult", () => {
+  it("short-circuits when already published", async () => {
+    const result = await resolveSubmitReviewToolResult(true, async () => {
+      throw new Error("should not run");
+    });
+    expect(result).toMatchObject({ alreadyPublished: true });
+  });
+
+  it("runs executor when not yet published", async () => {
+    const result = await resolveSubmitReviewToolResult(false, async () => ({ ok: true }));
+    expect(result).toEqual({ ok: true });
+  });
+});
+
+describe("createMcpBridge", () => {
+  it("exposes http mcp server config on loopback", async () => {
+    const bridge = await createMcpBridge({
+      tools: [{ name: "noop", description: "noop", parameters: { type: "object" } }],
+      executors: { noop: async () => "ok" },
+    });
+    try {
+      const config = bridge.mcpServers["pr-agent"];
+      expect(config?.type).toBe("http");
+      expect(config?.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/mcp\//);
+      expect(config?.headers?.Authorization).toMatch(/^Bearer /);
+    } finally {
+      await bridge.dispose();
+    }
+  });
+
+  it("rejects requests without bearer token", async () => {
+    const bridge = await createMcpBridge({
+      tools: [{ name: "noop", description: "noop", parameters: { type: "object" } }],
+      executors: { noop: async () => "ok" },
+    });
+    try {
+      const config = bridge.mcpServers["pr-agent"];
+      const res = await fetch(config!.url!, { method: "POST" });
+      expect(res.status).toBe(401);
+    } finally {
+      await bridge.dispose();
+    }
+  });
+});

--- a/test/cursorModels.test.ts
+++ b/test/cursorModels.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import {
+  CURSOR_API,
+  CURSOR_PROVIDER,
+  getCursorModel,
+  isCursorProvider,
+  listCursorModelIds,
+} from "../src/agent/cursor/models.js";
+
+describe("cursor models", () => {
+  it("builds cursor-sdk models for catalog ids", () => {
+    expect(isCursorProvider(CURSOR_PROVIDER)).toBe(true);
+    expect(listCursorModelIds()).toContain("composer-2.5");
+    const model = getCursorModel("composer-2.5");
+    expect(model.api).toBe(CURSOR_API);
+    expect(model.provider).toBe(CURSOR_PROVIDER);
+  });
+
+  it("falls back to composer-2.5 for unknown ids", () => {
+    const model = getCursorModel("not-a-real-model");
+    expect(model.id).toBe("composer-2.5");
+  });
+});

--- a/test/cursorModels.test.ts
+++ b/test/cursorModels.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  assertCursorModelId,
   CURSOR_API,
   CURSOR_PROVIDER,
   getCursorModel,
@@ -16,8 +17,8 @@ describe("cursor models", () => {
     expect(model.provider).toBe(CURSOR_PROVIDER);
   });
 
-  it("falls back to composer-2.5 for unknown ids", () => {
-    const model = getCursorModel("not-a-real-model");
-    expect(model.id).toBe("composer-2.5");
+  it("rejects unknown model ids", () => {
+    expect(() => assertCursorModelId("not-a-real-model")).toThrow(/not a supported Cursor model/);
+    expect(() => getCursorModel("not-a-real-model")).toThrow(/Unknown Cursor model/);
   });
 });

--- a/test/cursorPromptBuilder.test.ts
+++ b/test/cursorPromptBuilder.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { approximateCursorUsage, buildCursorPrompt } from "../src/agent/cursor/promptBuilder.js";
+
+describe("buildCursorPrompt", () => {
+  it("includes system prompt and user message", () => {
+    const { text, inputChars } = buildCursorPrompt({
+      systemPrompt: "Review the PR",
+      messages: [{ role: "user", content: "Check auth.ts", timestamp: 1 }],
+    });
+    expect(text).toContain("System:");
+    expect(text).toContain("Review the PR");
+    expect(text).toContain("Check auth.ts");
+    expect(inputChars).toBe(text.length);
+  });
+});
+
+describe("approximateCursorUsage", () => {
+  it("estimates tokens from char counts", () => {
+    const usage = approximateCursorUsage(400, 200);
+    expect(usage.input).toBe(100);
+    expect(usage.output).toBe(50);
+    expect(usage.totalTokens).toBe(150);
+  });
+});

--- a/test/cursorRegister.test.ts
+++ b/test/cursorRegister.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { getApiProvider } from "@earendil-works/pi-ai";
+import {
+  isCursorProviderRegistered,
+  registerCursorProvider,
+  resetCursorProviderRegistrationForTests,
+} from "../src/agent/cursor/register.js";
+
+describe("registerCursorProvider", () => {
+  it("registers cursor-sdk api provider", () => {
+    resetCursorProviderRegistrationForTests();
+    expect(isCursorProviderRegistered()).toBe(false);
+    registerCursorProvider();
+    expect(isCursorProviderRegistered()).toBe(true);
+    expect(getApiProvider("cursor-sdk")).toBeDefined();
+  });
+});

--- a/test/cursorStream.test.ts
+++ b/test/cursorStream.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { Agent, CursorAgentError } from "@cursor/sdk";
+import { streamCursor } from "../src/agent/cursor/streamCursor.js";
+import { attachCursorRunContext } from "../src/agent/cursor/runContext.js";
+import { getCursorModel } from "../src/agent/cursor/models.js";
+import {
+  CURSOR_RUN_ERROR_PREFIX,
+  CURSOR_STARTUP_ERROR_PREFIX,
+} from "../src/agent/cursor/errors.js";
+import type { Context } from "@earendil-works/pi-ai";
+
+const model = getCursorModel("composer-2.5");
+
+function baseContext(): Context {
+  return {
+    systemPrompt: "Review system prompt",
+    messages: [{ role: "user", content: "Review this pull request", timestamp: Date.now() }],
+    tools: [{ name: "noop", description: "noop", parameters: { type: "object" } }],
+  };
+}
+
+function attachExecutors(context: Context): void {
+  attachCursorRunContext(context, {
+    executors: { noop: async () => "ok" },
+    apiKey: "cursor_test_key",
+  });
+}
+
+describe("streamCursor", () => {
+  beforeEach(() => {
+    vi.mocked(Agent.create).mockReset();
+  });
+
+  it("returns done message with approximate usage", async () => {
+    vi.mocked(Agent.create).mockImplementation(async () => {
+      const run = {
+        cancel: vi.fn(),
+        wait: vi.fn().mockResolvedValue({
+          status: "completed",
+          result: "Final review summary",
+          id: "run-1",
+        }),
+      };
+      return {
+        send: vi.fn(async (_prompt, opts) => {
+          opts?.onDelta?.({ update: { type: "text-delta", text: "Partial " } });
+          return run;
+        }),
+        [Symbol.asyncDispose]: vi.fn(),
+      } as unknown as Awaited<ReturnType<typeof Agent.create>>;
+    });
+
+    const context = baseContext();
+    attachExecutors(context);
+    const result = await streamCursor(model, context, { apiKey: "cursor_test_key" }).result();
+
+    expect(result.stopReason).toBe("stop");
+    expect(
+      result.content.some(
+        (block) => block.type === "text" && block.text.includes("Final review summary"),
+      ),
+    ).toBe(true);
+    expect(result.usage.totalTokens).toBeGreaterThan(0);
+  });
+
+  it("maps CursorAgentError to cursor_startup_error", async () => {
+    vi.mocked(Agent.create).mockRejectedValue(new CursorAgentError("auth failed", true));
+
+    const context = baseContext();
+    attachExecutors(context);
+    const result = await streamCursor(model, context, { apiKey: "cursor_test_key" }).result();
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toContain(CURSOR_STARTUP_ERROR_PREFIX);
+    expect(result.errorMessage).toContain("auth failed");
+  });
+
+  it("maps run error status to cursor_run_error", async () => {
+    vi.mocked(Agent.create).mockImplementation(async () => {
+      const run = {
+        cancel: vi.fn(),
+        wait: vi.fn().mockResolvedValue({ status: "error", id: "run-err-9", result: null }),
+      };
+      return {
+        send: vi.fn(async () => run),
+        [Symbol.asyncDispose]: vi.fn(),
+      } as unknown as Awaited<ReturnType<typeof Agent.create>>;
+    });
+
+    const context = baseContext();
+    attachExecutors(context);
+    const result = await streamCursor(model, context, { apiKey: "cursor_test_key" }).result();
+
+    expect(result.errorMessage).toBe(`${CURSOR_RUN_ERROR_PREFIX} run-err-9`);
+  });
+
+  it("returns aborted when signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const context = baseContext();
+    attachExecutors(context);
+    const result = await streamCursor(model, context, {
+      apiKey: "cursor_test_key",
+      signal: controller.signal,
+    }).result();
+
+    expect(result.stopReason).toBe("aborted");
+  });
+});

--- a/test/refreshableGithubTools.test.ts
+++ b/test/refreshableGithubTools.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import { TOKEN_FRESHNESS_BUFFER_MS } from "../src/settings/constants.js";
+import { createRefreshableToolExecutors } from "../src/agent/cursor/refreshableGithubTools.js";
+
+describe("createRefreshableToolExecutors", () => {
+  it("refreshes token and rebuilds executors when near expiry", async () => {
+    const refresh = vi.fn(async () => ({
+      token: "fresh-token",
+      expiresAtTs: Date.now() + 3_600_000,
+    }));
+    const build = vi.fn((token: string) => ({
+      piTools: [],
+      executors: {
+        getPullRequest: vi.fn(async () => ({ tokenUsed: token })),
+      },
+    }));
+
+    const refreshable = createRefreshableToolExecutors({
+      initialToken: "stale-token",
+      tokenExpiresAtTs: Date.now() + TOKEN_FRESHNESS_BUFFER_MS - 1_000,
+      refreshInstallationToken: refresh,
+      build,
+      githubToolNames: new Set(["getPullRequest"]),
+    });
+
+    await refreshable.refreshBeforeTool("getPullRequest");
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(refreshable.getToken()).toBe("fresh-token");
+    expect(build).toHaveBeenCalledTimes(2);
+    expect(build).toHaveBeenLastCalledWith("fresh-token");
+  });
+});

--- a/test/reviewRun.cursor.test.ts
+++ b/test/reviewRun.cursor.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { Config } from "../src/config.js";
+import { automatedSecuritySystemPrompt } from "../src/agent/securityPrompt.js";
+
+vi.mock("../src/github/reviewPublish.js", () => ({
+  upsertReviewSummaryComment: vi.fn(async () => ({ id: 99, updated: true })),
+}));
+
+vi.mock("../src/agent/githubTools.js", () => ({
+  buildGithubTools: vi.fn(() => ({
+    piTools: [
+      { name: "getPullRequest", description: "d", parameters: { type: "object", properties: {} } },
+      {
+        name: "listPullRequestFiles",
+        description: "d",
+        parameters: { type: "object", properties: {} },
+      },
+    ],
+    executors: {
+      getPullRequest: vi.fn(async () => ({})),
+      listPullRequestFiles: vi.fn(async () => ({ files: [] })),
+    },
+  })),
+}));
+
+vi.mock("../src/agent/context7Tools.js", () => ({
+  buildContext7Tools: vi.fn(() => ({ piTools: [], executors: {} })),
+}));
+
+vi.mock("../src/agent/submitReviewTool.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/agent/submitReviewTool.js")>();
+  return {
+    ...actual,
+    buildSubmitReviewTool: vi.fn((params) => ({
+      piTool: {
+        name: "submitReview",
+        description: "d",
+        parameters: { type: "object", properties: {} },
+      },
+      executor: vi.fn(async () => {
+        params.state.published = true;
+        return { ok: true };
+      }),
+    })),
+  };
+});
+
+vi.mock("@earendil-works/pi-ai", () => ({
+  getModel: vi.fn(),
+  complete: vi.fn(async () => ({
+    role: "assistant" as const,
+    content: [{ type: "text" as const, text: "cursor review complete" }],
+    api: "cursor-sdk",
+    provider: "cursor",
+    model: "composer-2.5",
+    usage: {
+      input: 10,
+      output: 5,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 15,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop" as const,
+    timestamp: Date.now(),
+  })),
+}));
+
+import { complete } from "@earendil-works/pi-ai";
+import { runFullPrReview } from "../src/agent/reviewRun.js";
+
+const cursorCfg = {
+  port: 0,
+  githubAppId: "1",
+  githubAppPrivateKey: "k",
+  webhookSecret: "s",
+  piProvider: "cursor",
+  piModel: "composer-2.5",
+  cursorApiKey: "cursor_test_key",
+  maxToolRounds: 2,
+  maxReviewPublishAttempts: 3,
+  maxReviewPublishCalls: 2,
+  reviewConcurrency: 1,
+  askConcurrency: 3,
+  maxAskToolRounds: 12,
+  maxAskFinalizeRounds: 2,
+  webhookTimeoutMs: 10_000,
+  logLevel: "error",
+  maxReviewFindings: 8,
+  enableReviewLabelsEffort: false,
+  enableReviewLabelsSecurity: false,
+  maxPrFilesListed: 300,
+  maxPrFilesPatchBytes: 500_000,
+} satisfies Config;
+
+const farFutureTokenExpiry = Date.now() + 3_600_000;
+
+describe("runFullPrReview cursor provider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses one complete call and security lens prompt for review-security", async () => {
+    const result = await runFullPrReview({
+      cfg: cursorCfg,
+      token: "t",
+      tokenExpiresAtTs: farFutureTokenExpiry,
+      tokenTtlMs: 3_600_000,
+      owner: "o",
+      repo: "r",
+      prNumber: 1,
+      headSha: "sha",
+      mode: "review-security",
+    });
+
+    expect(vi.mocked(complete)).toHaveBeenCalledTimes(1);
+    const context = vi.mocked(complete).mock.calls[0][1] as { systemPrompt: string };
+    expect(context.systemPrompt).toBe(automatedSecuritySystemPrompt);
+    expect(result.publishAttempts).toBe(1);
+    expect(result.published).toBe(false);
+  });
+});

--- a/test/reviewRun.cursor.test.ts
+++ b/test/reviewRun.cursor.test.ts
@@ -67,6 +67,7 @@ vi.mock("@earendil-works/pi-ai", () => ({
 }));
 
 import { complete } from "@earendil-works/pi-ai";
+import { buildSubmitReviewTool } from "../src/agent/submitReviewTool.js";
 import { runFullPrReview } from "../src/agent/reviewRun.js";
 
 const cursorCfg = {
@@ -100,6 +101,21 @@ describe("runFullPrReview cursor provider", () => {
     vi.clearAllMocks();
   });
 
+  it("rejects non-finite tokenExpiresAtTs", async () => {
+    await expect(
+      runFullPrReview({
+        cfg: cursorCfg,
+        token: "t",
+        tokenExpiresAtTs: NaN,
+        tokenTtlMs: 3_600_000,
+        owner: "o",
+        repo: "r",
+        prNumber: 1,
+        headSha: "sha",
+      }),
+    ).rejects.toThrow(/tokenExpiresAtTs/);
+  });
+
   it("uses one complete call and security lens prompt for review-security", async () => {
     const result = await runFullPrReview({
       cfg: cursorCfg,
@@ -118,5 +134,8 @@ describe("runFullPrReview cursor provider", () => {
     expect(context.systemPrompt).toBe(automatedSecuritySystemPrompt);
     expect(result.publishAttempts).toBe(1);
     expect(result.published).toBe(false);
+    expect(vi.mocked(buildSubmitReviewTool)).toHaveBeenCalledWith(
+      expect.objectContaining({ getToken: expect.any(Function) }),
+    );
   });
 });

--- a/test/setup/cursor-sdk-mock.ts
+++ b/test/setup/cursor-sdk-mock.ts
@@ -11,7 +11,10 @@ class MockCursorAgentError extends Error {
 
 vi.mock("@cursor/sdk", () => ({
   Agent: {
-    create: vi.fn(),
+    create: vi.fn(async () => ({
+      send: vi.fn(),
+      [Symbol.asyncDispose]: vi.fn(),
+    })),
   },
   CursorAgentError: MockCursorAgentError,
 }));

--- a/test/setup/cursor-sdk-mock.ts
+++ b/test/setup/cursor-sdk-mock.ts
@@ -1,0 +1,17 @@
+import { vi } from "vitest";
+
+class MockCursorAgentError extends Error {
+  readonly isRetryable: boolean;
+  constructor(message: string, isRetryable = false) {
+    super(message);
+    this.name = "CursorAgentError";
+    this.isRetryable = isRetryable;
+  }
+}
+
+vi.mock("@cursor/sdk", () => ({
+  Agent: {
+    create: vi.fn(),
+  },
+  CursorAgentError: MockCursorAgentError,
+}));

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   test: {
     pool: "forks",
     include: ["test/**/*.test.ts"],
-    setupFiles: ["test/setup/evlog.ts"],
+    setupFiles: ["test/setup/evlog.ts", "test/setup/cursor-sdk-mock.ts"],
   },
 });


### PR DESCRIPTION
## Summary

- Adds an inline `cursor-sdk` pi-ai provider under `src/agent/cursor/`, registered at worker boot when `PI_PROVIDER=cursor`
- Runs review and ask via a single `complete()` call; Cursor owns the tool loop while GitHub, Context7, and `submitReview` tools are exposed through a per-run HTTP loopback MCP bridge
- Introduces `CURSOR_API_KEY` config validation, bundled Cursor model catalog, token refresh for long runs, and distinct startup/run error prefixes
- Documents the provider in README, `docs/configuration.md`, and ADR 0013; adds cursor-specific unit tests with a vitest `@cursor/sdk` mock

## Test plan

- [x] `pnpm test` (282 tests)
- [x] `pnpm typecheck`