### PR TITLE
Fix /ask posting interim narration as answer

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -151,7 +151,6 @@ These are related but not wired together on INSERT today.
 | `RATE_LIMIT_CIRCUIT_THRESHOLD`       | 3                                      |
 | `VALIDATION_REPAIR_ROUNDS`           | 3                                      |
 | `PUBLISH_RECOVERY_ROUNDS`            | 4                                      |
-| `ASK_RETRY_ROUNDS`                   | 4                                      |
 | `PUBLISH_RECOVERY_PROMPTS`           | recovery nudge strings                 |
 | `REVIEW_*_CIRCUIT_OPEN_*`            | rate-limit circuit messages            |
 | `ASK_*_CIRCUIT_OPEN_*`               | ask circuit messages                   |

--- a/src/agent/askRunHarness.ts
+++ b/src/agent/askRunHarness.ts
@@ -2,7 +2,7 @@ import { logInfo } from "../evlog.js";
 import { buildAskSystemPrompt } from "./askPrompt.js";
 import { formatAskFailureReply, formatAskReply } from "./formatAskReply.js";
 import { buildContext7Tools } from "./context7Tools.js";
-import { ASK_FAILURE_MESSAGE, ASK_RETRY_NUDGE, ASK_RETRY_ROUNDS } from "../settings/index.js";
+import { ASK_FAILURE_MESSAGE, ASK_RETRY_NUDGE } from "../settings/index.js";
 import { resolveAgentRunnerProvider } from "./providers/index.js";
 import { buildAskUserContent, type AskRunParams, type AskRunResult } from "./askRun.js";
 import { buildAskRunSetup } from "./askRunSetup.js";
@@ -30,20 +30,15 @@ export async function runAskHarness(params: AskRunParams): Promise<AskRunResult>
     const sendOpts = { maxToolRounds: cfg.maxAskToolRounds };
     let lastText = (await session.send(buildAskUserContent(params), sendOpts)).text.trim();
 
-    if (!lastText) {
-      lastText = (await session.send(ASK_RETRY_NUDGE, sendOpts)).text.trim();
-    }
-
-    for (let round = 0; round < ASK_RETRY_ROUNDS && !lastText; round++) {
-      lastText = (await session.send(ASK_RETRY_NUDGE, sendOpts)).text.trim();
-    }
-
-    if (!lastText) {
-      lastText = (
-        await session.send(
-          "Respond with plain text only (no tool calls). Answer the question using what you found, or explain clearly what blocked a complete answer.",
-        )
-      ).text.trim();
+    if (!lastText && cfg.maxAskFinalizeRounds > 0) {
+      session.restrictToTools([], {});
+      try {
+        for (let round = 0; round < cfg.maxAskFinalizeRounds && !lastText; round++) {
+          lastText = (await session.send(ASK_RETRY_NUDGE)).text.trim();
+        }
+      } finally {
+        session.restoreTools();
+      }
     }
 
     const answerText =

--- a/src/agent/providers/pi/index.ts
+++ b/src/agent/providers/pi/index.ts
@@ -23,6 +23,23 @@ function toolResultToText(result: unknown): string {
   return typeof result === "string" ? result : JSON.stringify(result, null, 2);
 }
 
+function assistantMessageText(message: { role: string; content: unknown }): string {
+  if (message.role !== "assistant" || !Array.isArray(message.content)) return "";
+  return message.content
+    .filter(
+      (part): part is { type: "text"; text: string } =>
+        typeof part === "object" &&
+        part !== null &&
+        "type" in part &&
+        part.type === "text" &&
+        "text" in part &&
+        typeof part.text === "string",
+    )
+    .map((part) => part.text)
+    .join("\n")
+    .trim();
+}
+
 function toCodingAgentTool(
   tool: PiTool,
   executor: AgentRunnerToolExecutor | undefined,
@@ -105,29 +122,24 @@ export const piAgentRunnerProvider: AgentRunnerProvider = {
     return {
       async send(prompt: string, opts?: AgentRunnerSendOptions) {
         sessionToolTurnCount = 0;
-        const chunks: string[] = [];
+        let finalText = "";
         const unsubscribe = session.subscribe((event) => {
-          if (
-            event.type === "message_update" &&
-            event.assistantMessageEvent.type === "text_delta"
-          ) {
-            chunks.push(event.assistantMessageEvent.delta);
-          }
-          if (opts?.maxToolRounds != null && event.type === "turn_end") {
-            sessionToolTurnCount += 1;
-            if (sessionToolTurnCount >= opts.maxToolRounds && event.toolResults.length > 0) {
-              void session.abort();
-            }
+          if (event.type !== "turn_end") return;
+          sessionToolTurnCount += 1;
+          if (event.toolResults.length === 0) {
+            finalText = assistantMessageText(event.message as { role: string; content: unknown });
+          } else if (opts?.maxToolRounds != null && sessionToolTurnCount >= opts.maxToolRounds) {
+            void session.abort();
           }
         });
         try {
           await session.prompt(prompt);
-          return { text: chunks.join("") };
+          return { text: finalText };
         } finally {
           unsubscribe();
         }
       },
-      restrictToTools(nextTools) {
+      restrictToTools(nextTools, _executors) {
         session.setActiveToolsByName(nextTools.map((tool) => tool.name));
       },
       restoreTools() {

--- a/src/agent/providers/pi/index.ts
+++ b/src/agent/providers/pi/index.ts
@@ -9,7 +9,8 @@ import {
   SessionManager,
   SettingsManager,
 } from "@earendil-works/pi-coding-agent";
-import type { Tool as PiTool } from "@earendil-works/pi-ai";
+import type { TurnEndEvent } from "@earendil-works/pi-coding-agent";
+import type { TextContent, Tool as PiTool } from "@earendil-works/pi-ai";
 import { mkdtemp, rm, chmod } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -23,18 +24,10 @@ function toolResultToText(result: unknown): string {
   return typeof result === "string" ? result : JSON.stringify(result, null, 2);
 }
 
-function assistantMessageText(message: { role: string; content: unknown }): string {
-  if (message.role !== "assistant" || !Array.isArray(message.content)) return "";
+function assistantMessageText(message: TurnEndEvent["message"]): string {
+  if (message.role !== "assistant") return "";
   return message.content
-    .filter(
-      (part): part is { type: "text"; text: string } =>
-        typeof part === "object" &&
-        part !== null &&
-        "type" in part &&
-        part.type === "text" &&
-        "text" in part &&
-        typeof part.text === "string",
-    )
+    .filter((part): part is TextContent => part.type === "text")
     .map((part) => part.text)
     .join("\n")
     .trim();
@@ -102,7 +95,6 @@ export const piAgentRunnerProvider: AgentRunnerProvider = {
     await resourceLoader.reload();
     const model = getModel(cfg.piProvider, cfg.piModel as never);
     const allToolNames = tools.map((tool) => tool.name);
-    let sessionToolTurnCount = 0;
     const { session } = await createAgentSession({
       cwd: cwd ?? process.cwd(),
       agentDir,
@@ -121,13 +113,14 @@ export const piAgentRunnerProvider: AgentRunnerProvider = {
 
     return {
       async send(prompt: string, opts?: AgentRunnerSendOptions) {
-        sessionToolTurnCount = 0;
+        let sessionToolTurnCount = 0;
         let finalText = "";
         const unsubscribe = session.subscribe((event) => {
           if (event.type !== "turn_end") return;
           sessionToolTurnCount += 1;
+          // A tool-free turn is the terminal turn of prompt(); capture only that answer text.
           if (event.toolResults.length === 0) {
-            finalText = assistantMessageText(event.message as { role: string; content: unknown });
+            finalText = assistantMessageText(event.message);
           } else if (opts?.maxToolRounds != null && sessionToolTurnCount >= opts.maxToolRounds) {
             void session.abort();
           }
@@ -139,6 +132,7 @@ export const piAgentRunnerProvider: AgentRunnerProvider = {
           unsubscribe();
         }
       },
+      // customTools are fixed at session creation; restrictToTools only toggles active names.
       restrictToTools(nextTools, _executors) {
         session.setActiveToolsByName(nextTools.map((tool) => tool.name));
       },

--- a/src/settings/constants.ts
+++ b/src/settings/constants.ts
@@ -137,7 +137,6 @@ export const PUBLISH_RECOVERY_PROMPTS = [
 
 export const VALIDATION_REPAIR_ROUNDS = 3;
 
-export const ASK_RETRY_ROUNDS = 4;
 export const ASK_RETRY_NUDGE =
   "Answer the question now in plain text based on your investigation above. Do not call more tools unless absolutely required to fix a factual gap.";
 

--- a/test/askRunHarness.test.ts
+++ b/test/askRunHarness.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { Config } from "../src/config.js";
+import { ASK_FAILURE_MESSAGE } from "../src/settings/index.js";
+
+vi.mock("../src/agent/askSafety.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/agent/askSafety.js")>();
+  return {
+    ...actual,
+    buildAskGithubTools: vi.fn(() => ({
+      piTools: [
+        {
+          name: "listPullRequestFiles",
+          description: "d",
+          parameters: { type: "object", properties: {} },
+        },
+      ],
+      executors: {
+        listPullRequestFiles: vi.fn(async () => ({ files: [] })),
+      },
+    })),
+  };
+});
+
+vi.mock("../src/agent/context7Tools.js", () => ({
+  buildContext7Tools: vi.fn(() => ({ piTools: [], executors: {} })),
+}));
+
+const sendMock = vi.fn();
+const restrictToToolsMock = vi.fn();
+const restoreToolsMock = vi.fn();
+const disposeMock = vi.fn(async () => undefined);
+
+vi.mock("../src/agent/providers/index.js", () => ({
+  resolveAgentRunnerProvider: () => ({
+    createSession: vi.fn(async () => ({
+      send: sendMock,
+      restrictToTools: restrictToToolsMock,
+      restoreTools: restoreToolsMock,
+      dispose: disposeMock,
+    })),
+  }),
+}));
+
+import { runAskHarness } from "../src/agent/askRunHarness.js";
+
+const cfg = {
+  port: 0,
+  githubAppId: "1",
+  githubAppPrivateKey: "k",
+  webhookSecret: "s",
+  agentProvider: "pi",
+  piProvider: "openai",
+  piModel: "gpt-4o-mini",
+  maxToolRounds: 2,
+  maxReviewPublishAttempts: 3,
+  maxReviewPublishCalls: 2,
+  reviewConcurrency: 1,
+  askConcurrency: 3,
+  maxAskToolRounds: 12,
+  maxAskFinalizeRounds: 2,
+  webhookTimeoutMs: 10_000,
+  logLevel: "error",
+  enableReviewLabelsEffort: false,
+  enableReviewLabelsSecurity: false,
+  maxPrFilesListed: 300,
+  maxPrFilesPatchBytes: 500_000,
+  context7ApiKey: "",
+} satisfies Config;
+
+const askParams = {
+  cfg,
+  token: "t",
+  tokenExpiresAtTs: Date.now() + 3_600_000,
+  tokenTtlMs: 3_600_000,
+  owner: "o",
+  repo: "r",
+  prNumber: 459,
+  headSha: "sha",
+  question: "Explain changes and provide a testing checklist.",
+  replyTarget: { kind: "prConversation" as const, prNumber: 459 },
+};
+
+describe("runAskHarness finalize", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("tool-restricted finalize runs when investigation returns empty text", async () => {
+    sendMock
+      .mockResolvedValueOnce({ text: "" })
+      .mockResolvedValueOnce({ text: "End-user summary and E2E checklist." });
+
+    const result = await runAskHarness(askParams);
+
+    expect(sendMock).toHaveBeenCalledTimes(2);
+    expect(sendMock.mock.calls[0]?.[1]).toEqual({ maxToolRounds: 12 });
+    expect(sendMock.mock.calls[1]?.[1]).toBeUndefined();
+    expect(restrictToToolsMock).toHaveBeenCalledWith([], {});
+    expect(restoreToolsMock).toHaveBeenCalled();
+    expect(result.answer).toContain("End-user summary and E2E checklist.");
+    expect(result.answer).not.toContain("I'll examine");
+  });
+
+  it("posts failure message when investigation and finalize both return empty", async () => {
+    sendMock.mockResolvedValue({ text: "" });
+
+    const result = await runAskHarness(askParams);
+
+    expect(sendMock).toHaveBeenCalledTimes(3);
+    expect(restrictToToolsMock).toHaveBeenCalledWith([], {});
+    expect(restoreToolsMock).toHaveBeenCalled();
+    expect(result.answer).toContain(ASK_FAILURE_MESSAGE);
+  });
+});

--- a/test/askRunHarness.test.ts
+++ b/test/askRunHarness.test.ts
@@ -111,4 +111,18 @@ describe("runAskHarness finalize", () => {
     expect(restoreToolsMock).toHaveBeenCalled();
     expect(result.answer).toContain(ASK_FAILURE_MESSAGE);
   });
+
+  it("skips finalize when maxAskFinalizeRounds is zero", async () => {
+    sendMock.mockResolvedValueOnce({ text: "" });
+
+    const result = await runAskHarness({
+      ...askParams,
+      cfg: { ...cfg, maxAskFinalizeRounds: 0 },
+    });
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(restrictToToolsMock).not.toHaveBeenCalled();
+    expect(restoreToolsMock).not.toHaveBeenCalled();
+    expect(result.answer).toContain(ASK_FAILURE_MESSAGE);
+  });
 });

--- a/test/piAgentRunner.test.ts
+++ b/test/piAgentRunner.test.ts
@@ -1,23 +1,27 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import type { Config } from "../src/config.js";
 
-type TurnEndEvent = {
+type MockTurnEndEvent = {
   type: "turn_end";
   toolResults: unknown[];
   message: {
     role: "assistant";
-    content: Array<{ type: "text"; text: string }>;
+    content: Array<
+      | { type: "text"; text: string }
+      | { type: "thinking"; thinking: string }
+      | { type: "toolCall"; id: string; name: string; arguments: Record<string, unknown> }
+    >;
   };
 };
 
-function makeAssistantMessage(text: string): TurnEndEvent["message"] {
+function makeAssistantMessage(text: string): MockTurnEndEvent["message"] {
   return { role: "assistant", content: [{ type: "text", text }] };
 }
 
-function buildMockSession(script: (emit: (event: TurnEndEvent) => void) => void) {
-  const listeners = new Set<(event: TurnEndEvent) => void>();
+function buildMockSession(script: (emit: (event: MockTurnEndEvent) => void) => void) {
+  const listeners = new Set<(event: MockTurnEndEvent) => void>();
   return {
-    subscribe(listener: (event: TurnEndEvent) => void) {
+    subscribe(listener: (event: MockTurnEndEvent) => void) {
       listeners.add(listener);
       return () => listeners.delete(listener);
     },
@@ -139,5 +143,38 @@ describe("piAgentRunnerProvider.send", () => {
     const result = await runnerSession.send("question", { maxToolRounds: 2 });
     expect(result.text).toBe("");
     expect(session.abort).toHaveBeenCalled();
+  });
+
+  it("returns only text parts from a terminal turn with mixed content", async () => {
+    const session = buildMockSession((emit) => {
+      emit({
+        type: "turn_end",
+        toolResults: [],
+        message: {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "internal reasoning" },
+            { type: "text", text: "Visible answer." },
+            {
+              type: "toolCall",
+              id: "tc1",
+              name: "listPullRequestFiles",
+              arguments: {},
+            },
+          ],
+        },
+      });
+    });
+    vi.mocked(createAgentSession).mockResolvedValue({ session } as never);
+
+    const runnerSession = await piAgentRunnerProvider.createSession({
+      cfg,
+      systemPrompt: "test",
+      tools: [],
+      executors: {},
+    });
+
+    const result = await runnerSession.send("question");
+    expect(result.text).toBe("Visible answer.");
   });
 });

--- a/test/piAgentRunner.test.ts
+++ b/test/piAgentRunner.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { Config } from "../src/config.js";
+
+type TurnEndEvent = {
+  type: "turn_end";
+  toolResults: unknown[];
+  message: {
+    role: "assistant";
+    content: Array<{ type: "text"; text: string }>;
+  };
+};
+
+function makeAssistantMessage(text: string): TurnEndEvent["message"] {
+  return { role: "assistant", content: [{ type: "text", text }] };
+}
+
+function buildMockSession(script: (emit: (event: TurnEndEvent) => void) => void) {
+  const listeners = new Set<(event: TurnEndEvent) => void>();
+  return {
+    subscribe(listener: (event: TurnEndEvent) => void) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    async prompt() {
+      script((event) => {
+        for (const listener of listeners) listener(event);
+      });
+    },
+    abort: vi.fn(),
+    setActiveToolsByName: vi.fn(),
+  };
+}
+
+vi.mock("@earendil-works/pi-ai", () => ({
+  getModel: vi.fn(() => ({ id: "test-model" })),
+}));
+
+vi.mock("@earendil-works/pi-coding-agent", () => ({
+  AuthStorage: {
+    create: vi.fn(() => ({
+      setRuntimeApiKey: vi.fn(),
+    })),
+  },
+  createAgentSession: vi.fn(),
+  createExtensionRuntime: vi.fn(),
+  defineTool: vi.fn((tool: unknown) => tool),
+  DefaultResourceLoader: vi.fn(function DefaultResourceLoader() {
+    return { reload: vi.fn(async () => undefined) };
+  }),
+  ModelRegistry: {
+    inMemory: vi.fn(() => ({})),
+    create: vi.fn(() => ({})),
+  },
+  SessionManager: { inMemory: vi.fn(() => ({})) },
+  SettingsManager: { inMemory: vi.fn(() => ({})) },
+}));
+
+import { createAgentSession } from "@earendil-works/pi-coding-agent";
+import { piAgentRunnerProvider } from "../src/agent/providers/pi/index.js";
+
+const cfg = {
+  port: 0,
+  githubAppId: "1",
+  githubAppPrivateKey: "k",
+  webhookSecret: "s",
+  agentProvider: "pi",
+  piProvider: "openai",
+  piModel: "gpt-4o-mini",
+  modelProviderKeys: { openai: "test-key" },
+  maxToolRounds: 2,
+  maxReviewPublishAttempts: 3,
+  maxReviewPublishCalls: 2,
+  reviewConcurrency: 1,
+  askConcurrency: 3,
+  maxAskToolRounds: 12,
+  maxAskFinalizeRounds: 2,
+  webhookTimeoutMs: 10_000,
+  logLevel: "error",
+  enableReviewLabelsEffort: false,
+  enableReviewLabelsSecurity: false,
+  maxPrFilesListed: 300,
+  maxPrFilesPatchBytes: 500_000,
+  context7ApiKey: "",
+} satisfies Config;
+
+describe("piAgentRunnerProvider.send", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns terminal answer-turn text and ignores commentary from tool-using turns", async () => {
+    const session = buildMockSession((emit) => {
+      emit({
+        type: "turn_end",
+        toolResults: [{}],
+        message: makeAssistantMessage("I'll examine the PR.Now let me check files."),
+      });
+      emit({
+        type: "turn_end",
+        toolResults: [],
+        message: makeAssistantMessage("End-user summary and testing checklist."),
+      });
+    });
+    vi.mocked(createAgentSession).mockResolvedValue({ session } as never);
+
+    const runnerSession = await piAgentRunnerProvider.createSession({
+      cfg,
+      systemPrompt: "test",
+      tools: [],
+      executors: {},
+    });
+
+    const result = await runnerSession.send("question");
+    expect(result.text).toBe("End-user summary and testing checklist.");
+  });
+
+  it("returns empty text when aborted before a terminal answer turn", async () => {
+    const session = buildMockSession((emit) => {
+      emit({
+        type: "turn_end",
+        toolResults: [{}],
+        message: makeAssistantMessage("I'll examine the PR."),
+      });
+      emit({
+        type: "turn_end",
+        toolResults: [{}],
+        message: makeAssistantMessage("Let me check more files."),
+      });
+    });
+    vi.mocked(createAgentSession).mockResolvedValue({ session } as never);
+
+    const runnerSession = await piAgentRunnerProvider.createSession({
+      cfg,
+      systemPrompt: "test",
+      tools: [],
+      executors: {},
+    });
+
+    const result = await runnerSession.send("question", { maxToolRounds: 2 });
+    expect(result.text).toBe("");
+    expect(session.abort).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes `/ask` replies that posted the model's investigation narration (e.g. "I'll examine the PR…") instead of the actual answer when using the pi provider (including MiMo).

- **Pi runner** — `send()` now returns text only from the terminal answer turn (`turn_end` with no tool results), not all streamed `text_delta` chunks across tool-using turns
- **Ask harness** — When investigation yields no terminal answer, runs tool-restricted finalize passes via `maxAskFinalizeRounds` before falling back to the standard failure message
- **Config** — Removes unused `ASK_RETRY_ROUNDS`; finalize behavior is driven by the existing `MAX_ASK_FINALIZE_ROUNDS` env knob
- **Tests** — Regression coverage for pi `send()` terminal-text extraction and ask harness finalize/failure paths