### PR TITLE
fix: Review summary table and links

### DIFF
--- a/src/agent/cursor/reviewRunCursor.ts
+++ b/src/agent/cursor/reviewRunCursor.ts
@@ -35,7 +35,12 @@ export async function runCursorFullPrReview(params: {
   userSupplement?: string;
   shouldLinkToSummary?: boolean;
   summaryCommentIdHint?: number | null;
-  initialPublishState?: { published?: boolean; inlinePublished?: boolean };
+  inlineReviewIdHint?: number | null;
+  initialPublishState?: {
+    published?: boolean;
+    inlinePublished?: boolean;
+    inlineReviewId?: number | null;
+  };
   recordPublishStep?: (
     step: "inline_review" | "summary_comment" | "labels",
     detail?: { githubId?: string | number; meta?: Record<string, unknown> },
@@ -63,6 +68,7 @@ export async function runCursorFullPrReview(params: {
   const submitState: SubmitReviewState = createSubmitReviewState({
     published: params.initialPublishState?.published,
     inlinePublished: params.initialPublishState?.inlinePublished,
+    inlineReviewId: params.initialPublishState?.inlineReviewId,
   });
   const publishCtx = { owner, repo, prNumber, headSha };
 
@@ -94,6 +100,7 @@ export async function runCursorFullPrReview(params: {
       cachedDiffIndex,
       shouldLinkToSummary: params.shouldLinkToSummary,
       summaryCommentIdHint: params.summaryCommentIdHint,
+      inlineReviewIdHint: params.inlineReviewIdHint,
       recordPublishStep: params.recordPublishStep,
       shouldAbortPublish: params.shouldAbortPublish,
     });

--- a/src/agent/cursor/reviewRunCursor.ts
+++ b/src/agent/cursor/reviewRunCursor.ts
@@ -35,7 +35,6 @@ export async function runCursorFullPrReview(params: {
   userSupplement?: string;
   shouldLinkToSummary?: boolean;
   summaryCommentIdHint?: number | null;
-  inlineReviewIdHint?: number | null;
   initialPublishState?: {
     published?: boolean;
     inlinePublished?: boolean;
@@ -100,7 +99,6 @@ export async function runCursorFullPrReview(params: {
       cachedDiffIndex,
       shouldLinkToSummary: params.shouldLinkToSummary,
       summaryCommentIdHint: params.summaryCommentIdHint,
-      inlineReviewIdHint: params.inlineReviewIdHint,
       recordPublishStep: params.recordPublishStep,
       shouldAbortPublish: params.shouldAbortPublish,
     });

--- a/src/agent/publishReview.ts
+++ b/src/agent/publishReview.ts
@@ -1,7 +1,9 @@
 import type { Config } from "../config.js";
 import {
   createPullRequestReviewWithComments,
+  enrichPlacementsWithInlineCommentUrls,
   listPullRequestLabels,
+  listPullRequestReviewCommentsForReview,
   resolveVerifiedSummaryCommentUrl,
   setPullRequestLabels,
   upsertReviewSummaryComment,
@@ -44,6 +46,7 @@ export async function publishReview(
     cachedDiffIndex?: CachedPrDiffIndex;
     shouldLinkToSummary?: boolean;
     summaryCommentIdHint?: number | null;
+    inlineReviewIdHint?: number | null;
     recordPublishStep?: (
       step: "inline_review" | "summary_comment" | "labels",
       detail?: { githubId?: string | number; meta?: Record<string, unknown> },
@@ -62,6 +65,7 @@ export async function publishReview(
   const inlineFindings = placements.filter((p) => p.inlinePosted);
   const event = reviewEventForFindings(payload.findings);
   let summaryPlacements = placements;
+  let inlineReviewId = params.inlineReviewIdHint ?? publishState.inlineReviewId;
   const diffCacheEmpty = params.cachedDiffIndex == null || params.cachedDiffIndex.files.size === 0;
   if (diffCacheEmpty) {
     logDebug("review_diff_cache_empty", {
@@ -132,6 +136,8 @@ export async function publishReview(
           comments,
           commitId: headSha,
         });
+        inlineReviewId = review.id;
+        publishState.inlineReviewId = review.id;
         await params.recordPublishStep?.("inline_review", {
           githubId: review.id,
           meta: {
@@ -221,6 +227,31 @@ export async function publishReview(
     }
 
     publishState.inlinePublished = true;
+  }
+
+  if (inlineReviewId != null) {
+    try {
+      const reviewComments = await listPullRequestReviewCommentsForReview(
+        token,
+        owner,
+        repo,
+        prNumber,
+        inlineReviewId,
+      );
+      summaryPlacements = enrichPlacementsWithInlineCommentUrls(
+        summaryPlacements,
+        reviewComments,
+      );
+    } catch (e) {
+      logWarn("review_inline_comment_urls_failed", {
+        mode,
+        owner,
+        repo,
+        pr: prNumber,
+        reviewId: inlineReviewId,
+        message: e instanceof Error ? e.message : String(e),
+      });
+    }
   }
 
   const summaryBody = renderReviewSummaryComment(payload, {

--- a/src/agent/publishReview.ts
+++ b/src/agent/publishReview.ts
@@ -46,7 +46,6 @@ export async function publishReview(
     cachedDiffIndex?: CachedPrDiffIndex;
     shouldLinkToSummary?: boolean;
     summaryCommentIdHint?: number | null;
-    inlineReviewIdHint?: number | null;
     recordPublishStep?: (
       step: "inline_review" | "summary_comment" | "labels",
       detail?: { githubId?: string | number; meta?: Record<string, unknown> },
@@ -65,7 +64,7 @@ export async function publishReview(
   const inlineFindings = placements.filter((p) => p.inlinePosted);
   const event = reviewEventForFindings(payload.findings);
   let summaryPlacements = placements;
-  let inlineReviewId = params.inlineReviewIdHint ?? publishState.inlineReviewId;
+  let inlineReviewId = publishState.inlineReviewId;
   const diffCacheEmpty = params.cachedDiffIndex == null || params.cachedDiffIndex.files.size === 0;
   if (diffCacheEmpty) {
     logDebug("review_diff_cache_empty", {

--- a/src/agent/reviewLocationValidation.ts
+++ b/src/agent/reviewLocationValidation.ts
@@ -13,6 +13,8 @@ export type InlinePlacement = {
   readonly inlineLine: number | null;
   readonly inlinePosted: boolean;
   readonly inlineCapEligible: boolean;
+  /** Set at publish time when the inline thread exists on the Files tab. */
+  readonly inlineCommentUrl?: string;
 };
 
 export {

--- a/src/agent/reviewRender.ts
+++ b/src/agent/reviewRender.ts
@@ -3,6 +3,7 @@ import {
   escapeTableCellContent,
   escapeTableHtml,
   renderGitHubAlert,
+  renderKeyValueTable,
 } from "../github/markdownFormat.js";
 import {
   AGENT_FIX_PROMPT_ACCORDION_SUMMARY,
@@ -180,7 +181,10 @@ function renderFindingTableCell(
   safeFinding: SanitizedFindingFields,
 ): string {
   const f = placement.finding;
-  const link = blobLineUrl(ctx, f.file, f.startLine, f.endLine);
+  const link =
+    placement.inlinePosted && placement.inlineCommentUrl
+      ? placement.inlineCommentUrl
+      : blobLineUrl(ctx, f.file, f.startLine, f.endLine);
   const marker = placement.inlinePosted ? "On the diff" : "Summary only";
   const meta = `_${escapeTableCell(marker)} · \`${escapeTableHtml(f.file)}\` · ${formatLineRange(f.startLine, f.endLine)}_`;
   const parts = [`**[${escapeTableCell(safeFinding.title)}](${link})**`, meta];
@@ -357,14 +361,15 @@ export function renderReviewSummaryComment(
     ),
   );
   rows.push("");
-  rows.push("| | |");
-  rows.push("| --- | --- |");
-  rows.push(`| **Effort** | ${formatEffortLabel(payload.estimatedEffort)} |`);
+
+  const tableRows: Array<[string, string]> = [
+    ["**Effort**", formatEffortLabel(payload.estimatedEffort)],
+  ];
 
   const summaryOnlyAccordions: string[] = [];
 
   if (sortedPlacements.length === 0) {
-    rows.push(`| **Findings** | ${REVIEW_FINDINGS_NONE} |`);
+    tableRows.push(["**Findings**", REVIEW_FINDINGS_NONE]);
   } else {
     for (const placement of sortedPlacements) {
       const safeFinding = sanitizePublicReviewFields({
@@ -377,9 +382,10 @@ export function renderReviewSummaryComment(
         detail: safeFinding.detail ?? placement.finding.detail,
         fixPrompt: safeFinding.fixPrompt ?? placement.finding.fixPrompt,
       };
-      rows.push(
-        `| **${placement.finding.severity}** | ${renderFindingTableCell(placement, ctx, sanitized)} |`,
-      );
+      tableRows.push([
+        `**${placement.finding.severity}**`,
+        renderFindingTableCell(placement, ctx, sanitized),
+      ]);
       if (
         !placement.inlinePosted &&
         sanitized.fixPrompt != null &&
@@ -396,19 +402,20 @@ export function renderReviewSummaryComment(
     }
   }
 
-  rows.push(`| **Relevant tests** | ${payload.relevantTests} |`);
-  rows.push(
-    `| **Security** | ${
-      safePayload.securityConcerns != null
-        ? escapeTableCell(safePayload.securityConcerns)
-        : REVIEW_SECURITY_DEFAULT
-    } |`,
-  );
+  tableRows.push(["**Relevant tests**", payload.relevantTests]);
+  tableRows.push([
+    "**Security**",
+    safePayload.securityConcerns != null
+      ? escapeTableCell(safePayload.securityConcerns)
+      : REVIEW_SECURITY_DEFAULT,
+  ]);
 
   const followUps = safePayload.followUps ?? payload.followUps;
   for (const item of followUps) {
-    rows.push(`| **Follow-ups** | ${escapeTableCell(item)} |`);
+    tableRows.push(["**Follow-ups**", escapeTableCell(item)]);
   }
+
+  rows.push(renderKeyValueTable(tableRows));
 
   if (summaryOnlyAccordions.length > 0) {
     rows.push("");

--- a/src/agent/reviewRender.ts
+++ b/src/agent/reviewRender.ts
@@ -1,9 +1,13 @@
 import {
-  escapeTableCell,
-  escapeTableCellContent,
+  escapeTablePlainCell,
   escapeTableHtml,
   renderGitHubAlert,
   renderKeyValueTable,
+  renderTableCode,
+  renderTableEm,
+  renderTableLink,
+  renderTableLocationMeta,
+  renderTableStrong,
 } from "../github/markdownFormat.js";
 import {
   AGENT_FIX_PROMPT_ACCORDION_SUMMARY,
@@ -68,6 +72,11 @@ export function issueCommentUrl(
 export function formatEffortLabel(effort: number): string {
   const word = REVIEW_EFFORT_WORDS[effort - 1] ?? REVIEW_EFFORT_WORDS[2];
   return `${word} · \`${effort}/5\``;
+}
+
+function formatEffortLabelHtml(effort: number): string {
+  const word = REVIEW_EFFORT_WORDS[effort - 1] ?? REVIEW_EFFORT_WORDS[2];
+  return `${escapeTableHtml(word)} · ${renderTableCode(`${effort}/5`)}`;
 }
 
 export function reviewPointerBodyForMode(mode: ReviewMode): string {
@@ -175,7 +184,7 @@ type SanitizedFindingFields = {
   fixPrompt?: string;
 };
 
-function renderFindingTableCell(
+function renderFindingTableCellHtml(
   placement: InlinePlacement,
   ctx: RenderContext,
   safeFinding: SanitizedFindingFields,
@@ -186,13 +195,17 @@ function renderFindingTableCell(
       ? placement.inlineCommentUrl
       : blobLineUrl(ctx, f.file, f.startLine, f.endLine);
   const marker = placement.inlinePosted ? "On the diff" : "Summary only";
-  const meta = `_${escapeTableCell(marker)} · \`${escapeTableHtml(f.file)}\` · ${formatLineRange(f.startLine, f.endLine)}_`;
-  const parts = [`**[${escapeTableCell(safeFinding.title)}](${link})**`, meta];
+  const parts = [
+    renderTableLink(safeFinding.title, link),
+    renderTableLocationMeta(marker, f.file, formatLineRange(f.startLine, f.endLine)),
+  ];
   if (!placement.inlinePosted) {
-    parts.push(escapeTableCellContent(safeFinding.detail));
+    parts.push(escapeTablePlainCell(safeFinding.detail));
   }
   parts.push(
-    `_${placement.inlinePosted ? REVIEW_FINDING_FOOTNOTE_INLINE : REVIEW_FINDING_FOOTNOTE_SUMMARY}_`,
+    renderTableEm(
+      placement.inlinePosted ? REVIEW_FINDING_FOOTNOTE_INLINE : REVIEW_FINDING_FOOTNOTE_SUMMARY,
+    ),
   );
   return parts.join("<br>");
 }
@@ -363,13 +376,13 @@ export function renderReviewSummaryComment(
   rows.push("");
 
   const tableRows: Array<[string, string]> = [
-    ["**Effort**", formatEffortLabel(payload.estimatedEffort)],
+    [renderTableStrong("Effort"), formatEffortLabelHtml(payload.estimatedEffort)],
   ];
 
   const summaryOnlyAccordions: string[] = [];
 
   if (sortedPlacements.length === 0) {
-    tableRows.push(["**Findings**", REVIEW_FINDINGS_NONE]);
+    tableRows.push([renderTableStrong("Findings"), escapeTableHtml(REVIEW_FINDINGS_NONE)]);
   } else {
     for (const placement of sortedPlacements) {
       const safeFinding = sanitizePublicReviewFields({
@@ -383,8 +396,8 @@ export function renderReviewSummaryComment(
         fixPrompt: safeFinding.fixPrompt ?? placement.finding.fixPrompt,
       };
       tableRows.push([
-        `**${placement.finding.severity}**`,
-        renderFindingTableCell(placement, ctx, sanitized),
+        renderTableStrong(placement.finding.severity),
+        renderFindingTableCellHtml(placement, ctx, sanitized),
       ]);
       if (
         !placement.inlinePosted &&
@@ -402,17 +415,17 @@ export function renderReviewSummaryComment(
     }
   }
 
-  tableRows.push(["**Relevant tests**", payload.relevantTests]);
+  tableRows.push([renderTableStrong("Relevant tests"), escapeTableHtml(payload.relevantTests)]);
   tableRows.push([
-    "**Security**",
+    renderTableStrong("Security"),
     safePayload.securityConcerns != null
-      ? escapeTableCell(safePayload.securityConcerns)
-      : REVIEW_SECURITY_DEFAULT,
+      ? escapeTablePlainCell(safePayload.securityConcerns)
+      : escapeTableHtml(REVIEW_SECURITY_DEFAULT),
   ]);
 
   const followUps = safePayload.followUps ?? payload.followUps;
   for (const item of followUps) {
-    tableRows.push(["**Follow-ups**", escapeTableCell(item)]);
+    tableRows.push([renderTableStrong("Follow-ups"), escapeTablePlainCell(item)]);
   }
 
   rows.push(renderKeyValueTable(tableRows));

--- a/src/agent/reviewRun.ts
+++ b/src/agent/reviewRun.ts
@@ -87,7 +87,6 @@ export async function runFullPrReview(params: {
   userSupplement?: string;
   shouldLinkToSummary?: boolean;
   summaryCommentIdHint?: number | null;
-  inlineReviewIdHint?: number | null;
   initialPublishState?: {
     published?: boolean;
     inlinePublished?: boolean;
@@ -145,7 +144,6 @@ export async function runFullPrReview(params: {
     cachedDiffIndex,
     shouldLinkToSummary: params.shouldLinkToSummary,
     summaryCommentIdHint: params.summaryCommentIdHint,
-    inlineReviewIdHint: params.inlineReviewIdHint,
     recordPublishStep: params.recordPublishStep,
     shouldAbortPublish: params.shouldAbortPublish,
   });

--- a/src/agent/reviewRun.ts
+++ b/src/agent/reviewRun.ts
@@ -87,7 +87,12 @@ export async function runFullPrReview(params: {
   userSupplement?: string;
   shouldLinkToSummary?: boolean;
   summaryCommentIdHint?: number | null;
-  initialPublishState?: { published?: boolean; inlinePublished?: boolean };
+  inlineReviewIdHint?: number | null;
+  initialPublishState?: {
+    published?: boolean;
+    inlinePublished?: boolean;
+    inlineReviewId?: number | null;
+  };
   recordPublishStep?: (
     step: "inline_review" | "summary_comment" | "labels",
     detail?: { githubId?: string | number; meta?: Record<string, unknown> },
@@ -128,6 +133,7 @@ export async function runFullPrReview(params: {
   const submitState: SubmitReviewState = createSubmitReviewState({
     published: params.initialPublishState?.published,
     inlinePublished: params.initialPublishState?.inlinePublished,
+    inlineReviewId: params.initialPublishState?.inlineReviewId,
   });
   const publishCtx = { owner, repo, prNumber, headSha };
   const { piTool: submitTool, executor: submitExecutor } = buildSubmitReviewTool({
@@ -139,6 +145,7 @@ export async function runFullPrReview(params: {
     cachedDiffIndex,
     shouldLinkToSummary: params.shouldLinkToSummary,
     summaryCommentIdHint: params.summaryCommentIdHint,
+    inlineReviewIdHint: params.inlineReviewIdHint,
     recordPublishStep: params.recordPublishStep,
     shouldAbortPublish: params.shouldAbortPublish,
   });

--- a/src/agent/submitReviewTool.ts
+++ b/src/agent/submitReviewTool.ts
@@ -50,7 +50,6 @@ export function buildSubmitReviewTool(params: {
   cachedDiffIndex?: CachedPrDiffIndex;
   shouldLinkToSummary?: boolean;
   summaryCommentIdHint?: number | null;
-  inlineReviewIdHint?: number | null;
   recordPublishStep?: (
     step: "inline_review" | "summary_comment" | "labels",
     detail?: { githubId?: string | number; meta?: Record<string, unknown> },
@@ -160,7 +159,6 @@ export function buildSubmitReviewTool(params: {
         cachedDiffIndex: params.cachedDiffIndex,
         shouldLinkToSummary: params.shouldLinkToSummary,
         summaryCommentIdHint: params.summaryCommentIdHint,
-        inlineReviewIdHint: params.inlineReviewIdHint,
         recordPublishStep: params.recordPublishStep,
       });
     } catch (e) {

--- a/src/agent/submitReviewTool.ts
+++ b/src/agent/submitReviewTool.ts
@@ -21,17 +21,19 @@ export { PUBLISH_BUDGET_EXHAUSTED_MESSAGE } from "../settings/index.js";
 export type SubmitReviewState = {
   published: boolean;
   inlinePublished: boolean;
+  inlineReviewId: number | null;
   lastValidationError: string | null;
   publishCallCount: number;
   publishCallsExhausted: boolean;
 };
 
 export function createSubmitReviewState(
-  initial?: Partial<Pick<SubmitReviewState, "published" | "inlinePublished">>,
+  initial?: Partial<Pick<SubmitReviewState, "published" | "inlinePublished" | "inlineReviewId">>,
 ): SubmitReviewState {
   return {
     published: initial?.published ?? false,
     inlinePublished: initial?.inlinePublished ?? false,
+    inlineReviewId: initial?.inlineReviewId ?? null,
     lastValidationError: null,
     publishCallCount: 0,
     publishCallsExhausted: false,
@@ -48,6 +50,7 @@ export function buildSubmitReviewTool(params: {
   cachedDiffIndex?: CachedPrDiffIndex;
   shouldLinkToSummary?: boolean;
   summaryCommentIdHint?: number | null;
+  inlineReviewIdHint?: number | null;
   recordPublishStep?: (
     step: "inline_review" | "summary_comment" | "labels",
     detail?: { githubId?: string | number; meta?: Record<string, unknown> },
@@ -157,6 +160,7 @@ export function buildSubmitReviewTool(params: {
         cachedDiffIndex: params.cachedDiffIndex,
         shouldLinkToSummary: params.shouldLinkToSummary,
         summaryCommentIdHint: params.summaryCommentIdHint,
+        inlineReviewIdHint: params.inlineReviewIdHint,
         recordPublishStep: params.recordPublishStep,
       });
     } catch (e) {

--- a/src/agentWork/progressComment.ts
+++ b/src/agentWork/progressComment.ts
@@ -1,4 +1,4 @@
-import { renderGitHubAlert } from "../github/markdownFormat.js";
+import { renderGitHubAlert, renderKeyValueTable } from "../github/markdownFormat.js";
 import { reviewSummarySentinelForMode, type ReviewMode } from "../agent/reviewSchema.js";
 import {
   REVIEW_FAILURE_ALERT,
@@ -20,10 +20,10 @@ export function renderReviewProgressComment(params: {
     "",
     renderGitHubAlert(REVIEW_OVERVIEW_ALERT, REVIEW_PROGRESS_NOTE),
     "",
-    "| | |",
-    "| --- | --- |",
-    `| **Head** | \`${params.headSha}\` |`,
-    `| **Source** | ${sourceLabel} |`,
+    renderKeyValueTable([
+      ["**Head**", `\`${params.headSha}\``],
+      ["**Source**", sourceLabel],
+    ]),
   ].join("\n");
 }
 

--- a/src/agentWork/progressComment.ts
+++ b/src/agentWork/progressComment.ts
@@ -1,4 +1,10 @@
-import { renderGitHubAlert, renderKeyValueTable } from "../github/markdownFormat.js";
+import {
+  escapeTableHtml,
+  renderGitHubAlert,
+  renderKeyValueTable,
+  renderTableCode,
+  renderTableStrong,
+} from "../github/markdownFormat.js";
 import { reviewSummarySentinelForMode, type ReviewMode } from "../agent/reviewSchema.js";
 import {
   REVIEW_FAILURE_ALERT,
@@ -21,8 +27,8 @@ export function renderReviewProgressComment(params: {
     renderGitHubAlert(REVIEW_OVERVIEW_ALERT, REVIEW_PROGRESS_NOTE),
     "",
     renderKeyValueTable([
-      ["**Head**", `\`${params.headSha}\``],
-      ["**Source**", sourceLabel],
+      [renderTableStrong("Head"), renderTableCode(params.headSha)],
+      [renderTableStrong("Source"), escapeTableHtml(sourceLabel)],
     ]),
   ].join("\n");
 }

--- a/src/agentWork/repository.ts
+++ b/src/agentWork/repository.ts
@@ -231,9 +231,13 @@ export async function getReviewPublishState(
   workItemId: string,
   resourceKey: string,
   reviewLens: ReviewWorkPayload["mode"],
-): Promise<{ inlinePublished: boolean; summaryPublished: boolean }> {
-  const { rows } = await pool.query<{ step: string }>(
-    `SELECT step
+): Promise<{
+  inlinePublished: boolean;
+  summaryPublished: boolean;
+  inlineReviewId: number | null;
+}> {
+  const { rows } = await pool.query<{ step: string; github_id: string | null }>(
+    `SELECT step, github_id
 		   FROM publish_records
 		  WHERE resource_key = $1
 		    AND review_lens = $2
@@ -243,9 +247,15 @@ export async function getReviewPublishState(
     [resourceKey, reviewLens, workItemId],
   );
   const steps = new Set(rows.map((r) => r.step));
+  const inlineRow = rows.find((r) => r.step === "inline_review");
+  const inlineReviewId =
+    inlineRow?.github_id != null && Number.isFinite(Number(inlineRow.github_id))
+      ? Number(inlineRow.github_id)
+      : null;
   return {
     inlinePublished: steps.has("inline_review"),
     summaryPublished: steps.has("summary_comment"),
+    inlineReviewId,
   };
 }
 

--- a/src/agentWork/worker.ts
+++ b/src/agentWork/worker.ts
@@ -227,9 +227,11 @@ async function handleReviewJob(
         userSupplement: payload.userSupplement,
         shouldLinkToSummary,
         summaryCommentIdHint,
+        inlineReviewIdHint: publishState.inlineReviewId,
         initialPublishState: {
           inlinePublished: publishState.inlinePublished,
           published: publishState.summaryPublished,
+          inlineReviewId: publishState.inlineReviewId,
         },
         recordPublishStep: (step, detail) =>
           recordPublishStep(pool, {

--- a/src/agentWork/worker.ts
+++ b/src/agentWork/worker.ts
@@ -227,7 +227,6 @@ async function handleReviewJob(
         userSupplement: payload.userSupplement,
         shouldLinkToSummary,
         summaryCommentIdHint,
-        inlineReviewIdHint: publishState.inlineReviewId,
         initialPublishState: {
           inlinePublished: publishState.inlinePublished,
           published: publishState.summaryPublished,

--- a/src/github/markdownFormat.ts
+++ b/src/github/markdownFormat.ts
@@ -4,11 +4,20 @@ export function escapeTableCell(text: string): string {
 }
 
 export function escapeTableHtml(text: string): string {
-  return text.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+export function escapeHtmlAttr(text: string): string {
+  return escapeTableHtml(text).replace(/"/g, "&quot;").replace(/'/g, "&#39;");
 }
 
 export function escapeTableCellContent(text: string): string {
   return escapeTableHtml(escapeTableCell(text));
+}
+
+/** Plain text in HTML table cells (no GFM pipe escaping). */
+export function escapeTablePlainCell(text: string): string {
+  return escapeTableHtml(text.replace(/\r?\n/g, " "));
 }
 
 export function escapeAlertBody(text: string): string {
@@ -23,44 +32,30 @@ export function renderGitHubAlert(alertType: string, body: string): string {
   return `> [!${alertType}]\n${escapeAlertBody(body)}`;
 }
 
-function unescapeTableCell(text: string): string {
-  return text.replace(/\\\|/g, "|");
+export function renderTableStrong(text: string): string {
+  return `<strong>${escapeTableHtml(text)}</strong>`;
 }
 
-/** Inline markdown used in review summary table cells → HTML for headerless tables. */
-export function markdownInlineToHtml(text: string): string {
-  return text.split("<br>").map(convertMarkdownInlineSegment).join("<br>");
+export function renderTableLink(title: string, href: string): string {
+  return `<strong><a href="${escapeHtmlAttr(href)}">${escapeTableHtml(title)}</a></strong>`;
 }
 
-function convertMarkdownInlineSegment(segment: string): string {
-  let s = segment;
-  s = s.replace(
-    /\*\*\[((?:\\.|[^\]])*)\]\(([^)]+)\)\*\*/g,
-    (_, title, url) =>
-      `<strong><a href="${url}">${unescapeTableCell(title)}</a></strong>`,
-  );
-  s = s.replace(
-    /\*\*((?:\\.|[^*])+)\*\*/g,
-    (_, inner) => `<strong>${unescapeTableCell(inner)}</strong>`,
-  );
-  s = s.replace(/_((?:\\.|[^_])+)_/g, (_, inner) => {
-    const body = unescapeTableCell(inner).replace(
-      /`([^`]+)`/g,
-      (_, code) => `<code>${code}</code>`,
-    );
-    return `<em>${body}</em>`;
-  });
-  s = s.replace(/`([^`]+)`/g, (_, code) => `<code>${code}</code>`);
-  return unescapeTableCell(s);
+export function renderTableEm(text: string): string {
+  return `<em>${escapeTableHtml(text)}</em>`;
+}
+
+export function renderTableCode(text: string): string {
+  return `<code>${escapeTableHtml(text)}</code>`;
+}
+
+export function renderTableLocationMeta(marker: string, file: string, lineRange: string): string {
+  return `<em>${escapeTableHtml(marker)} · ${renderTableCode(file)} · ${escapeTableHtml(lineRange)}</em>`;
 }
 
 /** Key-value table without a GFM header row (avoids the empty `| | |` header strip on GitHub). */
 export function renderKeyValueTable(rows: ReadonlyArray<readonly [string, string]>): string {
   const body = rows
-    .map(
-      ([label, value]) =>
-        `<tr><td>${markdownInlineToHtml(label)}</td><td>${markdownInlineToHtml(value)}</td></tr>`,
-    )
+    .map(([label, value]) => `<tr><td>${label}</td><td>${value}</td></tr>`)
     .join("\n");
   return `<table>\n<tbody>\n${body}\n</tbody>\n</table>`;
 }

--- a/src/github/markdownFormat.ts
+++ b/src/github/markdownFormat.ts
@@ -22,3 +22,45 @@ export function escapeAlertBody(text: string): string {
 export function renderGitHubAlert(alertType: string, body: string): string {
   return `> [!${alertType}]\n${escapeAlertBody(body)}`;
 }
+
+function unescapeTableCell(text: string): string {
+  return text.replace(/\\\|/g, "|");
+}
+
+/** Inline markdown used in review summary table cells → HTML for headerless tables. */
+export function markdownInlineToHtml(text: string): string {
+  return text.split("<br>").map(convertMarkdownInlineSegment).join("<br>");
+}
+
+function convertMarkdownInlineSegment(segment: string): string {
+  let s = segment;
+  s = s.replace(
+    /\*\*\[((?:\\.|[^\]])*)\]\(([^)]+)\)\*\*/g,
+    (_, title, url) =>
+      `<strong><a href="${url}">${unescapeTableCell(title)}</a></strong>`,
+  );
+  s = s.replace(
+    /\*\*((?:\\.|[^*])+)\*\*/g,
+    (_, inner) => `<strong>${unescapeTableCell(inner)}</strong>`,
+  );
+  s = s.replace(/_((?:\\.|[^_])+)_/g, (_, inner) => {
+    const body = unescapeTableCell(inner).replace(
+      /`([^`]+)`/g,
+      (_, code) => `<code>${code}</code>`,
+    );
+    return `<em>${body}</em>`;
+  });
+  s = s.replace(/`([^`]+)`/g, (_, code) => `<code>${code}</code>`);
+  return unescapeTableCell(s);
+}
+
+/** Key-value table without a GFM header row (avoids the empty `| | |` header strip on GitHub). */
+export function renderKeyValueTable(rows: ReadonlyArray<readonly [string, string]>): string {
+  const body = rows
+    .map(
+      ([label, value]) =>
+        `<tr><td>${markdownInlineToHtml(label)}</td><td>${markdownInlineToHtml(value)}</td></tr>`,
+    )
+    .join("\n");
+  return `<table>\n<tbody>\n${body}\n</tbody>\n</table>`;
+}

--- a/src/github/reviewPublish.ts
+++ b/src/github/reviewPublish.ts
@@ -57,7 +57,7 @@ export async function listPullRequestReviewCommentsForReview(
     pull_number: pullNumber,
     review_id: reviewId,
   });
-  return data.flatMap((comment) => {
+  const parsed = data.flatMap((comment) => {
     if (comment.path == null || comment.line == null) return [];
     return [
       {
@@ -68,24 +68,38 @@ export async function listPullRequestReviewCommentsForReview(
       },
     ];
   });
+  return parsed.toSorted((a, b) => a.id - b.id);
 }
 
 function reviewCommentAnchorKey(path: string, line: number): string {
   return `${path}:${line}`;
 }
 
-/** Match GitHub review comments to planned inline placements by path and posted line. */
+/** Match GitHub review comments to inline placements in placement order (FIFO per anchor). */
 export function enrichPlacementsWithInlineCommentUrls(
   placements: readonly InlinePlacement[],
   comments: readonly PublishedReviewComment[],
 ): InlinePlacement[] {
-  const byAnchor = new Map(
-    comments.map((c) => [reviewCommentAnchorKey(c.path, c.line), c.url] as const),
-  );
+  const commentsByAnchor = new Map<string, PublishedReviewComment[]>();
+  for (const comment of comments) {
+    const key = reviewCommentAnchorKey(comment.path, comment.line);
+    const bucket = commentsByAnchor.get(key) ?? [];
+    bucket.push(comment);
+    commentsByAnchor.set(key, bucket);
+  }
+
+  const anchorUseIndex = new Map<string, number>();
+
   return placements.map((placement) => {
     if (!placement.inlinePosted || placement.inlineLine == null) return placement;
-    const url = byAnchor.get(reviewCommentAnchorKey(placement.finding.file, placement.inlineLine));
-    return url ? { ...placement, inlineCommentUrl: url } : placement;
+    const key = reviewCommentAnchorKey(placement.finding.file, placement.inlineLine);
+    const bucket = commentsByAnchor.get(key);
+    if (!bucket || bucket.length === 0) return placement;
+    const index = anchorUseIndex.get(key) ?? 0;
+    const comment = bucket[index];
+    if (!comment) return placement;
+    anchorUseIndex.set(key, index + 1);
+    return { ...placement, inlineCommentUrl: comment.url };
   });
 }
 

--- a/src/github/reviewPublish.ts
+++ b/src/github/reviewPublish.ts
@@ -1,3 +1,4 @@
+import type { InlinePlacement } from "../agent/reviewLocationValidation.js";
 import { installationOctokit } from "./appAuth.js";
 import { REVIEW_SUMMARY_SENTINEL } from "../agent/reviewSchema.js";
 
@@ -33,6 +34,59 @@ export async function createPullRequestReviewWithComments(
     commit_id: params.commitId,
   });
   return { id: data.id, url: data.html_url };
+}
+
+export type PublishedReviewComment = {
+  path: string;
+  line: number;
+  id: number;
+  url: string;
+};
+
+export async function listPullRequestReviewCommentsForReview(
+  token: string,
+  owner: string,
+  repo: string,
+  pullNumber: number,
+  reviewId: number,
+): Promise<PublishedReviewComment[]> {
+  const octokit = installationOctokit(token);
+  const { data } = await octokit.rest.pulls.listCommentsForReview({
+    owner,
+    repo,
+    pull_number: pullNumber,
+    review_id: reviewId,
+  });
+  return data.flatMap((comment) => {
+    if (comment.path == null || comment.line == null) return [];
+    return [
+      {
+        path: comment.path,
+        line: comment.line,
+        id: comment.id,
+        url: comment.html_url,
+      },
+    ];
+  });
+}
+
+function reviewCommentAnchorKey(path: string, line: number): string {
+  return `${path}:${line}`;
+}
+
+/** Match GitHub review comments to planned inline placements by path and posted line. */
+export function enrichPlacementsWithInlineCommentUrls(
+  placements: readonly InlinePlacement[],
+  comments: readonly PublishedReviewComment[],
+): InlinePlacement[] {
+  const byAnchor = new Map(
+    comments.map((c) => [reviewCommentAnchorKey(c.path, c.line), c.url] as const),
+  );
+  return placements.map((placement) => {
+    if (!placement.inlinePosted || placement.inlineLine == null) return placement;
+    const url = byAnchor.get(reviewCommentAnchorKey(placement.finding.file, placement.inlineLine));
+    return url ? { ...placement, inlineCommentUrl: url } : placement;
+  });
 }
 
 export type IssueCommentRef = { id: number; url: string };

--- a/test/markdownFormat.test.ts
+++ b/test/markdownFormat.test.ts
@@ -3,7 +3,9 @@ import {
   escapeAlertBody,
   escapeTableCell,
   escapeTableCellContent,
+  markdownInlineToHtml,
   renderGitHubAlert,
+  renderKeyValueTable,
 } from "../src/github/markdownFormat.js";
 
 describe("markdownFormat", () => {
@@ -21,5 +23,24 @@ describe("markdownFormat", () => {
 
   it("renderGitHubAlert wraps body in alert syntax", () => {
     expect(renderGitHubAlert("NOTE", "hello")).toBe("> [!NOTE]\n> hello");
+  });
+
+  it("markdownInlineToHtml converts bold, links, emphasis, and code", () => {
+    const html = markdownInlineToHtml(
+      "**[Bug \\| typo](https://example.com)**<br>_On the diff · `src/x.ts` · lines 1-2_",
+    );
+    expect(html).toContain('<strong><a href="https://example.com">Bug | typo</a></strong>');
+    expect(html).toContain("<em>On the diff · <code>src/x.ts</code> · lines 1-2</em>");
+  });
+
+  it("renderKeyValueTable omits GFM header row", () => {
+    const table = renderKeyValueTable([
+      ["**Effort**", "Moderate · `2/5`"],
+      ["**P1**", "plain value"],
+    ]);
+    expect(table).not.toContain("| | |");
+    expect(table).toContain("<table>");
+    expect(table).toContain("<strong>Effort</strong>");
+    expect(table).toContain("<code>2/5</code>");
   });
 });

--- a/test/markdownFormat.test.ts
+++ b/test/markdownFormat.test.ts
@@ -3,9 +3,10 @@ import {
   escapeAlertBody,
   escapeTableCell,
   escapeTableCellContent,
-  markdownInlineToHtml,
   renderGitHubAlert,
   renderKeyValueTable,
+  renderTableLink,
+  renderTableStrong,
 } from "../src/github/markdownFormat.js";
 
 describe("markdownFormat", () => {
@@ -25,18 +26,17 @@ describe("markdownFormat", () => {
     expect(renderGitHubAlert("NOTE", "hello")).toBe("> [!NOTE]\n> hello");
   });
 
-  it("markdownInlineToHtml converts bold, links, emphasis, and code", () => {
-    const html = markdownInlineToHtml(
-      "**[Bug \\| typo](https://example.com)**<br>_On the diff · `src/x.ts` · lines 1-2_",
-    );
-    expect(html).toContain('<strong><a href="https://example.com">Bug | typo</a></strong>');
-    expect(html).toContain("<em>On the diff · <code>src/x.ts</code> · lines 1-2</em>");
+  it("renderTableLink escapes title and href for HTML", () => {
+    const html = renderTableLink("Bug <x>", 'https://example.com?q="1"');
+    expect(html).toContain("&lt;x&gt;");
+    expect(html).toContain("&quot;");
+    expect(html).not.toContain('href="https://example.com?q="1""');
   });
 
   it("renderKeyValueTable omits GFM header row", () => {
     const table = renderKeyValueTable([
-      ["**Effort**", "Moderate · `2/5`"],
-      ["**P1**", "plain value"],
+      [renderTableStrong("Effort"), "Moderate · <code>2/5</code>"],
+      [renderTableStrong("P1"), "plain value"],
     ]);
     expect(table).not.toContain("| | |");
     expect(table).toContain("<table>");

--- a/test/progressComment.test.ts
+++ b/test/progressComment.test.ts
@@ -32,8 +32,10 @@ describe("progressComment fallback wording", () => {
     });
     expect(body).toContain("[!NOTE]");
     expect(body).toContain(REVIEW_PROGRESS_NOTE);
-    expect(body).toContain("**Head**");
-    expect(body).toContain("`abc123`");
+    expect(body).toContain("<strong>Head</strong>");
+    expect(body).toContain("<code>abc123</code>");
     expect(body).toContain("Pull request update");
+    expect(body).not.toContain("| | |");
+    expect(body).toContain("<table>");
   });
 });

--- a/test/publishReview.test.ts
+++ b/test/publishReview.test.ts
@@ -16,20 +16,33 @@ import {
   testPublishState,
 } from "./helpers/reviewPublishTestHelpers.js";
 
-vi.mock("../src/github/reviewPublish.js", () => ({
-  createPullRequestReviewWithComments: vi.fn(async () => ({
-    id: 1,
-    url: "https://example.com/review/1",
-  })),
-  resolveVerifiedSummaryCommentUrl: vi.fn(async () => undefined),
-  upsertReviewSummaryComment: vi.fn(async () => ({ id: 2, updated: false })),
-  listPullRequestLabels: vi.fn(async () => []),
-  setPullRequestLabels: vi.fn(async () => undefined),
-}));
+vi.mock("../src/github/reviewPublish.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/github/reviewPublish.js")>();
+  return {
+    ...actual,
+    createPullRequestReviewWithComments: vi.fn(async () => ({
+      id: 1,
+      url: "https://example.com/review/1",
+    })),
+    listPullRequestReviewCommentsForReview: vi.fn(async () => [
+      {
+        path: "src/x.ts",
+        line: 4,
+        id: 99,
+        url: "https://github.com/o/r/pull/1#discussion_r99",
+      },
+    ]),
+    resolveVerifiedSummaryCommentUrl: vi.fn(async () => undefined),
+    upsertReviewSummaryComment: vi.fn(async () => ({ id: 2, updated: false })),
+    listPullRequestLabels: vi.fn(async () => []),
+    setPullRequestLabels: vi.fn(async () => undefined),
+  };
+});
 
 import {
   createPullRequestReviewWithComments,
   listPullRequestLabels,
+  listPullRequestReviewCommentsForReview,
   resolveVerifiedSummaryCommentUrl,
   setPullRequestLabels,
   upsertReviewSummaryComment,
@@ -99,8 +112,13 @@ describe("publishReview", () => {
         ],
       }),
     );
+    expect(listPullRequestReviewCommentsForReview).toHaveBeenCalledWith("t", "o", "r", 1, 1);
     expect(upsertReviewSummaryComment).toHaveBeenCalled();
+    const summaryBody = vi.mocked(upsertReviewSummaryComment).mock.calls[0]?.[4];
+    expect(summaryBody).toContain("#discussion_r99");
+    expect(summaryBody).not.toContain("/blob/sha/");
     expect(publishState.inlinePublished).toBe(true);
+    expect(publishState.inlineReviewId).toBe(1);
   });
 
   it("bases review event on full findings not inline subset", async () => {
@@ -235,6 +253,17 @@ describe("publishReview", () => {
 
     expect(createPullRequestReviewWithComments).not.toHaveBeenCalled();
     expect(upsertReviewSummaryComment).toHaveBeenCalled();
+  });
+
+  it("still resolves inline comment URLs when inline review was published earlier", async () => {
+    const publishState = testPublishState({ inlinePublished: true, inlineReviewId: 1 });
+
+    await publishReview({ ...baseParams, publishState, cachedDiffIndex: cachedDiffForLines("src/x.ts", [4]) });
+
+    expect(createPullRequestReviewWithComments).not.toHaveBeenCalled();
+    expect(listPullRequestReviewCommentsForReview).toHaveBeenCalledWith("t", "o", "r", 1, 1);
+    const summaryBody = vi.mocked(upsertReviewSummaryComment).mock.calls[0]?.[4];
+    expect(summaryBody).toContain("#discussion_r99");
   });
 
   it("uses security sentinel and pointer with agent fix prompt when mode is review-security", async () => {

--- a/test/reviewPublishComments.test.ts
+++ b/test/reviewPublishComments.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { enrichPlacementsWithInlineCommentUrls } from "../src/github/reviewPublish.js";
+import type { ReviewFinding } from "../src/agent/reviewSchema.js";
+import type { InlinePlacement } from "../src/agent/reviewLocationValidation.js";
+
+function finding(overrides: Partial<ReviewFinding> = {}): ReviewFinding {
+  return {
+    severity: "P1",
+    file: "src/x.ts",
+    startLine: 4,
+    endLine: 4,
+    title: "Bug",
+    detail: "Bad logic.",
+    fixPrompt: "Fix it.",
+    ...overrides,
+  };
+}
+
+function placement(
+  f: ReviewFinding,
+  opts: { inlinePosted?: boolean; inlineLine?: number | null } = {},
+): InlinePlacement {
+  const inlinePosted = opts.inlinePosted ?? true;
+  return {
+    finding: f,
+    inlineLine: inlinePosted ? (opts.inlineLine ?? f.startLine) : null,
+    inlinePosted,
+    inlineCapEligible: inlinePosted,
+  };
+}
+
+describe("enrichPlacementsWithInlineCommentUrls", () => {
+  it("attaches html_url for matching path and posted line", () => {
+    const f = finding();
+    const [enriched] = enrichPlacementsWithInlineCommentUrls([placement(f)], [
+      {
+        path: "src/x.ts",
+        line: 4,
+        id: 99,
+        url: "https://github.com/acme/widgets/pull/42#discussion_r99",
+      },
+    ]);
+    expect(enriched?.inlineCommentUrl).toBe(
+      "https://github.com/acme/widgets/pull/42#discussion_r99",
+    );
+  });
+
+  it("leaves summary-only placements unchanged", () => {
+    const f = finding({ file: "README.md", startLine: 1, endLine: 1 });
+    const [enriched] = enrichPlacementsWithInlineCommentUrls(
+      [placement(f, { inlinePosted: false })],
+      [
+        {
+          path: "README.md",
+          line: 1,
+          id: 1,
+          url: "https://github.com/acme/widgets/pull/42#discussion_r1",
+        },
+      ],
+    );
+    expect(enriched?.inlineCommentUrl).toBeUndefined();
+  });
+});

--- a/test/reviewPublishComments.test.ts
+++ b/test/reviewPublishComments.test.ts
@@ -45,6 +45,30 @@ describe("enrichPlacementsWithInlineCommentUrls", () => {
     );
   });
 
+  it("pairs multiple comments at the same anchor in placement order", () => {
+    const first = finding({ title: "First" });
+    const second = finding({ title: "Second" });
+    const enriched = enrichPlacementsWithInlineCommentUrls(
+      [placement(first), placement(second)],
+      [
+        {
+          path: "src/x.ts",
+          line: 4,
+          id: 10,
+          url: "https://github.com/acme/widgets/pull/42#discussion_r10",
+        },
+        {
+          path: "src/x.ts",
+          line: 4,
+          id: 20,
+          url: "https://github.com/acme/widgets/pull/42#discussion_r20",
+        },
+      ],
+    );
+    expect(enriched[0]?.inlineCommentUrl).toContain("discussion_r10");
+    expect(enriched[1]?.inlineCommentUrl).toContain("discussion_r20");
+  });
+
   it("leaves summary-only placements unchanged", () => {
     const f = finding({ file: "README.md", startLine: 1, endLine: 1 });
     const [enriched] = enrichPlacementsWithInlineCommentUrls(

--- a/test/reviewRender.test.ts
+++ b/test/reviewRender.test.ts
@@ -190,7 +190,7 @@ describe("renderReviewSummaryComment", () => {
       ...ctx,
       placements: testPlacements(payload.findings, { inlinePosted: false }),
     });
-    expect(body).toContain(">Bug | typo</a>");
+    expect(body).toContain("Bug | typo</a>");
   });
 
   it("labels summary-only accordions by severity and title", () => {

--- a/test/reviewRender.test.ts
+++ b/test/reviewRender.test.ts
@@ -55,9 +55,37 @@ describe("renderReviewSummaryComment", () => {
     });
     expect(body).toContain("## PR Agent Review");
     expect(body).toContain("[!NOTE]");
+    expect(body).not.toContain("| | |");
+    expect(body).toContain("<table>");
     expect(body).toContain(REVIEW_FINDINGS_NONE);
     expect(body).not.toContain("_No findings._");
     expect(body).not.toContain("### Findings");
+  });
+
+  it("links inline findings to review comment URLs when provided", () => {
+    const payload = basePayload({
+      findings: [
+        {
+          severity: "P1",
+          file: "src/x.ts",
+          startLine: 4,
+          endLine: 4,
+          title: "Bug",
+          detail: "Bad logic.",
+          fixPrompt: "Fix it.",
+        },
+      ],
+    });
+    const placements = testPlacements(payload.findings).map((p) => ({
+      ...p,
+      inlineCommentUrl: "https://github.com/acme/widgets/pull/42#discussion_r99",
+    }));
+    const body = renderReviewSummaryComment(payload, {
+      ...ctx,
+      placements,
+    });
+    expect(body).toContain("#discussion_r99");
+    expect(body).not.toContain("/blob/abc123def456/");
   });
 
   it("(b) P0 + P3 mix", () => {
@@ -89,7 +117,7 @@ describe("renderReviewSummaryComment", () => {
         ...testPlacements([payload.findings[1]!], { inlinePosted: false }),
       ],
     });
-    expect(body).toContain("**P0**");
+    expect(body).toContain("<strong>P0</strong>");
     expect(body).toContain("Null deref on empty payload");
     expect(body).not.toContain("payload is used before guard");
     expect(body).toContain("Typo in heading");
@@ -140,8 +168,8 @@ describe("renderReviewSummaryComment", () => {
       ...ctx,
       placements: testPlacements(payload.findings, { inlinePosted: false }),
     });
-    expect(body).toContain("Bad \\| logic second line");
-    expect(body).toMatch(/\| \*\*P1\*\* \|/);
+    expect(body).toContain("Bad | logic second line");
+    expect(body).toContain("<strong>P1</strong>");
   });
 
   it("escapes pipes in finding title inside table cells", () => {
@@ -162,7 +190,7 @@ describe("renderReviewSummaryComment", () => {
       ...ctx,
       placements: testPlacements(payload.findings, { inlinePosted: false }),
     });
-    expect(body).toContain("[Bug \\| typo]");
+    expect(body).toContain(">Bug | typo</a>");
   });
 
   it("labels summary-only accordions by severity and title", () => {
@@ -258,8 +286,8 @@ describe("renderReviewSummaryComment", () => {
       ...ctx,
       placements: testPlacementsFromPayload(payload),
     });
-    expect(body).toContain("foo \\| bar");
-    expect(body).toContain("baz \\| qux");
+    expect(body).toContain("foo | bar");
+    expect(body).toContain("baz | qux");
   });
 
   it("redacts banned finding text without replacing the entire summary body", () => {


### PR DESCRIPTION
## Summary
- Removes the blank header row at the top of review summary and progress tables by rendering headerless HTML key-value tables instead of GFM pipe tables with an empty `| | |` row
- Summary finding titles for inline-posted severities now link to the corresponding Files tab review thread (`#discussion_r…`) rather than the blob line range
- After inline publish (including summary-only retries), the worker loads the stored review id and resolves thread URLs before upserting the summary comment

## Test plan
- [x] `pnpm test test/markdownFormat.test.ts test/reviewRender.test.ts test/publishReview.test.ts test/reviewPublishComments.test.ts test/progressComment.test.ts`