### PR TITLE
fix: run auto describe only on PR open

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -107,6 +107,7 @@ These are related but not wired together on INSERT today.
 | `*_DEAD_LETTER_QUEUE`         | DLQ names                     |
 | `DEFERRED_HEAD_SHA`           | worker resolves head SHA      |
 | `AUTOMATED_PR_ACTIONS`        | opened, synchronize, reopened |
+| `AUTOMATED_DESCRIPTION_PR_ACTIONS` | opened only (use `/describe` after) |
 | `AUTOMATED_REVIEW_LENS`       | `review`                      |
 | `MAX_STORED_COMMENT_TEXT_LEN` | 16384                         |
 

--- a/src/agentWork/scheduler.ts
+++ b/src/agentWork/scheduler.ts
@@ -10,6 +10,7 @@ import {
 import type { ReplyTarget } from "../commands/replyTarget.js";
 import { parseSlashCommand } from "../commands/parseSlashCommand.js";
 import {
+  AUTOMATED_DESCRIPTION_PR_ACTIONS,
   AUTOMATED_PR_ACTIONS,
   AUTOMATED_REVIEW_LENS,
   MAX_STORED_COMMENT_TEXT_LEN,
@@ -439,34 +440,6 @@ export function makeAgentWorkScheduler(pool: Pool, boss: PgBoss) {
             });
             await enqueueReview(boss, client, ref, workItemId, AUTOMATED_REVIEW_LENS, correlation);
 
-            const descriptionTarget: AutoWorkSupersedeTarget = {
-              kind: "description",
-              resourceKey,
-            };
-            const { workItemId: descriptionWorkItemId, supersededIds: descriptionSuperseded } =
-              await replaceAutoWorkItem({
-                client,
-                target: descriptionTarget,
-                createWorkItem: () =>
-                  createDescriptionWorkItem(client, {
-                    webhookEventId: event.id,
-                    ref,
-                    source: "auto",
-                  }),
-              });
-            await releaseSingletonIfSuperseded({
-              boss,
-              db: slotDb,
-              supersededIds: descriptionSuperseded,
-              release: () =>
-                releaseSingletonSlot(boss, {
-                  queue: DESCRIPTION_QUEUE,
-                  singletonKey: descriptionSingletonKey(resourceKey),
-                  db: slotDb,
-                }),
-            });
-            await enqueueDescription(boss, client, ref, descriptionWorkItemId, correlation);
-
             recordEvent(intakeLog, "agent_work_enqueued", {
               type: "review",
               source: "auto",
@@ -474,13 +447,44 @@ export function makeAgentWorkScheduler(pool: Pool, boss: PgBoss) {
               resourceKey,
               ...correlation,
             });
-            recordEvent(intakeLog, "agent_work_enqueued", {
-              type: "description",
-              source: "auto",
-              workItemId: descriptionWorkItemId,
-              resourceKey,
-              ...correlation,
-            });
+
+            if (AUTOMATED_DESCRIPTION_PR_ACTIONS.has(action)) {
+              const descriptionTarget: AutoWorkSupersedeTarget = {
+                kind: "description",
+                resourceKey,
+              };
+              const { workItemId: descriptionWorkItemId, supersededIds: descriptionSuperseded } =
+                await replaceAutoWorkItem({
+                  client,
+                  target: descriptionTarget,
+                  createWorkItem: () =>
+                    createDescriptionWorkItem(client, {
+                      webhookEventId: event.id,
+                      ref,
+                      source: "auto",
+                    }),
+                });
+              await releaseSingletonIfSuperseded({
+                boss,
+                db: slotDb,
+                supersededIds: descriptionSuperseded,
+                release: () =>
+                  releaseSingletonSlot(boss, {
+                    queue: DESCRIPTION_QUEUE,
+                    singletonKey: descriptionSingletonKey(resourceKey),
+                    db: slotDb,
+                  }),
+              });
+              await enqueueDescription(boss, client, ref, descriptionWorkItemId, correlation);
+
+              recordEvent(intakeLog, "agent_work_enqueued", {
+                type: "description",
+                source: "auto",
+                workItemId: descriptionWorkItemId,
+                resourceKey,
+                ...correlation,
+              });
+            }
           }),
         catch: (e) => (e instanceof Error ? e : new Error(String(e))),
       }),

--- a/src/settings/constants.ts
+++ b/src/settings/constants.ts
@@ -10,6 +10,8 @@ export const DESCRIPTION_DEAD_LETTER_QUEUE = "agent-work-description-dead";
 export const DEFERRED_HEAD_SHA = "deferred-to-worker";
 
 export const AUTOMATED_PR_ACTIONS = new Set(["opened", "synchronize", "reopened"]);
+/** PR description auto-runs only on first open; use `/describe` after that. */
+export const AUTOMATED_DESCRIPTION_PR_ACTIONS = new Set(["opened"]);
 export const AUTOMATED_REVIEW_LENS = "review" as const;
 export const DESCRIPTION_PUBLISH_LENS = "description" as const;
 export const MAX_STORED_COMMENT_TEXT_LEN = 16_384;
@@ -300,13 +302,13 @@ export const SLASH_HELP_BODY = [
   "Commands (first line of a **new** comment):",
   "- `/help` — show this message",
   "- `/ask <question>` — ask about this PR or a specific line of code",
-  "- `/describe` — generate or refresh the PR title/body summary (also runs automatically on PR open/sync)",
+  "- `/describe` — generate or refresh the PR title/body summary (also runs automatically on PR open)",
   "- `/review` — general bug-and-correctness review (also runs automatically on PR open/sync)",
   "- `/review-security` — deep security review (DeepSec-style; trigger-only, not auto-run)",
   "- `/review-quality` — deep code-quality review (maintainability; trigger-only, not auto-run)",
   "",
   "Notes:",
-  "- Automated `/describe` and `/review` run on PR `opened` / `synchronize` / `reopened`.",
+  "- Automated `/describe` runs on PR `opened` only; `/review` runs on `opened` / `synchronize` / `reopened`.",
   "- `/describe` merges generated content below the PR Agent description header; your text above that header is preserved.",
   "- `/review`, `/review-security`, and `/review-quality` can each leave summary comments on the same PR (different sentinels).",
   "- `/ask` answers one question at a time; it does not remember prior `/ask` commands.",

--- a/test/schedulerAutomatedDescribe.test.ts
+++ b/test/schedulerAutomatedDescribe.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import { Effect } from "effect";
+import type { Pool, PoolClient } from "pg";
+import type { PgBoss } from "pg-boss";
+import { createOperationLogger } from "../src/evlog.js";
+import { makeAgentWorkScheduler } from "../src/agentWork/scheduler.js";
+import {
+  ACK_QUEUE,
+  DESCRIPTION_QUEUE,
+  REVIEW_QUEUE,
+} from "../src/agentWork/types.js";
+import * as postgres from "../src/db/postgres.js";
+
+function makeAutomatedHeaders() {
+  return { event: "pull_request", delivery: "d-auto", rawBody: Buffer.from("{}") };
+}
+
+function makePrRef() {
+  return {
+    owner: "acme",
+    repo: "app",
+    prNumber: 7,
+    installationId: 42,
+    headSha: "abc123",
+  };
+}
+
+function mockAutomatedClient() {
+  return {
+    query: vi.fn(async (sql: string) => {
+      if (sql.includes("INSERT INTO webhook_events")) {
+        return { rows: [{ id: "event-1" }] };
+      }
+      if (sql.includes("UPDATE agent_work_items")) {
+        return { rows: [] };
+      }
+      if (sql.includes("INSERT INTO agent_work_items") || sql.includes("INSERT INTO publish_records")) {
+        return { rows: [] };
+      }
+      throw new Error(`unexpected query: ${sql.slice(0, 120)}`);
+    }),
+  } as unknown as PoolClient;
+}
+
+describe("makeAgentWorkScheduler automated describe", () => {
+  it("enqueues description only on pull_request opened", async () => {
+    const sentQueues: string[] = [];
+    const boss = {
+      send: vi.fn(async (queue: string) => {
+        sentQueues.push(queue);
+        return "job-1";
+      }),
+    } as unknown as PgBoss;
+
+    const client = mockAutomatedClient();
+    const pool = {} as Pool;
+    vi.spyOn(postgres, "inTransaction").mockImplementation(async (_pool, fn) => fn(client));
+
+    const scheduler = makeAgentWorkScheduler(pool, boss);
+    const intakeLog = createOperationLogger({ method: "POST", path: "/webhooks" });
+
+    await Effect.runPromise(
+      scheduler.submitAutomatedReview(makeAutomatedHeaders(), makePrRef(), "opened", intakeLog),
+    );
+
+    expect(sentQueues).toContain(REVIEW_QUEUE);
+    expect(sentQueues).toContain(ACK_QUEUE);
+    expect(sentQueues).toContain(DESCRIPTION_QUEUE);
+  });
+
+  it("does not enqueue description on synchronize", async () => {
+    const sentQueues: string[] = [];
+    const boss = {
+      send: vi.fn(async (queue: string) => {
+        sentQueues.push(queue);
+        return "job-1";
+      }),
+    } as unknown as PgBoss;
+
+    const client = mockAutomatedClient();
+    const pool = {} as Pool;
+    vi.spyOn(postgres, "inTransaction").mockImplementation(async (_pool, fn) => fn(client));
+
+    const scheduler = makeAgentWorkScheduler(pool, boss);
+    const intakeLog = createOperationLogger({ method: "POST", path: "/webhooks" });
+
+    await Effect.runPromise(
+      scheduler.submitAutomatedReview(
+        makeAutomatedHeaders(),
+        makePrRef(),
+        "synchronize",
+        intakeLog,
+      ),
+    );
+
+    expect(sentQueues).toContain(REVIEW_QUEUE);
+    expect(sentQueues).toContain(ACK_QUEUE);
+    expect(sentQueues).not.toContain(DESCRIPTION_QUEUE);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Automated PR description generation was running on every `pull_request` push (`synchronize`), not only when the PR is first opened. This change limits auto `/describe` to the `opened` action; later updates require an explicit `/describe` comment.

## Changes

- Introduce `AUTOMATED_DESCRIPTION_PR_ACTIONS` (`opened` only) separate from `AUTOMATED_PR_ACTIONS` used by reviews
- Gate description work-item creation and queue enqueue in `submitAutomatedReview`
- Update slash help text and `docs/configuration.md`
- Add scheduler tests for `opened` vs `synchronize`

## Behavior

| Trigger | Auto review | Auto describe |
| --- | --- | --- |
| PR `opened` | Yes | Yes |
| PR `synchronize` | Yes | No |
| PR `reopened` | Yes | No |
| `/describe` comment | N/A | Yes (unchanged) |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48fd1953-1147-4ef2-8c98-2ca9d05319d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48fd1953-1147-4ef2-8c98-2ca9d05319d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

___

## PR Agent Description

### PR Type

Enhancement, Tests, Documentation

### Description

- Gate automated description enqueue behind new `AUTOMATED_DESCRIPTION_PR_ACTIONS` set (only `opened`)
- Add unit tests verifying description is queued on `opened` but not on `synchronize`
- Update help text and constants docs to reflect the new behavior

### Changes Diagram

```mermaid
flowchart LR
    A[PR webhook event] --> B{action?}
    B -->|opened| C[Enqueue description & review]
    B -->|synchronize / reopened| D[Enqueue review only]
    C --> E[AUTOMATED_DESCRIPTION_PR_ACTIONS has 'opened']
    E --> F[createDescriptionWorkItem]
    F --> G[enqueue DESCRIPTION_QUEUE]
```

### File Walkthrough

**Enhancement**

- `src/settings/constants.ts`: Add AUTOMATED_DESCRIPTION_PR_ACTIONS constant
  - New Set containing only 'opened'
  - Updated slash help text to say 'opened' instead of 'open/sync'
  - Updated help note to clarify review vs description trigger actions

- `src/agentWork/scheduler.ts`: Gate auto-describe behind action check
  - Wrap description enqueue logic in `if (AUTOMATED_DESCRIPTION_PR_ACTIONS.has(action))`
  - Review enqueue remains unconditional for opened/synchronize/reopened

**Tests**

- `test/schedulerAutomatedDescribe.test.ts`: Add tests for automated describe behaviour
  - Verify description is enqueued on 'opened' action
  - Verify description is NOT enqueued on 'synchronize' action
  - Review and ack queues are always sent in both cases

**Documentation**

- `docs/configuration.md`: Document new AUTOMATED_DESCRIPTION_PR_ACTIONS
  - Add row for the new constant in the constants table