### PR TITLE
feat: hyperlink file walkthrough paths in PR descriptions

### DIFF
--- a/src/agent/descriptionRender.ts
+++ b/src/agent/descriptionRender.ts
@@ -1,10 +1,14 @@
-import { escapeTableHtml } from "../github/markdownFormat.js";
+import path from "node:path";
+import { escapeTableHtml, renderInlineCodeLink } from "../github/markdownFormat.js";
+import { githubPullRequestFileDiffUrl, type GitHubPullRequestFileContext } from "../github/prFileUrls.js";
 import { redactOutboundSecrets } from "../security/redactOutboundSecrets.js";
 import { DESCRIPTION_AGENT_HEADER } from "../settings/index.js";
 import { sanitizeMermaidDiagram } from "./mermaidDiagram.js";
 import type { DescriptionPayload, DescriptionPrFile } from "./descriptionSchema.js";
 
 export { sanitizeMermaidDiagram } from "./mermaidDiagram.js";
+
+export type DescriptionRenderContext = GitHubPullRequestFileContext;
 
 function groupFilesByLabel(files: readonly DescriptionPrFile[]): Map<string, DescriptionPrFile[]> {
   const groups = new Map<string, DescriptionPrFile[]>();
@@ -17,44 +21,118 @@ function groupFilesByLabel(files: readonly DescriptionPrFile[]): Map<string, Des
   return groups;
 }
 
-function renderFileEntry(file: DescriptionPrFile): string[] {
+function uniqueBasenames(files: readonly DescriptionPrFile[]): Map<string, string> {
+  const byBase = new Map<string, string[]>();
+  for (const file of files) {
+    const base = path.basename(file.filename);
+    const bucket = byBase.get(base) ?? [];
+    bucket.push(file.filename);
+    byBase.set(base, bucket);
+  }
+  const unique = new Map<string, string>();
+  for (const [base, paths] of byBase) {
+    if (paths.length === 1) unique.set(base, paths[0]!);
+  }
+  return unique;
+}
+
+function fileUrlByPath(
+  files: readonly DescriptionPrFile[],
+  ctx: DescriptionRenderContext,
+): Map<string, string> {
+  const urls = new Map<string, string>();
+  for (const file of files) {
+    urls.set(file.filename, githubPullRequestFileDiffUrl(ctx, file.filename));
+  }
+  return urls;
+}
+
+function markdownFileLink(display: string, href: string): string {
+  return `[${display}](${href})`;
+}
+
+function linkifyFileReferences(
+  line: string,
+  urlByPath: ReadonlyMap<string, string>,
+  uniqueBasenameToPath: ReadonlyMap<string, string>,
+): string {
+  let out = line;
+  const paths = [...urlByPath.keys()].sort((a, b) => b.length - a.length);
+  for (const filePath of paths) {
+    const href = urlByPath.get(filePath)!;
+    const backtick = `\`${filePath}\``;
+    if (out.includes(backtick)) {
+      out = out.replaceAll(backtick, markdownFileLink(filePath, href));
+    }
+  }
+  for (const [basename, filePath] of uniqueBasenameToPath) {
+    const href = urlByPath.get(filePath)!;
+    const backtick = `\`${basename}\``;
+    if (out.includes(backtick)) {
+      out = out.replaceAll(backtick, markdownFileLink(basename, href));
+    }
+    const bulletPrefix = `- ${basename}:`;
+    if (out.includes(bulletPrefix)) {
+      out = out.replaceAll(bulletPrefix, `- ${markdownFileLink(basename, href)}:`);
+    }
+  }
+  return out;
+}
+
+function renderFileEntry(
+  file: DescriptionPrFile,
+  ctx: DescriptionRenderContext,
+  urlByPath: ReadonlyMap<string, string>,
+  uniqueBasenameToPath: ReadonlyMap<string, string>,
+): string[] {
+  const href = urlByPath.get(file.filename) ?? githubPullRequestFileDiffUrl(ctx, file.filename);
   const lines: string[] = [
     "<details>",
     `<summary>${escapeTableHtml(file.changesTitle)}</summary>`,
     "",
-    `\`${file.filename}\``,
+    renderInlineCodeLink(file.filename, href),
     "",
   ];
   if (file.changesSummary?.trim()) {
     for (const bullet of file.changesSummary.trim().split("\n")) {
       const trimmed = bullet.trim();
-      if (trimmed) lines.push(trimmed.startsWith("-") ? trimmed : `- ${trimmed}`);
+      if (!trimmed) continue;
+      const normalized = trimmed.startsWith("-") ? trimmed : `- ${trimmed}`;
+      lines.push(linkifyFileReferences(normalized, urlByPath, uniqueBasenameToPath));
     }
   }
   lines.push("", "</details>");
   return lines;
 }
 
-function renderFileWalkthrough(files: readonly DescriptionPrFile[]): string {
+function renderFileWalkthrough(
+  files: readonly DescriptionPrFile[],
+  ctx: DescriptionRenderContext,
+): string {
   if (files.length === 0) return "";
   const groups = groupFilesByLabel(files);
+  const urlByPath = fileUrlByPath(files, ctx);
+  const uniqueBasenameToPath = uniqueBasenames(files);
   const lines: string[] = ["### File Walkthrough", ""];
   for (const [label, group] of groups) {
     const labelTitle = `${label.charAt(0).toUpperCase()}${label.slice(1)} (${group.length} file${group.length === 1 ? "" : "s"})`;
     lines.push("<details>", `<summary>${escapeTableHtml(labelTitle)}</summary>`, "");
     for (const file of group) {
-      lines.push(...renderFileEntry(file), "");
+      lines.push(...renderFileEntry(file, ctx, urlByPath, uniqueBasenameToPath), "");
     }
     lines.push("</details>", "");
   }
   return lines.join("\n").trimEnd();
 }
 
-export function renderDescriptionAgentBlock(payload: DescriptionPayload): string {
+export function renderDescriptionAgentBlock(
+  payload: DescriptionPayload,
+  ctx: DescriptionRenderContext,
+): string {
   const typeLine = payload.type.join(", ");
   const description = payload.description.trim();
   const diagram = payload.changesDiagram ? sanitizeMermaidDiagram(payload.changesDiagram) : "";
-  const walkthrough = payload.prFiles?.length ? renderFileWalkthrough(payload.prFiles) : "";
+  const walkthrough = payload.prFiles?.length ? renderFileWalkthrough(payload.prFiles, ctx) : "";
 
   const sections = [
     DESCRIPTION_AGENT_HEADER,

--- a/src/agent/descriptionRender.ts
+++ b/src/agent/descriptionRender.ts
@@ -22,16 +22,17 @@ function groupFilesByLabel(files: readonly DescriptionPrFile[]): Map<string, Des
 }
 
 function uniqueBasenames(files: readonly DescriptionPrFile[]): Map<string, string> {
-  const byBase = new Map<string, string[]>();
+  const unique = new Map<string, string>();
+  const ambiguous = new Set<string>();
   for (const file of files) {
     const base = path.basename(file.filename);
-    const bucket = byBase.get(base) ?? [];
-    bucket.push(file.filename);
-    byBase.set(base, bucket);
-  }
-  const unique = new Map<string, string>();
-  for (const [base, paths] of byBase) {
-    if (paths.length === 1) unique.set(base, paths[0]!);
+    if (ambiguous.has(base)) continue;
+    if (unique.has(base)) {
+      unique.delete(base);
+      ambiguous.add(base);
+    } else {
+      unique.set(base, file.filename);
+    }
   }
   return unique;
 }
@@ -81,16 +82,15 @@ function linkifyFileReferences(
 
 function renderFileEntry(
   file: DescriptionPrFile,
-  ctx: DescriptionRenderContext,
+  fileHref: string,
   urlByPath: ReadonlyMap<string, string>,
   uniqueBasenameToPath: ReadonlyMap<string, string>,
 ): string[] {
-  const href = urlByPath.get(file.filename) ?? githubPullRequestFileDiffUrl(ctx, file.filename);
   const lines: string[] = [
     "<details>",
     `<summary>${escapeTableHtml(file.changesTitle)}</summary>`,
     "",
-    renderInlineCodeLink(file.filename, href),
+    renderInlineCodeLink(file.filename, fileHref),
     "",
   ];
   if (file.changesSummary?.trim()) {
@@ -118,7 +118,8 @@ function renderFileWalkthrough(
     const labelTitle = `${label.charAt(0).toUpperCase()}${label.slice(1)} (${group.length} file${group.length === 1 ? "" : "s"})`;
     lines.push("<details>", `<summary>${escapeTableHtml(labelTitle)}</summary>`, "");
     for (const file of group) {
-      lines.push(...renderFileEntry(file, ctx, urlByPath, uniqueBasenameToPath), "");
+      const fileHref = urlByPath.get(file.filename)!;
+      lines.push(...renderFileEntry(file, fileHref, urlByPath, uniqueBasenameToPath), "");
     }
     lines.push("</details>", "");
   }

--- a/src/agent/publishDescription.ts
+++ b/src/agent/publishDescription.ts
@@ -26,7 +26,7 @@ export async function publishDescriptionToPullRequest(params: {
     pull_number: prNumber,
   });
 
-  const agentBlock = renderDescriptionAgentBlock(payload);
+  const agentBlock = renderDescriptionAgentBlock(payload, { owner, repo, prNumber });
   const mergedBody = mergeDescriptionIntoPrBody({
     currentBody: pr.body,
     agentBlock,

--- a/src/github/markdownFormat.ts
+++ b/src/github/markdownFormat.ts
@@ -40,6 +40,11 @@ export function renderTableLink(title: string, href: string): string {
   return `<strong><a href="${escapeHtmlAttr(href)}">${escapeTableHtml(title)}</a></strong>`;
 }
 
+/** Inline link with monospace label (e.g. file paths in PR description walkthrough). */
+export function renderInlineCodeLink(label: string, href: string): string {
+  return `<a href="${escapeHtmlAttr(href)}">${renderTableCode(label)}</a>`;
+}
+
 export function renderTableEm(text: string): string {
   return `<em>${escapeTableHtml(text)}</em>`;
 }

--- a/src/github/prFileUrls.ts
+++ b/src/github/prFileUrls.ts
@@ -1,0 +1,22 @@
+import { createHash } from "node:crypto";
+
+export type GitHubPullRequestFileContext = {
+  readonly owner: string;
+  readonly repo: string;
+  readonly prNumber: number;
+};
+
+/** Anchor id for a file row on the PR "Files changed" tab (SHA-256 of the repo path). */
+export function githubPullRequestFileDiffAnchor(filePath: string): string {
+  const digest = createHash("sha256").update(filePath).digest("hex");
+  return `diff-${digest}`;
+}
+
+/** Link to a file's diff hunk on the pull request Files changed tab. */
+export function githubPullRequestFileDiffUrl(
+  ctx: GitHubPullRequestFileContext,
+  filePath: string,
+): string {
+  const anchor = githubPullRequestFileDiffAnchor(filePath);
+  return `https://github.com/${ctx.owner}/${ctx.repo}/pull/${ctx.prNumber}/files#${anchor}`;
+}

--- a/test/descriptionRender.test.ts
+++ b/test/descriptionRender.test.ts
@@ -84,4 +84,37 @@ describe("descriptionRender", () => {
     expect(body).toContain("[planner.ts](https://github.com/acme/widgets/pull/42/files#diff-");
     expect(body).not.toContain("`- planner.ts`");
   });
+
+  it("does not linkify ambiguous basenames shared by three files", () => {
+    const body = renderDescriptionAgentBlock(
+      {
+        title: "t",
+        type: ["Enhancement"],
+        description: "- Main",
+        prFiles: [
+          {
+            filename: "src/a/index.ts",
+            changesTitle: "A",
+            changesSummary: "- `index.ts`: a",
+            label: "enhancement",
+          },
+          {
+            filename: "src/b/index.ts",
+            changesTitle: "B",
+            changesSummary: "- `index.ts`: b",
+            label: "enhancement",
+          },
+          {
+            filename: "src/c/index.ts",
+            changesTitle: "C",
+            changesSummary: "- `index.ts`: c",
+            label: "enhancement",
+          },
+        ],
+      },
+      RENDER_CTX,
+    );
+    expect(body).toContain("- `index.ts`:");
+    expect(body).not.toMatch(/\[index\.ts\]\(https:\/\/github\.com/);
+  });
 });

--- a/test/descriptionRender.test.ts
+++ b/test/descriptionRender.test.ts
@@ -5,6 +5,8 @@ import {
 } from "../src/agent/descriptionRender.js";
 import { DESCRIPTION_AGENT_HEADER } from "../src/settings/index.js";
 
+const RENDER_CTX = { owner: "acme", repo: "widgets", prNumber: 42 };
+
 describe("descriptionRender", () => {
   it("sanitizes mermaid fences", () => {
     const raw = '```mermaid\nflowchart LR\n  A["`x`"] --> B["y"]\n';
@@ -14,41 +16,72 @@ describe("descriptionRender", () => {
   });
 
   it("renders agent block with header and type", () => {
-    const body = renderDescriptionAgentBlock({
-      title: "ignored in render",
-      type: ["Enhancement"],
-      description: "- Main change",
-    });
+    const body = renderDescriptionAgentBlock(
+      {
+        title: "ignored in render",
+        type: ["Enhancement"],
+        description: "- Main change",
+      },
+      RENDER_CTX,
+    );
     expect(body.startsWith(DESCRIPTION_AGENT_HEADER)).toBe(true);
     expect(body).toContain("### PR Type");
     expect(body).toContain("Enhancement");
   });
 
   it("renders file walkthrough as nested accordions", () => {
-    const body = renderDescriptionAgentBlock({
-      title: "t",
-      type: ["Enhancement"],
-      description: "- Main",
-      prFiles: [
-        {
-          filename: "src/a.ts",
-          changesTitle: "New render-safe redirect hook",
-          changesSummary: "- Uses state redirect",
-          label: "enhancement",
-        },
-        {
-          filename: "src/b.ts",
-          changesTitle: "Admin users list API proxy",
-          changesSummary: "- Proxies auth backend",
-          label: "enhancement",
-        },
-      ],
-    });
+    const body = renderDescriptionAgentBlock(
+      {
+        title: "t",
+        type: ["Enhancement"],
+        description: "- Main",
+        prFiles: [
+          {
+            filename: "src/a.ts",
+            changesTitle: "New render-safe redirect hook",
+            changesSummary: "- Uses state redirect",
+            label: "enhancement",
+          },
+          {
+            filename: "src/b.ts",
+            changesTitle: "Admin users list API proxy",
+            changesSummary: "- Proxies auth backend",
+            label: "enhancement",
+          },
+        ],
+      },
+      RENDER_CTX,
+    );
     expect(body).toContain("### File Walkthrough");
     expect(body).toContain("<details>");
     expect(body).toContain("<summary>Enhancement (2 files)</summary>");
     expect(body).toContain("<summary>New render-safe redirect hook</summary>");
-    expect(body).toContain("`src/a.ts`");
+    expect(body).toContain(
+      '<a href="https://github.com/acme/widgets/pull/42/files#diff-',
+    );
+    expect(body).toContain("<code>src/a.ts</code></a>");
+    expect(body).not.toContain("`src/a.ts`");
     expect(body).not.toMatch(/^- `src\/a\.ts`/m);
+  });
+
+  it("linkifies unique basenames in walkthrough bullets", () => {
+    const body = renderDescriptionAgentBlock(
+      {
+        title: "t",
+        type: ["Enhancement"],
+        description: "- Main",
+        prFiles: [
+          {
+            filename: "src/agentWork/intake/planner.ts",
+            changesTitle: "Intake sub-system decomposed",
+            changesSummary: "- `planner.ts`: pure function mapping action to work kinds",
+            label: "enhancement",
+          },
+        ],
+      },
+      RENDER_CTX,
+    );
+    expect(body).toContain("[planner.ts](https://github.com/acme/widgets/pull/42/files#diff-");
+    expect(body).not.toContain("`- planner.ts`");
   });
 });

--- a/test/prFileUrls.test.ts
+++ b/test/prFileUrls.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import {
+  githubPullRequestFileDiffAnchor,
+  githubPullRequestFileDiffUrl,
+} from "../src/github/prFileUrls.js";
+
+describe("prFileUrls", () => {
+  it("uses full sha256 of the repo path for PR file diff anchors", () => {
+    expect(githubPullRequestFileDiffAnchor("lib/whois/errors.rb")).toBe(
+      "diff-447a111a507d8046f1ee64817cd197e9c68424b597d85d83afbbc9364f4fe41d",
+    );
+  });
+
+  it("builds pull request files tab URLs", () => {
+    expect(
+      githubPullRequestFileDiffUrl(
+        { owner: "weppos", repo: "whois", prNumber: 90 },
+        "lib/whois/errors.rb",
+      ),
+    ).toBe(
+      "https://github.com/weppos/whois/pull/90/files#diff-447a111a507d8046f1ee64817cd197e9c68424b597d85d83afbbc9364f4fe41d",
+    );
+  });
+});

--- a/test/prFileUrls.test.ts
+++ b/test/prFileUrls.test.ts
@@ -5,6 +5,7 @@ import {
 } from "../src/github/prFileUrls.js";
 
 describe("prFileUrls", () => {
+  // Anchor matches live github.com/weppos/whois/pull/90/files HTML (verified 2026-05).
   it("uses full sha256 of the repo path for PR file diff anchors", () => {
     expect(githubPullRequestFileDiffAnchor("lib/whois/errors.rb")).toBe(
       "diff-447a111a507d8046f1ee64817cd197e9c68424b597d85d83afbbc9364f4fe41d",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

File Walkthrough entries in generated PR descriptions now render file paths as clickable links instead of plain backticks.

## Behavior

- Each walkthrough file path links to that file on the pull request **Files changed** tab (`/pull/{n}/files#diff-{sha256(path)}`), which is the default reviewers expect when reading a PR description.
- The visible label is unchanged (full repo path in monospace via `<code>`).
- Walkthrough summary bullets also link unique basenames (e.g. `` `planner.ts` `` or `- planner.ts:`) when they unambiguously match a single changed file in the walkthrough.

## Implementation

- Added `src/github/prFileUrls.ts` with SHA-256 diff anchor generation (verified against a live GitHub PR page).
- `renderDescriptionAgentBlock` now requires PR context (`owner`, `repo`, `prNumber`) supplied at publish time.
- Added `renderInlineCodeLink` helper for HTML walkthrough accordions.

## Tests

- `test/prFileUrls.test.ts` — anchor + URL against known GitHub example
- `test/descriptionRender.test.ts` — linked paths and basename linkify
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f0060ae-7295-4aae-8639-662505ce62c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f0060ae-7295-4aae-8639-662505ce62c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

___

## PR Agent Description

### PR Type

Enhancement, Tests

### Description

- Add `prFileUrls.ts` utility to build deep links to file diffs on PR Files tab
- Convert bare file paths in walkthrough entries into clickable `<code>` links
- Linkify unique basename references inside change summary bullets

### Changes Diagram

```mermaid
flowchart LR
  A["publishDescription.ts"] -->|"passes owner/repo/prNumber"| B["descriptionRender.ts"]
  B --> C["prFileUrls.ts"]
  C --> D["SHA-256 anchor per file path"]
  B --> E["markdownFormat.ts"]
  E --> F["renderInlineCodeLink()"]
  B --> G["linkifyFileReferences()"]
  G --> H["Clickable paths in walkthrough bullets"]
```

### File Walkthrough

<details>
<summary>Enhancement (4 files)</summary>

<details>
<summary>New PR file diff URL utility</summary>

`src/github/prFileUrls.ts`

- Computes SHA-256 anchor IDs for file rows
- Builds full GitHub URL to the Files changed tab

</details>

<details>
<summary>Inline clickable code link helper</summary>

`src/github/markdownFormat.ts`

- Exports renderInlineCodeLink for monospace links

</details>

<details>
<summary>Render file walkthrough with live links</summary>

`src/agent/descriptionRender.ts`

- Accepts DescriptionRenderContext (owner/repo/pr)
- Replaces backtick-wrapped paths with clickable links
- Linkifies unique basenames in change summary bullets

</details>

<details>
<summary>Pass PR context to description renderer</summary>

`src/agent/publishDescription.ts`

- Forwards owner/repo/prNumber to renderDescriptionAgentBlock

</details>

</details>

<details>
<summary>Tests (2 files)</summary>

<details>
<summary>Update tests for new context + linkification</summary>

`test/descriptionRender.test.ts`

- Passes RENDER_CTX to all render calls
- Asserts clickable anchor link output
- Adds test for unique basename linkification

</details>

<details>
<summary>Tests for file diff URL generation</summary>

`test/prFileUrls.test.ts`

- Verifies SHA-256 anchor format
- Verifies full URL construction from context

</details>

</details>