### PR TITLE
Fix merge-base failure when base branch has advanced

### DIFF
--- a/src/agentWork/localPrWorkspace.ts
+++ b/src/agentWork/localPrWorkspace.ts
@@ -50,6 +50,7 @@ export type PrepareLocalPrWorkspaceParams = {
   readonly baseSha: string;
   readonly headSha: string;
   readonly installationToken: string;
+  readonly baseRef?: string;
   readonly remoteUrlOverride?: string;
 };
 
@@ -237,7 +238,7 @@ export async function cleanupStaleLocalPrWorkspaces(cfg: Config): Promise<void> 
 export async function prepareLocalPrWorkspace(
   params: PrepareLocalPrWorkspaceParams,
 ): Promise<LocalPrWorkspace> {
-  const { cfg, owner, repo, prNumber, baseSha, headSha, installationToken } = params;
+  const { cfg, owner, repo, prNumber, baseSha, headSha, installationToken, baseRef } = params;
   assertRepoPart(owner, "owner");
   assertRepoPart(repo, "repo");
   assertSha(baseSha, "baseSha");
@@ -346,7 +347,15 @@ export async function prepareLocalPrWorkspace(
     await mkdir(agentCwd, { recursive: true });
     await git(["init"], cfg.localWorkspaceCloneTimeoutMs);
     await git(["remote", "add", "origin", remoteUrl]);
-    await git(["fetch", "--no-tags", "--depth=1", "origin", baseSha]);
+    if (baseRef) {
+      try {
+        await git(["fetch", "--no-tags", "origin", baseRef]);
+      } catch {
+        await git(["fetch", "--no-tags", "--depth=1", "origin", baseSha]);
+      }
+    } else {
+      await git(["fetch", "--no-tags", "--depth=1", "origin", baseSha]);
+    }
     await fetchPullHeadForMergeBase();
     const nameStatus = await git([
       "diff",

--- a/src/agentWork/prRepositoryView.ts
+++ b/src/agentWork/prRepositoryView.ts
@@ -22,21 +22,21 @@ export type PreparePrRepositoryViewParams = {
   readonly installationToken: string;
 };
 
-async function fetchPullRequestShas(
+async function fetchPullRequestInfo(
   token: string,
   owner: string,
   repo: string,
   prNumber: number,
-): Promise<{ baseSha: string; headSha: string }> {
+): Promise<{ baseSha: string; headSha: string; baseRef: string }> {
   const octokit = installationOctokit(token);
   const { data } = await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber });
-  return { baseSha: data.base.sha, headSha: data.head.sha };
+  return { baseSha: data.base.sha, headSha: data.head.sha, baseRef: data.base.ref };
 }
 
 export async function preparePrRepositoryView(
   params: PreparePrRepositoryViewParams,
 ): Promise<PrRepositoryView> {
-  const shas = await fetchPullRequestShas(
+  const info = await fetchPullRequestInfo(
     params.installationToken,
     params.owner,
     params.repo,
@@ -47,9 +47,10 @@ export async function preparePrRepositoryView(
     owner: params.owner,
     repo: params.repo,
     prNumber: params.prNumber,
-    baseSha: shas.baseSha,
+    baseSha: info.baseSha,
     headSha: params.headSha,
     installationToken: params.installationToken,
+    baseRef: info.baseRef,
   });
   return {
     workspace,

--- a/test/localPrWorkspace.test.ts
+++ b/test/localPrWorkspace.test.ts
@@ -62,6 +62,7 @@ describe("local PR workspace", () => {
         repo: "repo",
         prNumber: 1,
         baseSha,
+        baseRef: "base",
         headSha,
         installationToken: "unused",
         remoteUrlOverride: remote,


### PR DESCRIPTION
The local PR workspace fetches the base commit SHA with `--depth=1`, creating an orphan commit with no parent history. When the base branch has moved forward since the PR was opened, `git merge-base` cannot find a common ancestor with the PR head, causing every review attempt to fail permanently after 3 retries.

**Fix:** Fetch the base branch by ref name (e.g. `main`) instead of the base SHA. This pulls the full branch history into the object database, guaranteeing `merge-base` succeeds. A shallow fallback is preserved for callers that don't supply a branch ref.

**Changes:**
- `localPrWorkspace.ts`: add optional `baseRef` param; prefer `git fetch origin <baseRef>` over shallow SHA fetch, with fallback
- `prRepositoryView.ts`: pass `data.base.ref` from Octokit `pulls.get` into workspace preparation
- `localPrWorkspace.test.ts`: pass `baseRef: "base"` in the existing test