### PR TITLE
Abort superseded and cancelled review runs early

### DIFF
--- a/src/agent/reviewRun.ts
+++ b/src/agent/reviewRun.ts
@@ -9,6 +9,7 @@ export type ReviewRunResult = {
   lastAssistant: AssistantMessage;
   published: boolean;
   publishAttempts: number;
+  publishSuperseded: boolean;
 };
 
 export async function runFullPrReview(params: {

--- a/src/agent/reviewRunHarness.ts
+++ b/src/agent/reviewRunHarness.ts
@@ -119,6 +119,9 @@ export async function runReviewHarness(params: {
       repair < VALIDATION_REPAIR_ROUNDS && !setup.submitState.published;
       repair++
     ) {
+      if (setup.submitState.aborted) {
+        break;
+      }
       const validationError = setup.submitState.lastValidationError;
       if (!validationError) break;
       setup.submitState.lastValidationError = null;
@@ -154,6 +157,9 @@ export async function runReviewHarness(params: {
     if (!setup.submitState.published) {
       recordReviewMetric({ kind: "prose_only", phase: "pre_submit" });
       for (let round = 0; round < 2 && !setup.submitState.published; round++) {
+        if (setup.submitState.aborted) {
+          break;
+        }
         const prompt =
           round === 0
             ? [PROSE_ONLY_NUDGE, PRE_SUBMIT_USER_MESSAGE].join("\n\n")
@@ -166,6 +172,9 @@ export async function runReviewHarness(params: {
   };
 
   const runPublishRecoveryPhase = async (attemptIndex: number) => {
+    if (setup.submitState.aborted) {
+      return;
+    }
     recordReviewMetric({ kind: "phase_enter", phase: "publish_recovery" });
     const prompt =
       PUBLISH_RECOVERY_PROMPTS[attemptIndex - 1] ??
@@ -185,6 +194,9 @@ export async function runReviewHarness(params: {
       session.restrictToTools(submitOnly.piTools, submitOnly.executors);
     }
     for (let round = 0; round < PUBLISH_RECOVERY_ROUNDS && !setup.submitState.published; round++) {
+      if (setup.submitState.aborted) {
+        break;
+      }
       lastText = (
         await session.send(
           [
@@ -235,6 +247,9 @@ export async function runReviewHarness(params: {
       attempt < cfg.maxReviewPublishAttempts && !setup.submitState.published;
       attempt++
     ) {
+      if (setup.submitState.aborted) {
+        break;
+      }
       publishAttempts = attempt + 1;
       if (attempt === 0) {
         await runInvestigationPhase();
@@ -257,7 +272,7 @@ export async function runReviewHarness(params: {
         pr: prNumber,
         willRescheduleStaleHead,
       });
-      if (!willRescheduleStaleHead) {
+      if (!willRescheduleStaleHead && !setup.submitState.aborted) {
         await runMaintainerPlaintextFallback();
       }
     }

--- a/src/agent/reviewRunHarness.ts
+++ b/src/agent/reviewRunHarness.ts
@@ -27,7 +27,11 @@ import {
   recordReviewMetric,
   setReviewRunMetricFields,
 } from "./reviewRunMetrics.js";
-import { buildReviewRunSetup, buildSubmitOnlyReviewSessionTools } from "./reviewRunSetup.js";
+import {
+  buildReviewRunSetup,
+  buildSubmitOnlyReviewSessionTools,
+  shouldContinueReviewRun,
+} from "./reviewRunSetup.js";
 
 function assistantFromText(cfg: Config, text: string, provider: string): AssistantMessage {
   return {
@@ -116,12 +120,9 @@ export async function runReviewHarness(params: {
     recordReviewMetric({ kind: "phase_enter", phase });
     for (
       let repair = 0;
-      repair < VALIDATION_REPAIR_ROUNDS && !setup.submitState.published;
+      repair < VALIDATION_REPAIR_ROUNDS && shouldContinueReviewRun(setup);
       repair++
     ) {
-      if (setup.submitState.aborted) {
-        break;
-      }
       const validationError = setup.submitState.lastValidationError;
       if (!validationError) break;
       setup.submitState.lastValidationError = null;
@@ -132,6 +133,7 @@ export async function runReviewHarness(params: {
           `Minimal valid example:\n${JSON.stringify(REVIEW_PAYLOAD_MINIMAL_EXAMPLE, null, 2)}`,
         ].join("\n\n"),
       );
+      if (!shouldContinueReviewRun(setup)) break;
     }
   };
 
@@ -139,11 +141,12 @@ export async function runReviewHarness(params: {
     recordReviewMetric({ kind: "phase_enter", phase: "investigation" });
     const investigationOpts = { maxToolRounds: cfg.maxToolRounds };
     lastText = (await session.send(setup.userContent, investigationOpts)).text;
+    if (!shouldContinueReviewRun(setup)) return;
 
     if (
       cfg.reviewInjectAnchorMenu &&
       setup.cachedDiffIndex.files.size > 0 &&
-      !setup.submitState.published
+      shouldContinueReviewRun(setup)
     ) {
       const anchorMenu = renderAnchorMenuBlock(setup.cachedDiffIndex, {
         maxFiles: cfg.reviewAnchorMenuMaxFiles,
@@ -151,30 +154,29 @@ export async function runReviewHarness(params: {
       });
       if (anchorMenu) {
         lastText = (await session.send(anchorMenu, investigationOpts)).text;
+        if (!shouldContinueReviewRun(setup)) return;
       }
     }
 
-    if (!setup.submitState.published) {
+    if (shouldContinueReviewRun(setup)) {
       recordReviewMetric({ kind: "prose_only", phase: "pre_submit" });
-      for (let round = 0; round < 2 && !setup.submitState.published; round++) {
-        if (setup.submitState.aborted) {
-          break;
-        }
+      for (let round = 0; round < 2 && shouldContinueReviewRun(setup); round++) {
         const prompt =
           round === 0
             ? [PROSE_ONLY_NUDGE, PRE_SUBMIT_USER_MESSAGE].join("\n\n")
             : PRE_SUBMIT_USER_MESSAGE;
         lastText = await sendSubmitOnlyRepair(prompt);
+        if (!shouldContinueReviewRun(setup)) break;
       }
     }
 
-    await runValidationRepair("validation_repair");
+    if (shouldContinueReviewRun(setup)) {
+      await runValidationRepair("validation_repair");
+    }
   };
 
   const runPublishRecoveryPhase = async (attemptIndex: number) => {
-    if (setup.submitState.aborted) {
-      return;
-    }
+    if (!shouldContinueReviewRun(setup)) return;
     recordReviewMetric({ kind: "phase_enter", phase: "publish_recovery" });
     const prompt =
       PUBLISH_RECOVERY_PROMPTS[attemptIndex - 1] ??
@@ -193,10 +195,11 @@ export async function runReviewHarness(params: {
       const submitOnly = buildSubmitOnlyReviewSessionTools(setup);
       session.restrictToTools(submitOnly.piTools, submitOnly.executors);
     }
-    for (let round = 0; round < PUBLISH_RECOVERY_ROUNDS && !setup.submitState.published; round++) {
-      if (setup.submitState.aborted) {
-        break;
-      }
+    for (
+      let round = 0;
+      round < PUBLISH_RECOVERY_ROUNDS && shouldContinueReviewRun(setup);
+      round++
+    ) {
       lastText = (
         await session.send(
           [
@@ -205,8 +208,11 @@ export async function runReviewHarness(params: {
           ].join("\n\n"),
         )
       ).text;
+      if (!shouldContinueReviewRun(setup)) break;
     }
-    await runValidationRepair("validation_repair");
+    if (shouldContinueReviewRun(setup)) {
+      await runValidationRepair("validation_repair");
+    }
     if (isLastAttempt) {
       session.restoreTools();
     }
@@ -244,12 +250,9 @@ export async function runReviewHarness(params: {
   try {
     for (
       let attempt = 0;
-      attempt < cfg.maxReviewPublishAttempts && !setup.submitState.published;
+      attempt < cfg.maxReviewPublishAttempts && shouldContinueReviewRun(setup);
       attempt++
     ) {
-      if (setup.submitState.aborted) {
-        break;
-      }
       publishAttempts = attempt + 1;
       if (attempt === 0) {
         await runInvestigationPhase();
@@ -272,7 +275,7 @@ export async function runReviewHarness(params: {
         pr: prNumber,
         willRescheduleStaleHead,
       });
-      if (!willRescheduleStaleHead && !setup.submitState.aborted) {
+      if (!willRescheduleStaleHead && shouldContinueReviewRun(setup)) {
         await runMaintainerPlaintextFallback();
       }
     }
@@ -290,5 +293,6 @@ export async function runReviewHarness(params: {
     lastAssistant: assistantFromText(cfg, lastText, providerName),
     published: setup.submitState.published,
     publishAttempts,
+    publishSuperseded: setup.submitState.publishSuperseded,
   };
 }

--- a/src/agent/reviewRunSetup.ts
+++ b/src/agent/reviewRunSetup.ts
@@ -32,6 +32,11 @@ export type ReviewRunSetup = {
   readonly refreshBeforeTool: (toolName: string) => Promise<void>;
 };
 
+/** True while the harness should keep investigating or retrying publish. */
+export function shouldContinueReviewRun(setup: Pick<ReviewRunSetup, "submitState">): boolean {
+  return !setup.submitState.published && !setup.submitState.publishSuperseded;
+}
+
 const TOKEN_REFRESH_TOOL = "getPullRequest";
 
 export function buildReviewRunSetup(params: {

--- a/src/agent/submitReviewTool.ts
+++ b/src/agent/submitReviewTool.ts
@@ -30,6 +30,7 @@ export type SubmitReviewState = {
   lastValidationError: string | null;
   publishCallCount: number;
   publishCallsExhausted: boolean;
+  aborted: boolean;
 };
 
 export function createSubmitReviewState(
@@ -42,6 +43,7 @@ export function createSubmitReviewState(
     lastValidationError: null,
     publishCallCount: 0,
     publishCallsExhausted: false,
+    aborted: false,
   };
 }
 
@@ -193,6 +195,7 @@ export function buildSubmitReviewTool(params: {
           repo: params.ctx.repo,
           pr: params.ctx.prNumber,
         });
+        params.state.aborted = true;
         throw new Error("Review publish skipped: work superseded or cancelled");
       }
     }

--- a/src/agent/submitReviewTool.ts
+++ b/src/agent/submitReviewTool.ts
@@ -30,7 +30,8 @@ export type SubmitReviewState = {
   lastValidationError: string | null;
   publishCallCount: number;
   publishCallsExhausted: boolean;
-  aborted: boolean;
+  /** Set only by submitReview when publish is skipped (superseded, cancelled, or abort-check failed). */
+  publishSuperseded: boolean;
 };
 
 export function createSubmitReviewState(
@@ -43,7 +44,7 @@ export function createSubmitReviewState(
     lastValidationError: null,
     publishCallCount: 0,
     publishCallsExhausted: false,
-    aborted: false,
+    publishSuperseded: false,
   };
 }
 
@@ -195,7 +196,7 @@ export function buildSubmitReviewTool(params: {
           repo: params.ctx.repo,
           pr: params.ctx.prNumber,
         });
-        params.state.aborted = true;
+        params.state.publishSuperseded = true;
         throw new Error("Review publish skipped: work superseded or cancelled");
       }
     }

--- a/src/agentWork/worker.ts
+++ b/src/agentWork/worker.ts
@@ -400,15 +400,24 @@ async function handleReviewJob(
           };
         }
         if (!result.published) {
-          logWarn("review_not_published", {
-            owner: item.owner,
-            repo: item.repo,
-            pr: item.prNumber,
-            publishAttempts: result.publishAttempts,
-            publishDegraded: true,
-          });
+          if (result.publishSuperseded) {
+            logInfo("review_publish_superseded", {
+              owner: item.owner,
+              repo: item.repo,
+              pr: item.prNumber,
+              publishAttempts: result.publishAttempts,
+            });
+          } else {
+            logWarn("review_not_published", {
+              owner: item.owner,
+              repo: item.repo,
+              pr: item.prNumber,
+              publishAttempts: result.publishAttempts,
+              publishDegraded: true,
+            });
+          }
         }
-        return { degraded: !result.published };
+        return { degraded: !result.published && !result.publishSuperseded };
       } finally {
         await repositoryView.cleanup();
       }

--- a/test/reviewRun.test.ts
+++ b/test/reviewRun.test.ts
@@ -11,15 +11,19 @@ vi.mock("../src/github/reviewPublish.js", () => ({
 }));
 
 const sendMock = vi.fn(async () => ({ text: "analysis without submitReview" }));
-const createSessionMock = vi.fn(async (params: { systemPrompt: string }) => {
-  capturedSystemPrompt = params.systemPrompt;
-  return {
-    send: sendMock,
-    restrictToTools: vi.fn(),
-    restoreTools: vi.fn(),
-    dispose: vi.fn(async () => undefined),
-  };
-});
+let capturedExecutors: Record<string, any> = {};
+const createSessionMock = vi.fn(
+  async (params: { systemPrompt: string; executors: Record<string, any> }) => {
+    capturedSystemPrompt = params.systemPrompt;
+    capturedExecutors = params.executors;
+    return {
+      send: sendMock,
+      restrictToTools: vi.fn(),
+      restoreTools: vi.fn(),
+      dispose: vi.fn(async () => undefined),
+    };
+  },
+);
 
 let capturedSystemPrompt = "";
 
@@ -180,5 +184,34 @@ describe("runFullPrReview publish retries", () => {
       }),
     );
     infoSpy.mockRestore();
+  });
+
+  it("aborts early and does not post fallback comment if shouldAbortPublish returns true", async () => {
+    sendMock.mockImplementation(async () => {
+      try {
+        await capturedExecutors.submitReview({
+          prCharacter: "Does things.",
+          findings: [],
+          estimatedEffort: 1,
+          relevantTests: "no",
+          securityConcerns: null,
+          followUps: [],
+        });
+      } catch {
+        // Expected
+      }
+      return { text: "aborted review attempt" };
+    });
+
+    const result = await runFullPrReview(
+      reviewParams({
+        cfg: { ...cfg, reviewRequireDiffCacheBeforeSubmit: false },
+        shouldAbortPublish: async () => true,
+      }),
+    );
+
+    expect(result.published).toBe(false);
+    expect(result.publishAttempts).toBe(1);
+    expect(upsertReviewSummaryComment).not.toHaveBeenCalled();
   });
 });

--- a/test/reviewRun.test.ts
+++ b/test/reviewRun.test.ts
@@ -11,9 +11,10 @@ vi.mock("../src/github/reviewPublish.js", () => ({
 }));
 
 const sendMock = vi.fn(async () => ({ text: "analysis without submitReview" }));
-let capturedExecutors: Record<string, any> = {};
+type ReviewExecutor = (args: Record<string, unknown>) => Promise<unknown>;
+let capturedExecutors: Record<string, ReviewExecutor> = {};
 const createSessionMock = vi.fn(
-  async (params: { systemPrompt: string; executors: Record<string, any> }) => {
+  async (params: { systemPrompt: string; executors: Record<string, ReviewExecutor> }) => {
     capturedSystemPrompt = params.systemPrompt;
     capturedExecutors = params.executors;
     return {
@@ -212,6 +213,7 @@ describe("runFullPrReview publish retries", () => {
 
     expect(result.published).toBe(false);
     expect(result.publishAttempts).toBe(1);
+    expect(result.publishSuperseded).toBe(true);
     expect(upsertReviewSummaryComment).not.toHaveBeenCalled();
   });
 });

--- a/test/reviewRunSetup.test.ts
+++ b/test/reviewRunSetup.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { createSubmitReviewState } from "../src/agent/submitReviewTool.js";
+import { shouldContinueReviewRun } from "../src/agent/reviewRunSetup.js";
+
+describe("shouldContinueReviewRun", () => {
+  it("returns false when publishSuperseded is set", () => {
+    const submitState = createSubmitReviewState();
+    submitState.publishSuperseded = true;
+    expect(shouldContinueReviewRun({ submitState })).toBe(false);
+  });
+
+  it("returns false when already published", () => {
+    const submitState = createSubmitReviewState({ published: true });
+    expect(shouldContinueReviewRun({ submitState })).toBe(false);
+  });
+
+  it("returns true while unpublished and not superseded", () => {
+    const submitState = createSubmitReviewState();
+    expect(shouldContinueReviewRun({ submitState })).toBe(true);
+  });
+});

--- a/test/submitReviewTool.test.ts
+++ b/test/submitReviewTool.test.ts
@@ -135,6 +135,31 @@ describe("submitReview tool", () => {
     await expect(executor(valid)).rejects.toThrow(/superseded or cancelled/i);
     expect(publishReview).not.toHaveBeenCalled();
     expect(state.publishCallCount).toBe(0);
+    expect(state.publishSuperseded).toBe(true);
+  });
+
+  it("sets publishSuperseded when shouldAbortPublish returns true", async () => {
+    const state = createSubmitReviewState();
+    const { executor } = buildSubmitReviewTool({
+      cfg,
+      token: "tok",
+      ctx: { owner: "o", repo: "r", prNumber: 1, headSha: "sha" },
+      state,
+      canEnforceDiffCacheBeforeSubmit: () => false,
+      shouldAbortPublish: async () => true,
+    });
+    const valid = {
+      prCharacter: "Does things.",
+      findings: [],
+      estimatedEffort: 1,
+      relevantTests: "no" as const,
+      securityConcerns: null,
+      followUps: [],
+    };
+
+    await expect(executor(valid)).rejects.toThrow(/superseded or cancelled/i);
+    expect(state.publishSuperseded).toBe(true);
+    expect(publishReview).not.toHaveBeenCalled();
   });
 
   it("mentions the security summary sentinel in the tool description", () => {


### PR DESCRIPTION
## Summary
- **Track aborted state:** Added an `aborted` flag to `SubmitReviewState` in `submitReviewTool.ts`, setting it to `true` when a review publish is cooperatively cancelled or superseded.
- **Harness early exit:** Modified the `runReviewHarness` loops and sub-routines in `reviewRunHarness.ts` to immediately break out of validation repair, prose-only, and publish recovery cycles on abort, stopping redundant retry loops.
- **Suppress fallback comments:** Avoided posting plain-text fallback failure notices when the review run has been intentionally aborted due to supersession or cancellation.
- **Regression test coverage:** Added a new unit test in `reviewRun.test.ts` to verify early exit behavior and ensure no fallback comment is posted on abort.

## Test plan
- Run the unit test suite: `pnpm test test/reviewRun.test.ts` to ensure the early-exit behavior works deterministically under abort conditions.
- Run complete codebase checks: `pnpm check:code` to verify that lint, formatting, and type-checks are perfectly green.