### PR TITLE
Standardize GitHub review comment markdown

### DIFF
--- a/docs/adr/0005-structured-review-output.md
+++ b/docs/adr/0005-structured-review-output.md
@@ -11,7 +11,7 @@ The review agent previously instructed the model to submit a GitHub pull request
 ## Decision
 
 1. **`ReviewPayload`** (Zod) is the single source of truth per review run, emitted via a **`submitReview`** pseudo-tool exactly once.
-2. **Server-side renderers** (`reviewRender.ts`) produce inline thread bodies (P0–P2, with `Prompt to fix` accordion), the **review pointer body** (Files-tab pull request review header with an aggregate **agent fix prompt** accordion), and the **review summary comment** (sentinel `## PR Agent Review`, table overview with deep-links only—no duplicated finding bodies).
+2. **Server-side renderers** (`reviewRender.ts`) produce inline thread bodies (P0–P2, with `Prompt to fix` accordion), the **review pointer body** (Files-tab pull request review header with an aggregate **agent fix prompt** accordion), and the **review summary comment** (sentinel `## PR Agent Review`, overview alert plus a unified table: effort, finding rows keyed by severity, tests, security, and follow-ups). Finding rows for inline-posted severities list title, location, and a footnote only; **detail text appears in the summary table only for summary-only placements**.
 3. **Publish** (`publishReview.ts` + `github/reviewPublish.ts`) calls Octokit directly; `createPullRequestReview` / `addPullRequestComment` are **filtered out** of the review agent tool list.
 4. **Phase 3:** summary comment upsert by sentinel; optional idempotent labels (`Review effort N/5`, `Possible security concern`) behind config flags.
 5. **Strict bugs only** — no suggestions/improvements framing; `fixPrompt` is for coding agents, not human refactor advice.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,11 +6,11 @@ Maintenance rules: [AGENTS.md](../AGENTS.md).
 
 ## How to change something
 
-| Kind | Where to edit |
-|------|----------------|
-| **env** | `.env` / deployment env → keys below; defaults in `src/settings/defaults.ts` |
-| **code** | `src/settings/constants.ts` |
-| **external** | Provider env (pi-ai); documented only here |
+| Kind         | Where to edit                                                                |
+| ------------ | ---------------------------------------------------------------------------- |
+| **env**      | `.env` / deployment env → keys below; defaults in `src/settings/defaults.ts` |
+| **code**     | `src/settings/constants.ts`                                                  |
+| **external** | Provider env (pi-ai); documented only here                                   |
 
 Import convention: `import { … } from "../settings/index.js"` for constants; `Config` from `config.ts` at runtime.
 
@@ -18,62 +18,62 @@ Import convention: `import { … } from "../settings/index.js"` for constants; `
 
 ## Environment (`loadConfig`)
 
-| Name | Env var | Default | Notes |
-|------|---------|---------|-------|
-| HTTP port | `PORT` | `3000` (7224 in Compose) | |
-| Process role | `ROLE` | `web` | `web` or `worker` |
-| GitHub App ID | `GITHUB_APP_ID` | — | required |
-| App private key | `GITHUB_APP_PRIVATE_KEY` | — | required PEM |
-| Webhook HMAC secret | `WEBHOOK_SECRET` | — | required |
-| Postgres URL | `DATABASE_URL` | — | required |
-| LLM provider | `PI_PROVIDER` | `openai` | pi-ai registry id; use `cursor` for Cursor SDK |
-| LLM model | `PI_MODEL` | `gpt-4o-mini` | For `cursor`, e.g. `composer-2.5`, `auto` |
-| Cursor API key | `CURSOR_API_KEY` | empty | required when `PI_PROVIDER=cursor` |
-| Review tool rounds | `MAX_TOOL_ROUNDS` | `24` | per review run |
-| Publish recovery attempts | `MAX_REVIEW_PUBLISH_ATTEMPTS` | `3` | when submitReview never succeeds |
-| Publish execution budget | `MAX_REVIEW_PUBLISH_CALLS` | `2` | valid submitReview publishes per run |
-| Review worker concurrency | `REVIEW_CONCURRENCY` | `2` | pg-boss review queue workers |
-| Ask worker concurrency | `ASK_CONCURRENCY` | `1` | pg-boss ask queue workers |
-| Ack worker concurrency | `ACK_CONCURRENCY` | `2` | reactions + progress stub |
-| Installation group cap | `INSTALLATION_GROUP_CONCURRENCY` | `2` | pg-boss group policy |
-| Queue retry limit | `QUEUE_RETRY_LIMIT` | `3` | pg-boss job retries |
-| Queue retry delay | `QUEUE_RETRY_DELAY_SECONDS` | `30` | |
-| Queue retry delay max | `QUEUE_RETRY_DELAY_MAX_SECONDS` | `300` | |
-| Job expire | `QUEUE_EXPIRE_IN_SECONDS` | `3600` | |
-| Job heartbeat | `QUEUE_HEARTBEAT_SECONDS` | `60` | min 10 |
-| Job retention | `QUEUE_RETENTION_SECONDS` | `1209600` | |
-| Job delete after | `QUEUE_DELETE_AFTER_SECONDS` | `604800` | |
-| Ask tool rounds | `MAX_ASK_TOOL_ROUNDS` | `12` | |
-| Ask finalize rounds | `MAX_ASK_FINALIZE_ROUNDS` | `2` | |
-| Webhook time budget | `WEBHOOK_TIMEOUT_MS` | `10000` | log warning only |
-| Context7 API key | `CONTEXT7_API_KEY` | empty | optional |
-| Max review findings | `MAX_REVIEW_FINDINGS` | `8` | Zod schema + publish cap |
-| Label effort | `ENABLE_REVIEW_LABELS_EFFORT` | `true` | |
-| Label security | `ENABLE_REVIEW_LABELS_SECURITY` | `false` | |
-| Max PR files listed | `MAX_PR_FILES_LISTED` | `300` | listPullRequestFiles |
-| Max PR patch bytes | `MAX_PR_FILES_PATCH_BYTES` | `500000` | |
-| Log level | `LOG_LEVEL` | `info` | |
-| Max wide sub-events | `LOG_MAX_WIDE_EVENTS` | `128` | |
-| Pretty logs | `LOG_PRETTY` | dev `true`, prod `false` | |
+| Name                      | Env var                          | Default                  | Notes                                          |
+| ------------------------- | -------------------------------- | ------------------------ | ---------------------------------------------- |
+| HTTP port                 | `PORT`                           | `3000` (7224 in Compose) |                                                |
+| Process role              | `ROLE`                           | `web`                    | `web` or `worker`                              |
+| GitHub App ID             | `GITHUB_APP_ID`                  | —                        | required                                       |
+| App private key           | `GITHUB_APP_PRIVATE_KEY`         | —                        | required PEM                                   |
+| Webhook HMAC secret       | `WEBHOOK_SECRET`                 | —                        | required                                       |
+| Postgres URL              | `DATABASE_URL`                   | —                        | required                                       |
+| LLM provider              | `PI_PROVIDER`                    | `openai`                 | pi-ai registry id; use `cursor` for Cursor SDK |
+| LLM model                 | `PI_MODEL`                       | `gpt-4o-mini`            | For `cursor`, e.g. `composer-2.5`, `auto`      |
+| Cursor API key            | `CURSOR_API_KEY`                 | empty                    | required when `PI_PROVIDER=cursor`             |
+| Review tool rounds        | `MAX_TOOL_ROUNDS`                | `24`                     | per review run                                 |
+| Publish recovery attempts | `MAX_REVIEW_PUBLISH_ATTEMPTS`    | `3`                      | when submitReview never succeeds               |
+| Publish execution budget  | `MAX_REVIEW_PUBLISH_CALLS`       | `2`                      | valid submitReview publishes per run           |
+| Review worker concurrency | `REVIEW_CONCURRENCY`             | `2`                      | pg-boss review queue workers                   |
+| Ask worker concurrency    | `ASK_CONCURRENCY`                | `1`                      | pg-boss ask queue workers                      |
+| Ack worker concurrency    | `ACK_CONCURRENCY`                | `2`                      | reactions + progress stub                      |
+| Installation group cap    | `INSTALLATION_GROUP_CONCURRENCY` | `2`                      | pg-boss group policy                           |
+| Queue retry limit         | `QUEUE_RETRY_LIMIT`              | `3`                      | pg-boss job retries                            |
+| Queue retry delay         | `QUEUE_RETRY_DELAY_SECONDS`      | `30`                     |                                                |
+| Queue retry delay max     | `QUEUE_RETRY_DELAY_MAX_SECONDS`  | `300`                    |                                                |
+| Job expire                | `QUEUE_EXPIRE_IN_SECONDS`        | `3600`                   |                                                |
+| Job heartbeat             | `QUEUE_HEARTBEAT_SECONDS`        | `60`                     | min 10                                         |
+| Job retention             | `QUEUE_RETENTION_SECONDS`        | `1209600`                |                                                |
+| Job delete after          | `QUEUE_DELETE_AFTER_SECONDS`     | `604800`                 |                                                |
+| Ask tool rounds           | `MAX_ASK_TOOL_ROUNDS`            | `12`                     |                                                |
+| Ask finalize rounds       | `MAX_ASK_FINALIZE_ROUNDS`        | `2`                      |                                                |
+| Webhook time budget       | `WEBHOOK_TIMEOUT_MS`             | `10000`                  | log warning only                               |
+| Context7 API key          | `CONTEXT7_API_KEY`               | empty                    | optional                                       |
+| Max review findings       | `MAX_REVIEW_FINDINGS`            | `8`                      | Zod schema + publish cap                       |
+| Label effort              | `ENABLE_REVIEW_LABELS_EFFORT`    | `true`                   |                                                |
+| Label security            | `ENABLE_REVIEW_LABELS_SECURITY`  | `false`                  |                                                |
+| Max PR files listed       | `MAX_PR_FILES_LISTED`            | `300`                    | listPullRequestFiles                           |
+| Max PR patch bytes        | `MAX_PR_FILES_PATCH_BYTES`       | `500000`                 |                                                |
+| Log level                 | `LOG_LEVEL`                      | `info`                   |                                                |
+| Max wide sub-events       | `LOG_MAX_WIDE_EVENTS`            | `128`                    |                                                |
+| Pretty logs               | `LOG_PRETTY`                     | dev `true`, prod `false` |                                                |
 
 ### External (pi-ai)
 
 Not loaded by `loadConfig()`. Set the secret(s) for your `PI_PROVIDER`.
 
-| Env var | Purpose |
-|---------|---------|
-| `OPENAI_API_KEY` | OpenAI provider |
-| `ANTHROPIC_API_KEY` | Anthropic provider |
-| `GOOGLE_GENERATIVE_AI_API_KEY` | Google provider |
+| Env var                        | Purpose            |
+| ------------------------------ | ------------------ |
+| `OPENAI_API_KEY`               | OpenAI provider    |
+| `ANTHROPIC_API_KEY`            | Anthropic provider |
+| `GOOGLE_GENERATIVE_AI_API_KEY` | Google provider    |
 
 ---
 
 ## Retry model split (document only)
 
-| Mechanism | Default | Where |
-|-----------|---------|--------|
-| `agent_work_items.max_attempts` | `3` | SQL migration `001_agent_work.sql` |
-| pg-boss `QUEUE_RETRY_LIMIT` | `3` | `src/agentWork/boss.ts` |
+| Mechanism                       | Default | Where                              |
+| ------------------------------- | ------- | ---------------------------------- |
+| `agent_work_items.max_attempts` | `3`     | SQL migration `001_agent_work.sql` |
+| pg-boss `QUEUE_RETRY_LIMIT`     | `3`     | `src/agentWork/boss.ts`            |
 
 These are related but not wired together on INSERT today.
 
@@ -83,83 +83,92 @@ These are related but not wired together on INSERT today.
 
 ### Agent work (queues)
 
-| Symbol | Value / role |
-|--------|----------------|
-| `ACK_QUEUE` | `agent-work-ack` |
-| `REVIEW_QUEUE` | `agent-work-review` |
-| `ASK_QUEUE` | `agent-work-ask` |
-| `*_DEAD_LETTER_QUEUE` | DLQ names |
-| `DEFERRED_HEAD_SHA` | worker resolves head SHA |
-| `AUTOMATED_PR_ACTIONS` | opened, synchronize, reopened |
-| `AUTOMATED_REVIEW_LENS` | `review` |
-| `MAX_STORED_COMMENT_TEXT_LEN` | 16384 |
+| Symbol                        | Value / role                  |
+| ----------------------------- | ----------------------------- |
+| `ACK_QUEUE`                   | `agent-work-ack`              |
+| `REVIEW_QUEUE`                | `agent-work-review`           |
+| `ASK_QUEUE`                   | `agent-work-ask`              |
+| `*_DEAD_LETTER_QUEUE`         | DLQ names                     |
+| `DEFERRED_HEAD_SHA`           | worker resolves head SHA      |
+| `AUTOMATED_PR_ACTIONS`        | opened, synchronize, reopened |
+| `AUTOMATED_REVIEW_LENS`       | `review`                      |
+| `MAX_STORED_COMMENT_TEXT_LEN` | 16384                         |
 
 ### Review output
 
-| Symbol | Role |
-|--------|------|
-| `REVIEW_SUMMARY_SENTINEL` | PR conversation summary marker |
-| `SECURITY_REVIEW_SUMMARY_SENTINEL` | Security summary marker |
-| `REVIEW_POINTER_BODY` / `SECURITY_REVIEW_POINTER_BODY` | Files-tab pointer text |
-| `REVIEW_POINTER_BODY_MAX_CHARS` | 60000 |
-| `MAX_REVIEW_FOLLOW_UPS` | 5 |
-| `REVIEW_EFFORT_MIN` / `REVIEW_EFFORT_MAX` | 1–5 |
-| `REVIEW_SEVERITY_RANK` | P0–P3 ordering |
-| Label prefixes | `LABEL_REVIEW_EFFORT_PREFIX`, `LABEL_SECURITY_CONCERN` |
+| Symbol                                                               | Role                                                   |
+| -------------------------------------------------------------------- | ------------------------------------------------------ |
+| `REVIEW_SUMMARY_SENTINEL`                                            | PR conversation summary marker                         |
+| `SECURITY_REVIEW_SUMMARY_SENTINEL`                                   | Security summary marker                                |
+| `REVIEW_POINTER_BODY` / `SECURITY_REVIEW_POINTER_BODY`               | Files-tab pointer text (repeat no-bugs fallback)       |
+| `REVIEW_POINTER_NOTE_LEAD`                                           | First-publish pointer NOTE body                        |
+| `REVIEW_POINTER_BODY_MAX_CHARS`                                      | 60000                                                  |
+| `REVIEW_EFFORT_WORDS`                                                | Light → Heavy labels for effort row                    |
+| `REVIEW_OVERVIEW_ALERT` / `REVIEW_FAILURE_ALERT`                     | GitHub alert types (`NOTE`, `CAUTION`)                 |
+| `REVIEW_PROGRESS_NOTE`                                               | In-progress NOTE body                                  |
+| `REVIEW_PROGRESS_SOURCE_AUTO` / `REVIEW_PROGRESS_SOURCE_SLASH`       | Progress table source labels                           |
+| `REVIEW_FINDING_FOOTNOTE_INLINE` / `REVIEW_FINDING_FOOTNOTE_SUMMARY` | Finding row footnotes                                  |
+| `REVIEW_FINDINGS_NONE`                                               | Empty findings table cell                              |
+| `REVIEW_SECURITY_DEFAULT`                                            | Default security row when null                         |
+| `AGENT_FIX_PROMPT_ACCORDION_SUMMARY`                                 | Pointer accordion title                                |
+| `MAX_REVIEW_FOLLOW_UPS`                                              | 5                                                      |
+| `REVIEW_EFFORT_MIN` / `REVIEW_EFFORT_MAX`                            | 1–5                                                    |
+| `REVIEW_SEVERITY_RANK`                                               | P0–P3 ordering                                         |
+| Label prefixes                                                       | `LABEL_REVIEW_EFFORT_PREFIX`, `LABEL_SECURITY_CONCERN` |
 
 ### Review / ask agent loops
 
-| Symbol | Default |
-|--------|---------|
-| `RATE_LIMIT_CIRCUIT_THRESHOLD` | 3 |
-| `VALIDATION_REPAIR_ROUNDS` | 3 |
-| `PUBLISH_RECOVERY_ROUNDS` | 4 |
-| `ASK_RETRY_ROUNDS` | 4 |
-| `PUBLISH_RECOVERY_PROMPTS` | recovery nudge strings |
-| `REVIEW_*_CIRCUIT_OPEN_*` | rate-limit circuit messages |
-| `ASK_*_CIRCUIT_OPEN_*` | ask circuit messages |
-| `PUBLISH_BUDGET_EXHAUSTED_MESSAGE` | submitReview guard |
+| Symbol                             | Default                     |
+| ---------------------------------- | --------------------------- |
+| `RATE_LIMIT_CIRCUIT_THRESHOLD`     | 3                           |
+| `VALIDATION_REPAIR_ROUNDS`         | 3                           |
+| `PUBLISH_RECOVERY_ROUNDS`          | 4                           |
+| `ASK_RETRY_ROUNDS`                 | 4                           |
+| `PUBLISH_RECOVERY_PROMPTS`         | recovery nudge strings      |
+| `REVIEW_*_CIRCUIT_OPEN_*`          | rate-limit circuit messages |
+| `ASK_*_CIRCUIT_OPEN_*`             | ask circuit messages        |
+| `PUBLISH_BUDGET_EXHAUSTED_MESSAGE` | submitReview guard          |
 
 ### Ask safety
 
-| Symbol | Default |
-|--------|---------|
-| `MAX_ASK_QUESTION_CHARS` | 8192 |
-| `ASK_META_REFUSAL` | meta-probe reply |
-| `BOT_META_PATTERNS` | regex set |
-| `BOT_SECRET_PATTERNS` | outbound redaction |
-| `SENSITIVE_PATH_PATTERNS` | path gate |
-| `ASK_TOOLS_WITH_OWNER_REPO` / `ASK_TOOLS_WITH_PULL_NUMBER` | tool scope sets |
+| Symbol                                                     | Default            |
+| ---------------------------------------------------------- | ------------------ |
+| `MAX_ASK_QUESTION_CHARS`                                   | 8192               |
+| `ASK_META_REFUSAL`                                         | meta-probe reply   |
+| `BOT_META_PATTERNS`                                        | regex set          |
+| `BOT_SECRET_PATTERNS`                                      | outbound redaction |
+| `SENSITIVE_PATH_PATTERNS`                                  | path gate          |
+| `ASK_TOOLS_WITH_OWNER_REPO` / `ASK_TOOLS_WITH_PULL_NUMBER` | tool scope sets    |
 
 ### GitHub API
 
-| Symbol | Default |
-|--------|---------|
-| `TOKEN_FRESHNESS_BUFFER_MS` | 60000 |
-| `INSTALLATION_TOKEN_FALLBACK_TTL_MS` | 1h |
-| `DEFAULT_COOLDOWN_SECONDS` | 60 |
-| `PRIMARY_RATE_LIMIT_MAX_RETRIES` | 2 |
-| `COMMENTS_PAGE_SIZE` | 100 |
-| `GITHUB_REACTION_EYES` | eyes |
+| Symbol                               | Default |
+| ------------------------------------ | ------- |
+| `TOKEN_FRESHNESS_BUFFER_MS`          | 60000   |
+| `INSTALLATION_TOKEN_FALLBACK_TTL_MS` | 1h      |
+| `DEFAULT_COOLDOWN_SECONDS`           | 60      |
+| `PRIMARY_RATE_LIMIT_MAX_RETRIES`     | 2       |
+| `COMMENTS_PAGE_SIZE`                 | 100     |
+| `GITHUB_REACTION_EYES`               | eyes    |
 
 ### Cursor SDK bridge
 
-| Symbol | Default |
-|--------|---------|
-| `CURSOR_MCP_BIND_HOST` | 127.0.0.1 |
-| `CURSOR_MCP_TOKEN_BYTES` | 32 |
-| `CURSOR_MCP_SERVER_START_TIMEOUT_MS` | 5000 |
-| `CURSOR_MAX_PORT_RETRIES` | 5 |
-| `CURSOR_MCP_SERVER_NAME` | pr-agent |
+| Symbol                               | Default   |
+| ------------------------------------ | --------- |
+| `CURSOR_MCP_BIND_HOST`               | 127.0.0.1 |
+| `CURSOR_MCP_TOKEN_BYTES`             | 32        |
+| `CURSOR_MCP_SERVER_START_TIMEOUT_MS` | 5000      |
+| `CURSOR_MAX_PORT_RETRIES`            | 5         |
+| `CURSOR_MCP_SERVER_NAME`             | pr-agent  |
 
 ### Other
 
-| Symbol | Role |
-|--------|------|
-| `CONTEXT7_BASE_URL` | Context7 API |
-| `PUBLIC_OUTPUT_BANNED_PATTERNS` | sanitizer |
-| `MAX_LOG_MESSAGE_LEN` | 2000 |
-| `SLASH_HELP_BODY` | `/help` text |
-| `MIGRATIONS_DIR_NAME` | `migrations` |
+| Symbol                          | Role         |
+| ------------------------------- | ------------ |
+| `CONTEXT7_BASE_URL`             | Context7 API |
+| `PUBLIC_OUTPUT_BANNED_PATTERNS` | sanitizer    |
+| `MAX_LOG_MESSAGE_LEN`           | 2000         |
+| `SLASH_HELP_BODY`               | `/help` text |
+| `MIGRATIONS_DIR_NAME`           | `migrations` |
 
 Prompt prose (investigator contracts) remains in `src/agent/reviewPromptBlocks.ts` and `src/agent/securityPrompt.ts`.

--- a/src/agent/reviewRender.ts
+++ b/src/agent/reviewRender.ts
@@ -1,4 +1,10 @@
 import {
+  escapeTableCell,
+  escapeTableCellContent,
+  escapeTableHtml,
+  renderGitHubAlert,
+} from "../github/markdownFormat.js";
+import {
   AGENT_FIX_PROMPT_ACCORDION_SUMMARY,
   AGENT_FIX_PROMPT_PREAMBLE,
   AGENT_FIX_PROMPT_TRUNCATION_SUFFIX,
@@ -39,29 +45,9 @@ export type RenderContext = ReviewPublishContext & {
   maxFindings: number;
 };
 
-function escapeTableCell(text: string): string {
-  return text.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
-}
-
 /** Prevent model-authored text from closing a surrounding markdown code fence. */
 function escapeCodeFenceBreakers(text: string): string {
   return text.replace(/```/g, "\\`\\`\\`");
-}
-
-function escapeTableHtml(text: string): string {
-  return text.replace(/</g, "&lt;").replace(/>/g, "&gt;");
-}
-
-export function escapeAlertBody(text: string): string {
-  return text
-    .replace(/\r\n/g, "\n")
-    .split("\n")
-    .map((line) => `> ${line.replace(/^>/, "\\>")}`)
-    .join("\n");
-}
-
-export function renderGitHubAlert(alertType: string, body: string): string {
-  return `> [!${alertType}]\n${escapeAlertBody(body)}`;
 }
 
 function blobLineUrl(ctx: RenderContext, file: string, startLine: number, endLine: number): string {
@@ -107,14 +93,22 @@ function formatLineRange(startLine: number, endLine: number): string {
   return startLine === endLine ? `line ${startLine}` : `lines ${startLine}-${endLine}`;
 }
 
+function compareFindingsBySeverityFileLine(a: ReviewFinding, b: ReviewFinding): number {
+  const bySeverity = REVIEW_SEVERITY_RANK[a.severity] - REVIEW_SEVERITY_RANK[b.severity];
+  if (bySeverity !== 0) return bySeverity;
+  const byFile = a.file.localeCompare(b.file);
+  if (byFile !== 0) return byFile;
+  return a.startLine - b.startLine;
+}
+
+function sortPlacements(placements: readonly InlinePlacement[]): InlinePlacement[] {
+  return [...placements].toSorted((a, b) =>
+    compareFindingsBySeverityFileLine(a.finding, b.finding),
+  );
+}
+
 function sortFindingsForAgentFixPrompt(findings: ReviewFinding[]): ReviewFinding[] {
-  return [...findings].toSorted((a, b) => {
-    const bySeverity = REVIEW_SEVERITY_RANK[a.severity] - REVIEW_SEVERITY_RANK[b.severity];
-    if (bySeverity !== 0) return bySeverity;
-    const byFile = a.file.localeCompare(b.file);
-    if (byFile !== 0) return byFile;
-    return a.startLine - b.startLine;
-  });
+  return [...findings].toSorted(compareFindingsBySeverityFileLine);
 }
 
 export function renderFindingFixBlock(
@@ -142,13 +136,6 @@ export function renderFindingFixBlock(
   return lines.join("\n");
 }
 
-function renderAgentFixFindingBlock(
-  finding: ReviewFinding,
-  opts: { inlinePosted: boolean; inlineCapEligible?: boolean },
-): string {
-  return renderFindingFixBlock(finding, opts);
-}
-
 export function renderSingleFindingAgentFixPrompt(
   finding: ReviewFinding,
   ctx: RenderContext,
@@ -164,10 +151,10 @@ export function renderSingleFindingAgentFixPrompt(
   ].join("\n");
 }
 
-function renderSummaryOnlyFixAccordion(fixPrompt: string): string[] {
+function renderSummaryOnlyFixAccordion(finding: ReviewFinding, fixPrompt: string): string[] {
   return [
     "<details>",
-    "<summary>Prompt to fix</summary>",
+    `<summary>Prompt to fix — ${finding.severity} · ${escapeTableCell(finding.title)}</summary>`,
     "",
     "```",
     escapeCodeFenceBreakers(fixPrompt),
@@ -177,20 +164,24 @@ function renderSummaryOnlyFixAccordion(fixPrompt: string): string[] {
   ];
 }
 
-function renderFindingTableCell(placement: InlinePlacement, ctx: RenderContext): string {
+type SanitizedFindingFields = {
+  title: string;
+  detail: string;
+  fixPrompt?: string;
+};
+
+function renderFindingTableCell(
+  placement: InlinePlacement,
+  ctx: RenderContext,
+  safeFinding: SanitizedFindingFields,
+): string {
   const f = placement.finding;
-  const safeFinding = sanitizePublicReviewFields({
-    title: f.title,
-    detail: f.detail,
-    fixPrompt: f.fixPrompt,
-  });
-  const title = safeFinding.title ?? f.title;
   const link = blobLineUrl(ctx, f.file, f.startLine, f.endLine);
   const marker = placement.inlinePosted ? "On the diff" : "Summary only";
   const meta = `_${escapeTableCell(marker)} · \`${escapeTableHtml(f.file)}\` · ${formatLineRange(f.startLine, f.endLine)}_`;
-  const parts = [`**[${escapeTableCell(title)}](${link})**`, meta];
+  const parts = [`**[${escapeTableCell(safeFinding.title)}](${link})**`, meta];
   if (!placement.inlinePosted) {
-    parts.push(escapeTableHtml(safeFinding.detail ?? f.detail));
+    parts.push(escapeTableCellContent(safeFinding.detail));
   }
   parts.push(
     `_${placement.inlinePosted ? REVIEW_FINDING_FOOTNOTE_INLINE : REVIEW_FINDING_FOOTNOTE_SUMMARY}_`,
@@ -250,7 +241,7 @@ export function renderAgentFixPrompt(
       fixPrompt: safe.fixPrompt ?? f.fixPrompt,
     };
     const placement = placementByFinding.get(f);
-    return renderAgentFixFindingBlock(sanitizedFinding, {
+    return renderFindingFixBlock(sanitizedFinding, {
       inlinePosted: placement?.inlinePosted ?? false,
       inlineCapEligible: placement?.inlineCapEligible,
     });
@@ -350,14 +341,7 @@ export function renderReviewSummaryComment(
     securityConcerns: payload.securityConcerns,
     followUps: payload.followUps,
   });
-  const sortedPlacements = [...ctx.placements].toSorted((a, b) => {
-    const bySeverity =
-      REVIEW_SEVERITY_RANK[a.finding.severity] - REVIEW_SEVERITY_RANK[b.finding.severity];
-    if (bySeverity !== 0) return bySeverity;
-    const byFile = a.finding.file.localeCompare(b.finding.file);
-    if (byFile !== 0) return byFile;
-    return a.finding.startLine - b.finding.startLine;
-  });
+  const sortedPlacements = sortPlacements(ctx.placements);
 
   const rows: string[] = [];
   rows.push(ctx.summarySentinel);
@@ -373,13 +357,34 @@ export function renderReviewSummaryComment(
   rows.push("| --- | --- |");
   rows.push(`| **Effort** | ${formatEffortLabel(payload.estimatedEffort)} |`);
 
+  const summaryOnlyAccordions: string[] = [];
+
   if (sortedPlacements.length === 0) {
     rows.push(`| **Findings** | ${REVIEW_FINDINGS_NONE} |`);
   } else {
     for (const placement of sortedPlacements) {
+      const safeFinding = sanitizePublicReviewFields({
+        title: placement.finding.title,
+        detail: placement.finding.detail,
+        fixPrompt: placement.finding.fixPrompt,
+      });
+      const sanitized = {
+        title: safeFinding.title ?? placement.finding.title,
+        detail: safeFinding.detail ?? placement.finding.detail,
+        fixPrompt: safeFinding.fixPrompt ?? placement.finding.fixPrompt,
+      };
       rows.push(
-        `| **${placement.finding.severity}** | ${renderFindingTableCell(placement, ctx)} |`,
+        `| **${placement.finding.severity}** | ${renderFindingTableCell(placement, ctx, sanitized)} |`,
       );
+      if (
+        !placement.inlinePosted &&
+        sanitized.fixPrompt != null &&
+        sanitized.fixPrompt.length > 0
+      ) {
+        summaryOnlyAccordions.push(
+          ...renderSummaryOnlyFixAccordion(placement.finding, sanitized.fixPrompt),
+        );
+      }
     }
   }
 
@@ -395,17 +400,6 @@ export function renderReviewSummaryComment(
   const followUps = safePayload.followUps ?? payload.followUps;
   for (const item of followUps) {
     rows.push(`| **Follow-ups** | ${escapeTableCell(item)} |`);
-  }
-
-  const summaryOnlyAccordions: string[] = [];
-  for (const placement of sortedPlacements) {
-    if (placement.inlinePosted) continue;
-    const safeFinding = sanitizePublicReviewFields({
-      fixPrompt: placement.finding.fixPrompt,
-    });
-    const fixPrompt = safeFinding.fixPrompt ?? placement.finding.fixPrompt;
-    if (!fixPrompt || fixPrompt.length === 0) continue;
-    summaryOnlyAccordions.push(...renderSummaryOnlyFixAccordion(fixPrompt));
   }
 
   if (summaryOnlyAccordions.length > 0) {

--- a/src/agent/reviewRender.ts
+++ b/src/agent/reviewRender.ts
@@ -151,10 +151,14 @@ export function renderSingleFindingAgentFixPrompt(
   ].join("\n");
 }
 
-function renderSummaryOnlyFixAccordion(finding: ReviewFinding, fixPrompt: string): string[] {
+function renderSummaryOnlyFixAccordion(
+  severity: ReviewFinding["severity"],
+  title: string,
+  fixPrompt: string,
+): string[] {
   return [
     "<details>",
-    `<summary>Prompt to fix — ${finding.severity} · ${escapeTableCell(finding.title)}</summary>`,
+    `<summary>Prompt to fix — ${severity} · ${escapeTableHtml(title)}</summary>`,
     "",
     "```",
     escapeCodeFenceBreakers(fixPrompt),
@@ -382,7 +386,11 @@ export function renderReviewSummaryComment(
         sanitized.fixPrompt.length > 0
       ) {
         summaryOnlyAccordions.push(
-          ...renderSummaryOnlyFixAccordion(placement.finding, sanitized.fixPrompt),
+          ...renderSummaryOnlyFixAccordion(
+            placement.finding.severity,
+            sanitized.title,
+            sanitized.fixPrompt,
+          ),
         );
       }
     }

--- a/src/agent/reviewRender.ts
+++ b/src/agent/reviewRender.ts
@@ -3,8 +3,15 @@ import {
   AGENT_FIX_PROMPT_PREAMBLE,
   AGENT_FIX_PROMPT_TRUNCATION_SUFFIX,
   REPEAT_NO_BUGS_PREFIX,
+  REVIEW_EFFORT_WORDS,
+  REVIEW_FINDING_FOOTNOTE_INLINE,
+  REVIEW_FINDING_FOOTNOTE_SUMMARY,
+  REVIEW_FINDINGS_NONE,
+  REVIEW_OVERVIEW_ALERT,
   REVIEW_POINTER_BODY,
   REVIEW_POINTER_BODY_MAX_CHARS,
+  REVIEW_POINTER_NOTE_LEAD,
+  REVIEW_SECURITY_DEFAULT,
   REVIEW_SEVERITY_RANK,
   SECURITY_REVIEW_POINTER_BODY,
 } from "../settings/index.js";
@@ -24,6 +31,7 @@ export {
   REPEAT_NO_BUGS_PREFIX,
   REVIEW_POINTER_BODY,
   REVIEW_POINTER_BODY_MAX_CHARS,
+  REVIEW_POINTER_NOTE_LEAD,
   SECURITY_REVIEW_POINTER_BODY,
 } from "../settings/index.js";
 
@@ -40,6 +48,22 @@ function escapeCodeFenceBreakers(text: string): string {
   return text.replace(/```/g, "\\`\\`\\`");
 }
 
+function escapeTableHtml(text: string): string {
+  return text.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+export function escapeAlertBody(text: string): string {
+  return text
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .map((line) => `> ${line.replace(/^>/, "\\>")}`)
+    .join("\n");
+}
+
+export function renderGitHubAlert(alertType: string, body: string): string {
+  return `> [!${alertType}]\n${escapeAlertBody(body)}`;
+}
+
 function blobLineUrl(ctx: RenderContext, file: string, startLine: number, endLine: number): string {
   const lineAnchor = startLine === endLine ? `L${startLine}` : `L${startLine}-L${endLine}`;
   return `https://github.com/${ctx.owner}/${ctx.repo}/blob/${ctx.headSha}/${file}#${lineAnchor}`;
@@ -54,14 +78,9 @@ export function issueCommentUrl(
   return `https://github.com/${owner}/${repo}/pull/${prNumber}#issuecomment-${commentId}`;
 }
 
-function effortBar(n: number): string {
-  const filled = "🔵".repeat(n);
-  const empty = "⚪".repeat(5 - n);
-  return filled + empty;
-}
-
-function severityBadge(severity: ReviewFinding["severity"]): string {
-  return `**${severity}**`;
+export function formatEffortLabel(effort: number): string {
+  const word = REVIEW_EFFORT_WORDS[effort - 1] ?? REVIEW_EFFORT_WORDS[2];
+  return `${word} · \`${effort}/5\``;
 }
 
 export function reviewPointerBodyForMode(mode: ReviewMode): string {
@@ -145,6 +164,40 @@ export function renderSingleFindingAgentFixPrompt(
   ].join("\n");
 }
 
+function renderSummaryOnlyFixAccordion(fixPrompt: string): string[] {
+  return [
+    "<details>",
+    "<summary>Prompt to fix</summary>",
+    "",
+    "```",
+    escapeCodeFenceBreakers(fixPrompt),
+    "```",
+    "",
+    "</details>",
+  ];
+}
+
+function renderFindingTableCell(placement: InlinePlacement, ctx: RenderContext): string {
+  const f = placement.finding;
+  const safeFinding = sanitizePublicReviewFields({
+    title: f.title,
+    detail: f.detail,
+    fixPrompt: f.fixPrompt,
+  });
+  const title = safeFinding.title ?? f.title;
+  const link = blobLineUrl(ctx, f.file, f.startLine, f.endLine);
+  const marker = placement.inlinePosted ? "On the diff" : "Summary only";
+  const meta = `_${escapeTableCell(marker)} · \`${escapeTableHtml(f.file)}\` · ${formatLineRange(f.startLine, f.endLine)}_`;
+  const parts = [`**[${escapeTableCell(title)}](${link})**`, meta];
+  if (!placement.inlinePosted) {
+    parts.push(escapeTableHtml(safeFinding.detail ?? f.detail));
+  }
+  parts.push(
+    `_${placement.inlinePosted ? REVIEW_FINDING_FOOTNOTE_INLINE : REVIEW_FINDING_FOOTNOTE_SUMMARY}_`,
+  );
+  return parts.join("<br>");
+}
+
 export function renderInlineThreadBody(finding: ReviewFinding, ctx: RenderContext): string {
   const safe = sanitizePublicReviewFields({
     title: finding.title,
@@ -158,7 +211,9 @@ export function renderInlineThreadBody(finding: ReviewFinding, ctx: RenderContex
     fixPrompt: safe.fixPrompt ?? finding.fixPrompt,
   };
   const lines = [
-    `[${sanitizedFinding.severity}] ${sanitizedFinding.title}`,
+    `**${sanitizedFinding.severity}** · **${sanitizedFinding.title}**`,
+    "",
+    `\`${sanitizedFinding.file}\` · ${formatLineRange(sanitizedFinding.startLine, sanitizedFinding.endLine)}`,
     "",
     sanitizedFinding.detail,
     "",
@@ -214,6 +269,13 @@ export function renderAgentFixPrompt(
   ].join("\n");
 }
 
+function renderPointerLead(mode: ReviewMode, summaryCommentUrl?: string): string {
+  if (summaryCommentUrl) {
+    return renderReviewPointerLine(mode, summaryCommentUrl);
+  }
+  return renderGitHubAlert(REVIEW_OVERVIEW_ALERT, REVIEW_POINTER_NOTE_LEAD);
+}
+
 function assembleReviewPointerBody(pointerLine: string, agentFixPrompt: string): string {
   return [
     pointerLine,
@@ -260,7 +322,7 @@ export function renderReviewPointerBody(
     placements: readonly InlinePlacement[];
   },
 ): { body: string; truncated: boolean } {
-  const pointerLine = renderReviewPointerLine(ctx.mode, ctx.summaryCommentUrl);
+  const pointerLine = renderPointerLead(ctx.mode, ctx.summaryCommentUrl);
   let agentFixPrompt = renderAgentFixPrompt(payload, ctx, ctx.placements);
   let truncated = false;
 
@@ -289,7 +351,8 @@ export function renderReviewSummaryComment(
     followUps: payload.followUps,
   });
   const sortedPlacements = [...ctx.placements].toSorted((a, b) => {
-    const bySeverity = REVIEW_SEVERITY_RANK[a.finding.severity] - REVIEW_SEVERITY_RANK[b.finding.severity];
+    const bySeverity =
+      REVIEW_SEVERITY_RANK[a.finding.severity] - REVIEW_SEVERITY_RANK[b.finding.severity];
     if (bySeverity !== 0) return bySeverity;
     const byFile = a.finding.file.localeCompare(b.finding.file);
     if (byFile !== 0) return byFile;
@@ -299,69 +362,55 @@ export function renderReviewSummaryComment(
   const rows: string[] = [];
   rows.push(ctx.summarySentinel);
   rows.push("");
-  rows.push(escapeTableCell((safePayload.prCharacter ?? payload.prCharacter).trim()));
+  rows.push(
+    renderGitHubAlert(
+      REVIEW_OVERVIEW_ALERT,
+      (safePayload.prCharacter ?? payload.prCharacter).trim(),
+    ),
+  );
   rows.push("");
   rows.push("| | |");
   rows.push("| --- | --- |");
-  rows.push(`| Effort | ${effortBar(payload.estimatedEffort)} (${payload.estimatedEffort}/5) |`);
-  rows.push(`| Relevant tests | ${payload.relevantTests} |`);
+  rows.push(`| **Effort** | ${formatEffortLabel(payload.estimatedEffort)} |`);
+
+  if (sortedPlacements.length === 0) {
+    rows.push(`| **Findings** | ${REVIEW_FINDINGS_NONE} |`);
+  } else {
+    for (const placement of sortedPlacements) {
+      rows.push(
+        `| **${placement.finding.severity}** | ${renderFindingTableCell(placement, ctx)} |`,
+      );
+    }
+  }
+
+  rows.push(`| **Relevant tests** | ${payload.relevantTests} |`);
   rows.push(
-    `| Security | ${
+    `| **Security** | ${
       safePayload.securityConcerns != null
         ? escapeTableCell(safePayload.securityConcerns)
-        : "No security concerns identified"
+        : REVIEW_SECURITY_DEFAULT
     } |`,
   );
 
   const followUps = safePayload.followUps ?? payload.followUps;
-  if (followUps.length > 0) {
-    rows.push("| Follow-ups | |");
-    for (const item of followUps) {
-      rows.push(`| | ${escapeTableCell(item)} |`);
-    }
+  for (const item of followUps) {
+    rows.push(`| **Follow-ups** | ${escapeTableCell(item)} |`);
   }
 
-  if (sortedPlacements.length === 0) {
-    rows.push("");
-    rows.push("_No findings._");
-    return rows.join("\n");
-  }
-
-  rows.push("");
-  rows.push("### Findings");
-  rows.push("");
-
+  const summaryOnlyAccordions: string[] = [];
   for (const placement of sortedPlacements) {
-    const f = placement.finding;
+    if (placement.inlinePosted) continue;
     const safeFinding = sanitizePublicReviewFields({
-      title: f.title,
-      detail: f.detail,
-      fixPrompt: f.fixPrompt,
+      fixPrompt: placement.finding.fixPrompt,
     });
-    const link = blobLineUrl(ctx, f.file, f.startLine, f.endLine);
-    const marker = placement.inlinePosted ? "Inline thread posted" : "Summary only";
-    rows.push(`#### ${severityBadge(f.severity)} [${safeFinding.title ?? f.title}](${link})`);
+    const fixPrompt = safeFinding.fixPrompt ?? placement.finding.fixPrompt;
+    if (!fixPrompt || fixPrompt.length === 0) continue;
+    summaryOnlyAccordions.push(...renderSummaryOnlyFixAccordion(fixPrompt));
+  }
+
+  if (summaryOnlyAccordions.length > 0) {
     rows.push("");
-    rows.push(`_${marker}_ · \`${f.file}\` · ${formatLineRange(f.startLine, f.endLine)}`);
-    rows.push("");
-    rows.push(safeFinding.detail ?? f.detail);
-    if (safeFinding.fixPrompt && safeFinding.fixPrompt.length > 0) {
-      if (placement.inlinePosted) {
-        rows.push("");
-        rows.push("_See inline thread for fix prompt._");
-      } else {
-        rows.push("");
-        rows.push("<details>");
-        rows.push("<summary>Prompt to fix</summary>");
-        rows.push("");
-        rows.push("```");
-        rows.push(escapeCodeFenceBreakers(safeFinding.fixPrompt));
-        rows.push("```");
-        rows.push("");
-        rows.push("</details>");
-      }
-    }
-    rows.push("");
+    rows.push(...summaryOnlyAccordions);
   }
 
   return rows.join("\n").trimEnd();

--- a/src/agentWork/progressComment.ts
+++ b/src/agentWork/progressComment.ts
@@ -1,18 +1,29 @@
+import { renderGitHubAlert } from "../agent/reviewRender.js";
 import { reviewSummarySentinelForMode, type ReviewMode } from "../agent/reviewSchema.js";
+import {
+  REVIEW_FAILURE_ALERT,
+  REVIEW_OVERVIEW_ALERT,
+  REVIEW_PROGRESS_NOTE,
+  REVIEW_PROGRESS_SOURCE_AUTO,
+  REVIEW_PROGRESS_SOURCE_SLASH,
+} from "../settings/index.js";
 
 export function renderReviewProgressComment(params: {
   mode: ReviewMode;
   headSha: string;
   source: "auto" | "slash";
 }): string {
-  const lens = params.mode === "review-security" ? "security review" : "review";
+  const sourceLabel =
+    params.source === "auto" ? REVIEW_PROGRESS_SOURCE_AUTO : REVIEW_PROGRESS_SOURCE_SLASH;
   return [
     reviewSummarySentinelForMode(params.mode),
     "",
-    `_PR Agent ${lens} in progress._`,
+    renderGitHubAlert(REVIEW_OVERVIEW_ALERT, REVIEW_PROGRESS_NOTE),
     "",
-    `Head SHA: \`${params.headSha}\``,
-    `Source: ${params.source === "auto" ? "automated pull request event" : "slash command"}`,
+    "| | |",
+    "| --- | --- |",
+    `| **Head** | \`${params.headSha}\` |`,
+    `| **Source** | ${sourceLabel} |`,
   ].join("\n");
 }
 
@@ -23,9 +34,10 @@ export function renderReviewFailureNotice(params: {
   return [
     reviewSummarySentinelForMode(params.mode),
     "",
-    `_PR Agent could not complete this ${params.mode === "review-security" ? "security review" : "review"}._`,
-    "",
-    `Please retry with \`${params.retryCommand}\`.`,
+    renderGitHubAlert(
+      REVIEW_FAILURE_ALERT,
+      `Review did not finish. Run \`${params.retryCommand}\` to try again.`,
+    ),
   ].join("\n");
 }
 

--- a/src/agentWork/progressComment.ts
+++ b/src/agentWork/progressComment.ts
@@ -1,4 +1,4 @@
-import { renderGitHubAlert } from "../agent/reviewRender.js";
+import { renderGitHubAlert } from "../github/markdownFormat.js";
 import { reviewSummarySentinelForMode, type ReviewMode } from "../agent/reviewSchema.js";
 import {
   REVIEW_FAILURE_ALERT,

--- a/src/github/markdownFormat.ts
+++ b/src/github/markdownFormat.ts
@@ -1,0 +1,24 @@
+/** GFM table cell: escape pipes/newlines, then HTML-sensitive characters. */
+export function escapeTableCell(text: string): string {
+  return text.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+}
+
+export function escapeTableHtml(text: string): string {
+  return text.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+export function escapeTableCellContent(text: string): string {
+  return escapeTableHtml(escapeTableCell(text));
+}
+
+export function escapeAlertBody(text: string): string {
+  return text
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .map((line) => `> ${line.replace(/^>/, "\\>")}`)
+    .join("\n");
+}
+
+export function renderGitHubAlert(alertType: string, body: string): string {
+  return `> [!${alertType}]\n${escapeAlertBody(body)}`;
+}

--- a/src/settings/constants.ts
+++ b/src/settings/constants.ts
@@ -23,10 +23,30 @@ export const SECURITY_REVIEW_POINTER_BODY =
 export const REPEAT_NO_BUGS_PREFIX = "No bugs found";
 export const AGENT_FIX_PROMPT_PREAMBLE =
   "Verify each finding against current code. Fix only still-valid issues, skip the rest with a brief reason, keep changes minimal, and validate.";
-export const AGENT_FIX_PROMPT_ACCORDION_SUMMARY = "Prompt for AI agents to fix all review findings";
+export const AGENT_FIX_PROMPT_ACCORDION_SUMMARY = "Fix all findings (agent prompt)";
 export const REVIEW_POINTER_BODY_MAX_CHARS = 60_000;
 export const AGENT_FIX_PROMPT_TRUNCATION_SUFFIX =
   "\n...[truncated; see inline threads and PR summary]";
+
+/** Review comment formatting (GitHub markdown). */
+export const REVIEW_EFFORT_WORDS = [
+  "Light",
+  "Moderate",
+  "Moderate",
+  "Substantial",
+  "Heavy",
+] as const;
+export const REVIEW_OVERVIEW_ALERT = "NOTE";
+export const REVIEW_FAILURE_ALERT = "CAUTION";
+export const REVIEW_PROGRESS_NOTE = "Review in progress on the latest commit.";
+export const REVIEW_FINDING_FOOTNOTE_INLINE = "Fix prompt on the inline thread.";
+export const REVIEW_FINDING_FOOTNOTE_SUMMARY = "Expand Prompt to fix below (summary-only).";
+export const REVIEW_FINDINGS_NONE = "No issues on this pass.";
+export const REVIEW_POINTER_NOTE_LEAD =
+  "Full review is in the PR conversation. Expand below to copy fixes for your coding agent.";
+export const REVIEW_SECURITY_DEFAULT = "No security concerns identified";
+export const REVIEW_PROGRESS_SOURCE_AUTO = "Pull request update";
+export const REVIEW_PROGRESS_SOURCE_SLASH = "slash command";
 
 export const MAX_REVIEW_FOLLOW_UPS = 5;
 export const REVIEW_EFFORT_MIN = 1;

--- a/src/settings/constants.ts
+++ b/src/settings/constants.ts
@@ -29,6 +29,7 @@ export const AGENT_FIX_PROMPT_TRUNCATION_SUFFIX =
   "\n...[truncated; see inline threads and PR summary]";
 
 /** Review comment formatting (GitHub markdown). */
+/** Effort 2–3 both map to "Moderate" on the 1–5 scale. */
 export const REVIEW_EFFORT_WORDS = [
   "Light",
   "Moderate",

--- a/test/__snapshots__/reviewRender.test.ts.snap
+++ b/test/__snapshots__/reviewRender.test.ts.snap
@@ -20,7 +20,9 @@ minor typo"
 `;
 
 exports[`renderInlineThreadBody > P0 with fixPrompt accordion 1`] = `
-"[P0] Race on shared map
+"**P0** · **Race on shared map**
+
+\`src/a.ts\` · lines 5-7
 
 Concurrent writes without lock.
 
@@ -42,7 +44,9 @@ Guard the map with a mutex or use Ref.modify.
 `;
 
 exports[`renderInlineThreadBody > P1 with fixPrompt accordion 1`] = `
-"[P1] Missing await
+"**P1** · **Missing await**
+
+\`src/b.ts\` · line 1
 
 Promise not awaited in handler.
 
@@ -64,7 +68,9 @@ Await the promise before returning.
 `;
 
 exports[`renderInlineThreadBody > P2 with fixPrompt accordion 1`] = `
-"[P2] Off-by-one in slice
+"**P2** · **Off-by-one in slice**
+
+\`src/c.ts\` · lines 20-22
 
 End index excludes last element incorrectly.
 
@@ -86,10 +92,11 @@ Adjust slice end index to include the last item.
 `;
 
 exports[`renderReviewPointerBody > wraps agent fix prompt in accordion with pointer line 1`] = `
-"See the structured review summary in the PR conversation.
+"> [!NOTE]
+> Full review is in the PR conversation. Expand below to copy fixes for your coding agent.
 
 <details>
-<summary>Prompt for AI agents to fix all review findings</summary>
+<summary>Fix all findings (agent prompt)</summary>
 
 \`\`\`
 Verify each finding against current code. Fix only still-valid issues, skip the rest with a brief reason, keep changes minimal, and validate.

--- a/test/markdownFormat.test.ts
+++ b/test/markdownFormat.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+  escapeAlertBody,
+  escapeTableCell,
+  escapeTableCellContent,
+  renderGitHubAlert,
+} from "../src/github/markdownFormat.js";
+
+describe("markdownFormat", () => {
+  it("escapeTableCell escapes pipes and newlines", () => {
+    expect(escapeTableCell("a | b\nc")).toBe("a \\| b c");
+  });
+
+  it("escapeTableCellContent applies table then HTML escaping", () => {
+    expect(escapeTableCellContent("a | b\n<script>")).toBe("a \\| b &lt;script&gt;");
+  });
+
+  it("escapeAlertBody handles blank lines and leading gt", () => {
+    expect(escapeAlertBody("line one\n\n> quoted")).toBe("> line one\n> \n> \\> quoted");
+  });
+
+  it("renderGitHubAlert wraps body in alert syntax", () => {
+    expect(renderGitHubAlert("NOTE", "hello")).toBe("> [!NOTE]\n> hello");
+  });
+});

--- a/test/progressComment.test.ts
+++ b/test/progressComment.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, it } from "vitest";
 import {
   renderReviewFailureNotice,
+  renderReviewProgressComment,
   renderStructuredPublishFallback,
 } from "../src/agentWork/progressComment.js";
+import { REVIEW_PROGRESS_NOTE } from "../src/settings/index.js";
 
 describe("progressComment fallback wording", () => {
   it("uses neutral failure notice without attempt counts or server logs", () => {
     const body = renderReviewFailureNotice({ mode: "review", retryCommand: "/review" });
-    expect(body).toContain("could not complete");
+    expect(body).toContain("[!CAUTION]");
+    expect(body).toContain("Review did not finish");
     expect(body).toContain("/review");
     expect(body).not.toMatch(/structured publish/i);
     expect(body).not.toMatch(/server logs/i);
@@ -17,6 +20,20 @@ describe("progressComment fallback wording", () => {
   it("keeps security retry command", () => {
     const body = renderStructuredPublishFallback({ mode: "review-security" });
     expect(body).toContain("/review-security");
+    expect(body).toContain("[!CAUTION]");
     expect(body).not.toMatch(/structured publish/i);
+  });
+
+  it("renders progress with NOTE alert and metadata table", () => {
+    const body = renderReviewProgressComment({
+      mode: "review",
+      headSha: "abc123",
+      source: "auto",
+    });
+    expect(body).toContain("[!NOTE]");
+    expect(body).toContain(REVIEW_PROGRESS_NOTE);
+    expect(body).toContain("**Head**");
+    expect(body).toContain("`abc123`");
+    expect(body).toContain("Pull request update");
   });
 });

--- a/test/publishReview.test.ts
+++ b/test/publishReview.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../src/agent/reviewSchema.js";
 import {
   AGENT_FIX_PROMPT_ACCORDION_SUMMARY,
-  SECURITY_REVIEW_POINTER_BODY,
+  REVIEW_POINTER_NOTE_LEAD,
 } from "../src/agent/reviewRender.js";
 import {
   cachedDiffForFiles,
@@ -252,7 +252,7 @@ describe("publishReview", () => {
       "r",
       1,
       expect.objectContaining({
-        body: expect.stringContaining(SECURITY_REVIEW_POINTER_BODY),
+        body: expect.stringContaining(REVIEW_POINTER_NOTE_LEAD),
       }),
     );
     expect(createPullRequestReviewWithComments).toHaveBeenCalledWith(
@@ -374,7 +374,7 @@ describe("publishReview", () => {
       "r",
       1,
       expect.objectContaining({
-        body: expect.stringContaining("See the structured review summary in the PR conversation."),
+        body: expect.stringContaining(REVIEW_POINTER_NOTE_LEAD),
       }),
     );
   });

--- a/test/reviewRender.test.ts
+++ b/test/reviewRender.test.ts
@@ -196,6 +196,27 @@ describe("renderReviewSummaryComment", () => {
     expect(body).toContain("<summary>Prompt to fix — P2 · Second</summary>");
   });
 
+  it("HTML-escapes summary-only accordion titles", () => {
+    const payload = basePayload({
+      findings: [
+        {
+          severity: "P1",
+          file: "src/x.ts",
+          startLine: 1,
+          endLine: 1,
+          title: "Bug <script>",
+          detail: "d",
+          fixPrompt: "fix",
+        },
+      ],
+    });
+    const body = renderReviewSummaryComment(payload, {
+      ...ctx,
+      placements: testPlacements(payload.findings, { inlinePosted: false }),
+    });
+    expect(body).toContain("<summary>Prompt to fix — P1 · Bug &lt;script&gt;</summary>");
+  });
+
   it("(c) securityConcerns set", () => {
     const payload = basePayload({
       securityConcerns: "Webhook secret compared without timing-safe equal.",

--- a/test/reviewRender.test.ts
+++ b/test/reviewRender.test.ts
@@ -4,6 +4,7 @@ import {
   REPEAT_NO_BUGS_PREFIX,
   REVIEW_POINTER_BODY,
   REVIEW_POINTER_BODY_MAX_CHARS,
+  REVIEW_POINTER_NOTE_LEAD,
   renderAgentFixPrompt,
   renderInlineThreadBody,
   renderRepeatNoBugsReviewBody,
@@ -11,6 +12,7 @@ import {
   renderReviewSummaryComment,
   SECURITY_REVIEW_POINTER_BODY,
 } from "../src/agent/reviewRender.js";
+import { REVIEW_FINDINGS_NONE, REVIEW_FINDING_FOOTNOTE_INLINE } from "../src/settings/index.js";
 import type { ReviewPayload } from "../src/agent/reviewSchema.js";
 import {
   REVIEW_SUMMARY_SENTINEL,
@@ -52,7 +54,10 @@ describe("renderReviewSummaryComment", () => {
       placements: testPlacementsFromPayload(basePayload()),
     });
     expect(body).toContain("## PR Agent Review");
-    expect(body).toContain("_No findings._");
+    expect(body).toContain("[!NOTE]");
+    expect(body).toContain(REVIEW_FINDINGS_NONE);
+    expect(body).not.toContain("_No findings._");
+    expect(body).not.toContain("### Findings");
   });
 
   it("(b) P0 + P3 mix", () => {
@@ -79,14 +84,18 @@ describe("renderReviewSummaryComment", () => {
     });
     const body = renderReviewSummaryComment(payload, {
       ...ctx,
-      placements: testPlacementsFromPayload(payload),
+      placements: [
+        ...testPlacements([payload.findings[0]!]),
+        ...testPlacements([payload.findings[1]!], { inlinePosted: false }),
+      ],
     });
     expect(body).toContain("**P0**");
     expect(body).toContain("Null deref on empty payload");
-    expect(body).toContain("payload is used before guard");
+    expect(body).not.toContain("payload is used before guard");
     expect(body).toContain("Typo in heading");
-    expect(body).toContain("Inline thread posted");
-    expect(body).toContain("See inline thread for fix prompt");
+    expect(body).toContain("minor");
+    expect(body).toContain("Summary only");
+    expect(body).toContain(REVIEW_FINDING_FOOTNOTE_INLINE);
     expect(body).not.toContain("<summary>Prompt to fix</summary>");
   });
 
@@ -130,7 +139,8 @@ describe("renderReviewSummaryComment", () => {
       ...ctx,
       placements: testPlacementsFromPayload(payload),
     });
-    expect(body).toContain("Adds auth \\| breaks table");
+    expect(body).toContain("[!NOTE]");
+    expect(body).toContain("Adds auth | breaks table");
   });
 
   it("uses security sentinel when requested", () => {
@@ -174,7 +184,7 @@ describe("renderReviewSummaryComment", () => {
     });
     const body = renderReviewSummaryComment(payload, {
       ...ctx,
-      placements: testPlacementsFromPayload(payload),
+      placements: testPlacements(payload.findings, { inlinePosted: false }),
     });
 
     expect(body).toContain("Safe overview.");
@@ -458,7 +468,8 @@ describe("renderReviewPointerBody", () => {
       ),
     });
 
-    expect(body).toContain(REVIEW_POINTER_BODY);
+    expect(body).toContain(REVIEW_POINTER_NOTE_LEAD);
+    expect(body).toContain("[!NOTE]");
     expect(body).toContain("[redacted internal details]");
     expect(body).toContain("Fix src/y.ts line 2.");
     expect(body).not.toBe("[redacted internal details]");
@@ -490,7 +501,8 @@ describe("renderReviewPointerBody", () => {
 
     expect(truncated).toBe(false);
     expect(body).toMatchSnapshot();
-    expect(body).toContain(REVIEW_POINTER_BODY);
+    expect(body).toContain(REVIEW_POINTER_NOTE_LEAD);
+    expect(body).toContain("[!NOTE]");
     expect(body).toContain("<details>");
     expect(body).toContain(`<summary>${AGENT_FIX_PROMPT_ACCORDION_SUMMARY}</summary>`);
     expect(body).toContain("Fix src/x.ts line 4.");
@@ -516,7 +528,7 @@ describe("renderReviewPointerBody", () => {
       placements: planInlineFromPayload(payload, renderCtx.maxFindings),
     });
 
-    expect(body).toContain(SECURITY_REVIEW_POINTER_BODY);
+    expect(body).toContain(REVIEW_POINTER_NOTE_LEAD);
     expect(body).toContain("Add auth guard.");
   });
 
@@ -544,7 +556,7 @@ describe("renderReviewPointerBody", () => {
     expect(body).toContain(
       "[View the updated review.](https://github.com/acme/widgets/pull/42#issuecomment-123)",
     );
-    expect(body).not.toContain(REVIEW_POINTER_BODY);
+    expect(body).not.toContain(REVIEW_POINTER_NOTE_LEAD);
   });
 
   it("truncates agent fix prompt when assembled body exceeds max chars", () => {

--- a/test/reviewRender.test.ts
+++ b/test/reviewRender.test.ts
@@ -118,8 +118,82 @@ describe("renderReviewSummaryComment", () => {
       placements: testPlacements(payload.findings, { inlinePosted: false }),
     });
     expect(body).toContain("Summary only");
-    expect(body).toContain("<summary>Prompt to fix</summary>");
+    expect(body).toContain("<summary>Prompt to fix — P1 · Bug</summary>");
     expect(body).toContain("Fix src/x.ts line 4.");
+  });
+
+  it("escapes pipes and newlines in summary-only detail table cells", () => {
+    const payload = basePayload({
+      findings: [
+        {
+          severity: "P1",
+          file: "src/x.ts",
+          startLine: 4,
+          endLine: 4,
+          title: "Bug",
+          detail: "Bad | logic\nsecond line",
+          fixPrompt: "Fix it.",
+        },
+      ],
+    });
+    const body = renderReviewSummaryComment(payload, {
+      ...ctx,
+      placements: testPlacements(payload.findings, { inlinePosted: false }),
+    });
+    expect(body).toContain("Bad \\| logic second line");
+    expect(body).toMatch(/\| \*\*P1\*\* \|/);
+  });
+
+  it("escapes pipes in finding title inside table cells", () => {
+    const payload = basePayload({
+      findings: [
+        {
+          severity: "P2",
+          file: "src/x.ts",
+          startLine: 1,
+          endLine: 1,
+          title: "Bug | typo",
+          detail: "minor",
+          fixPrompt: "Fix title.",
+        },
+      ],
+    });
+    const body = renderReviewSummaryComment(payload, {
+      ...ctx,
+      placements: testPlacements(payload.findings, { inlinePosted: false }),
+    });
+    expect(body).toContain("[Bug \\| typo]");
+  });
+
+  it("labels summary-only accordions by severity and title", () => {
+    const payload = basePayload({
+      findings: [
+        {
+          severity: "P1",
+          file: "src/a.ts",
+          startLine: 1,
+          endLine: 1,
+          title: "First",
+          detail: "d1",
+          fixPrompt: "fix 1",
+        },
+        {
+          severity: "P2",
+          file: "src/b.ts",
+          startLine: 2,
+          endLine: 2,
+          title: "Second",
+          detail: "d2",
+          fixPrompt: "fix 2",
+        },
+      ],
+    });
+    const body = renderReviewSummaryComment(payload, {
+      ...ctx,
+      placements: testPlacements(payload.findings, { inlinePosted: false }),
+    });
+    expect(body).toContain("<summary>Prompt to fix — P1 · First</summary>");
+    expect(body).toContain("<summary>Prompt to fix — P2 · Second</summary>");
   });
 
   it("(c) securityConcerns set", () => {

--- a/test/reviewRun.test.ts
+++ b/test/reviewRun.test.ts
@@ -201,7 +201,7 @@ describe("runFullPrReview mode", () => {
 
     const body = vi.mocked(upsertReviewSummaryComment).mock.calls.at(-1)?.[4] as string;
     expect(body).toContain("## PR Agent Security Review");
-    expect(body).toContain("could not complete");
+    expect(body).toContain("Review did not finish");
     expect(body).not.toMatch(/structured publish/i);
     expect(body).not.toMatch(/server logs/i);
     expect(body).not.toContain("analysis without submitReview");
@@ -237,7 +237,7 @@ describe("runFullPrReview publish retries", () => {
     expect(result.published).toBe(false);
     const body = vi.mocked(upsertReviewSummaryComment).mock.calls.at(-1)?.[4] as string;
     expect(body).toContain("## PR Agent Review");
-    expect(body).toContain("could not complete");
+    expect(body).toContain("Review did not finish");
     expect(body).toContain("/review");
     expect(body).not.toMatch(/structured publish/i);
     expect(body).not.toMatch(/server logs/i);


### PR DESCRIPTION
## Summary

- Rework review comment renderers to use GitHub alerts and a unified summary table (effort, finding rows, tests, security, follow-ups)
- Inline-posted findings show title and location only in the summary; detail stays on diff threads or summary-only accordions
- Align inline threads, review pointer, progress stubs, and failure notices with the same format
- Add format constants, update ADR 0005, and refresh renderer tests/snapshots

## Test plan

- [x] `pnpm test`