### PR TITLE
Clean up Fallow analysis findings

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,65 +18,65 @@ Import convention: `import { … } from "../settings/index.js"` for constants; `
 
 ## Environment (`loadConfig`)
 
-| Name                      | Env var                                     | Default                  | Notes                                              |
-| ------------------------- | ------------------------------------------- | ------------------------ | -------------------------------------------------- |
-| HTTP port                 | `PORT`                                      | `3000` (7224 in Compose) |                                                    |
-| Process role              | `ROLE`                                      | `web`                    | `web` or `worker`                                  |
-| GitHub App ID             | `GITHUB_APP_ID`                             | —                        | required                                           |
-| App private key           | `GITHUB_APP_PRIVATE_KEY`                    | —                        | required PEM                                       |
-| Webhook HMAC secret       | `WEBHOOK_SECRET`                            | —                        | required                                           |
-| Postgres URL              | `DATABASE_URL`                              | —                        | required                                           |
-| Agent provider            | `AGENT_PROVIDER`                            | `pi`                     | `pi` or `cursor` runner                            |
-| LLM provider              | `PI_PROVIDER`                               | `openai`                 | Pi coding-agent model provider                     |
-| LLM model                 | `PI_MODEL`                                  | `gpt-4o-mini`            | Cursor runner also uses this model id              |
-| Cursor API key            | `CURSOR_API_KEY`                            | empty                    | required when `AGENT_PROVIDER=cursor`              |
+| Name                      | Env var                                     | Default                  | Notes                                                   |
+| ------------------------- | ------------------------------------------- | ------------------------ | ------------------------------------------------------- |
+| HTTP port                 | `PORT`                                      | `3000` (7224 in Compose) |                                                         |
+| Process role              | `ROLE`                                      | `web`                    | `web` or `worker`                                       |
+| GitHub App ID             | `GITHUB_APP_ID`                             | —                        | required                                                |
+| App private key           | `GITHUB_APP_PRIVATE_KEY`                    | —                        | required PEM                                            |
+| Webhook HMAC secret       | `WEBHOOK_SECRET`                            | —                        | required                                                |
+| Postgres URL              | `DATABASE_URL`                              | —                        | required                                                |
+| Agent provider            | `AGENT_PROVIDER`                            | `pi`                     | `pi` or `cursor` runner                                 |
+| LLM provider              | `PI_PROVIDER`                               | `openai`                 | Pi coding-agent model provider                          |
+| LLM model                 | `PI_MODEL`                                  | `gpt-4o-mini`            | Cursor runner also uses this model id                   |
+| Cursor API key            | `CURSOR_API_KEY`                            | empty                    | required when `AGENT_PROVIDER=cursor`                   |
 | Provider prompt timeout   | `PROVIDER_PROMPT_TIMEOUT_MS`                | `300000`                 | inactivity cap: abort if no provider activity this long |
-| Review tool rounds        | `MAX_TOOL_ROUNDS`                           | `24`                     | per review run                                     |
-| Publish recovery attempts | `MAX_REVIEW_PUBLISH_ATTEMPTS`               | `3`                      | when submitReview never succeeds                   |
-| Publish execution budget  | `MAX_REVIEW_PUBLISH_CALLS`                  | `2`                      | valid submitReview publishes per run               |
-| Review worker concurrency | `REVIEW_CONCURRENCY`                        | `2`                      | pg-boss review queue workers                       |
-| Ask worker concurrency    | `ASK_CONCURRENCY`                           | `1`                      | pg-boss ask queue workers                          |
-| Description concurrency   | `DESCRIPTION_CONCURRENCY`                   | `1`                      | pg-boss description queue workers                  |
-| Description tool rounds   | `MAX_TOOL_ROUNDS_DESCRIBE`                  | `16`                     | agent investigation cap for `/describe`            |
-| Description AI title      | `DESCRIPTION_GENERATE_TITLE`                | `false`                  | when false, keep existing PR title on publish      |
-| Ack worker concurrency    | `ACK_CONCURRENCY`                           | `2`                      | reactions + progress stub                          |
-| Installation group cap    | `INSTALLATION_GROUP_CONCURRENCY`            | `2`                      | pg-boss group policy                               |
-| Queue retry limit         | `QUEUE_RETRY_LIMIT`                         | `3`                      | pg-boss job retries                                |
-| Queue retry delay         | `QUEUE_RETRY_DELAY_SECONDS`                 | `30`                     |                                                    |
-| Queue retry delay max     | `QUEUE_RETRY_DELAY_MAX_SECONDS`             | `300`                    |                                                    |
-| Job expire                | `QUEUE_EXPIRE_IN_SECONDS`                   | `3600`                   |                                                    |
-| Job heartbeat             | `QUEUE_HEARTBEAT_SECONDS`                   | `60`                     | min 10                                             |
-| Job retention             | `QUEUE_RETENTION_SECONDS`                   | `1209600`                |                                                    |
-| Job delete after          | `QUEUE_DELETE_AFTER_SECONDS`                | `604800`                 |                                                    |
-| Shutdown drain budget     | `SHUTDOWN_DRAIN_TIMEOUT_SECONDS`            | `25`                     | graceful pg-boss stop wait (s) on SIGTERM/SIGINT   |
-| Webhook event retention   | `WEBHOOK_EVENTS_RETENTION_SECONDS`          | `2592000`                | delete webhook_events older than this (30d)        |
-| Agent work retention      | `AGENT_WORK_RETENTION_SECONDS`              | `2592000`                | delete terminal agent_work_items older than this   |
-| Retention schedule        | `RETENTION_CRON`                            | `17 3 * * *`             | cron for the worker cleanup sweep                  |
-| Retention enabled         | `RETENTION_ENABLED`                         | `true`                   | toggle the scheduled cleanup sweep                 |
-| Ask tool rounds           | `MAX_ASK_TOOL_ROUNDS`                       | `12`                     |                                                    |
-| Ask finalize rounds       | `MAX_ASK_FINALIZE_ROUNDS`                   | `2`                      |                                                    |
-| Webhook time budget       | `WEBHOOK_TIMEOUT_MS`                        | `10000`                  | log warning only                                   |
-| Context7 API key          | `CONTEXT7_API_KEY`                          | empty                    | optional                                           |
-| Label effort              | `ENABLE_REVIEW_LABELS_EFFORT`               | `true`                   |                                                    |
-| Label security            | `ENABLE_REVIEW_LABELS_SECURITY`             | `false`                  |                                                    |
-| Max PR files listed       | `MAX_PR_FILES_LISTED`                       | `300`                    | listPullRequestFiles                               |
-| Max PR patch bytes        | `MAX_PR_FILES_PATCH_BYTES`                  | `500000`                 |                                                    |
-| Review anchor menu inject | `REVIEW_INJECT_ANCHOR_MENU`                 | `true`                   | inject commentable line ranges before submitReview |
-| Require diff cache submit | `REVIEW_REQUIRE_DIFF_CACHE_BEFORE_SUBMIT`   | `true`                   | block submitReview when diff index empty           |
-| Anchor menu max files     | `REVIEW_ANCHOR_MENU_MAX_FILES`              | `40`                     | cap files in anchor menu block                     |
-| Anchor menu max ranges    | `REVIEW_ANCHOR_MENU_MAX_RANGES_PER_FILE`    | `20`                     | cap ranges per file in anchor menu                 |
-| Workspace clone timeout   | `LOCAL_WORKSPACE_CLONE_TIMEOUT_MS`          | `60000`                  | git clone/setup budget                             |
-| Workspace fetch timeout   | `LOCAL_WORKSPACE_FETCH_TIMEOUT_MS`          | `60000`                  | git fetch/diff budget                              |
-| Workspace search file cap | `LOCAL_WORKSPACE_SEARCH_MAX_FILES`          | `500`                    | max files scanned per `searchWorkspace` call       |
-| Workspace single-file cap | `LOCAL_WORKSPACE_MAX_FILE_BYTES`            | `1000000`                | max file bytes readable by local tools             |
-| Workspace search byte cap | `LOCAL_WORKSPACE_SEARCH_MAX_TOTAL_BYTES`    | `50000000`               | max bytes scanned per `searchWorkspace` call       |
-| Workspace diff cap        | `LOCAL_WORKSPACE_MAX_DIFF_BYTES`            | `5000000`                | max local diff bytes returned to tools             |
-| Workspace free space min  | `LOCAL_WORKSPACE_MIN_FREE_SPACE_BYTES`      | `500000000`              | fail setup below this free-space threshold         |
-| Workspace stale cleanup   | `LOCAL_WORKSPACE_STALE_CLEANUP_AGE_SECONDS` | `86400`                  | startup cleanup age for leaked temp dirs           |
-| Log level                 | `LOG_LEVEL`                                 | `info`                   |                                                    |
-| Max wide sub-events       | `LOG_MAX_WIDE_EVENTS`                       | `128`                    |                                                    |
-| Pretty logs               | `LOG_PRETTY`                                | dev `true`, prod `false` |                                                    |
-| Redact logs               | `LOG_REDACT`                                | `true`                   | scrub secret-shaped substrings from emitted logs   |
+| Review tool rounds        | `MAX_TOOL_ROUNDS`                           | `24`                     | per review run                                          |
+| Publish recovery attempts | `MAX_REVIEW_PUBLISH_ATTEMPTS`               | `3`                      | when submitReview never succeeds                        |
+| Publish execution budget  | `MAX_REVIEW_PUBLISH_CALLS`                  | `2`                      | valid submitReview publishes per run                    |
+| Review worker concurrency | `REVIEW_CONCURRENCY`                        | `2`                      | pg-boss review queue workers                            |
+| Ask worker concurrency    | `ASK_CONCURRENCY`                           | `1`                      | pg-boss ask queue workers                               |
+| Description concurrency   | `DESCRIPTION_CONCURRENCY`                   | `1`                      | pg-boss description queue workers                       |
+| Description tool rounds   | `MAX_TOOL_ROUNDS_DESCRIBE`                  | `16`                     | agent investigation cap for `/describe`                 |
+| Description AI title      | `DESCRIPTION_GENERATE_TITLE`                | `false`                  | when false, keep existing PR title on publish           |
+| Ack worker concurrency    | `ACK_CONCURRENCY`                           | `2`                      | reactions + progress stub                               |
+| Installation group cap    | `INSTALLATION_GROUP_CONCURRENCY`            | `2`                      | pg-boss group policy                                    |
+| Queue retry limit         | `QUEUE_RETRY_LIMIT`                         | `3`                      | pg-boss job retries                                     |
+| Queue retry delay         | `QUEUE_RETRY_DELAY_SECONDS`                 | `30`                     |                                                         |
+| Queue retry delay max     | `QUEUE_RETRY_DELAY_MAX_SECONDS`             | `300`                    |                                                         |
+| Job expire                | `QUEUE_EXPIRE_IN_SECONDS`                   | `3600`                   |                                                         |
+| Job heartbeat             | `QUEUE_HEARTBEAT_SECONDS`                   | `60`                     | min 10                                                  |
+| Job retention             | `QUEUE_RETENTION_SECONDS`                   | `1209600`                |                                                         |
+| Job delete after          | `QUEUE_DELETE_AFTER_SECONDS`                | `604800`                 |                                                         |
+| Shutdown drain budget     | `SHUTDOWN_DRAIN_TIMEOUT_SECONDS`            | `25`                     | graceful pg-boss stop wait (s) on SIGTERM/SIGINT        |
+| Webhook event retention   | `WEBHOOK_EVENTS_RETENTION_SECONDS`          | `2592000`                | delete webhook_events older than this (30d)             |
+| Agent work retention      | `AGENT_WORK_RETENTION_SECONDS`              | `2592000`                | delete terminal agent_work_items older than this        |
+| Retention schedule        | `RETENTION_CRON`                            | `17 3 * * *`             | cron for the worker cleanup sweep                       |
+| Retention enabled         | `RETENTION_ENABLED`                         | `true`                   | toggle the scheduled cleanup sweep                      |
+| Ask tool rounds           | `MAX_ASK_TOOL_ROUNDS`                       | `12`                     |                                                         |
+| Ask finalize rounds       | `MAX_ASK_FINALIZE_ROUNDS`                   | `2`                      |                                                         |
+| Webhook time budget       | `WEBHOOK_TIMEOUT_MS`                        | `10000`                  | log warning only                                        |
+| Context7 API key          | `CONTEXT7_API_KEY`                          | empty                    | optional                                                |
+| Label effort              | `ENABLE_REVIEW_LABELS_EFFORT`               | `true`                   |                                                         |
+| Label security            | `ENABLE_REVIEW_LABELS_SECURITY`             | `false`                  |                                                         |
+| Max PR files listed       | `MAX_PR_FILES_LISTED`                       | `300`                    | listPullRequestFiles                                    |
+| Max PR patch bytes        | `MAX_PR_FILES_PATCH_BYTES`                  | `500000`                 |                                                         |
+| Review anchor menu inject | `REVIEW_INJECT_ANCHOR_MENU`                 | `true`                   | inject commentable line ranges before submitReview      |
+| Require diff cache submit | `REVIEW_REQUIRE_DIFF_CACHE_BEFORE_SUBMIT`   | `true`                   | block submitReview when diff index empty                |
+| Anchor menu max files     | `REVIEW_ANCHOR_MENU_MAX_FILES`              | `40`                     | cap files in anchor menu block                          |
+| Anchor menu max ranges    | `REVIEW_ANCHOR_MENU_MAX_RANGES_PER_FILE`    | `20`                     | cap ranges per file in anchor menu                      |
+| Workspace clone timeout   | `LOCAL_WORKSPACE_CLONE_TIMEOUT_MS`          | `60000`                  | git clone/setup budget                                  |
+| Workspace fetch timeout   | `LOCAL_WORKSPACE_FETCH_TIMEOUT_MS`          | `60000`                  | git fetch/diff budget                                   |
+| Workspace search file cap | `LOCAL_WORKSPACE_SEARCH_MAX_FILES`          | `500`                    | max files scanned per `searchWorkspace` call            |
+| Workspace single-file cap | `LOCAL_WORKSPACE_MAX_FILE_BYTES`            | `1000000`                | max file bytes readable by local tools                  |
+| Workspace search byte cap | `LOCAL_WORKSPACE_SEARCH_MAX_TOTAL_BYTES`    | `50000000`               | max bytes scanned per `searchWorkspace` call            |
+| Workspace diff cap        | `LOCAL_WORKSPACE_MAX_DIFF_BYTES`            | `5000000`                | max local diff bytes returned to tools                  |
+| Workspace free space min  | `LOCAL_WORKSPACE_MIN_FREE_SPACE_BYTES`      | `500000000`              | fail setup below this free-space threshold              |
+| Workspace stale cleanup   | `LOCAL_WORKSPACE_STALE_CLEANUP_AGE_SECONDS` | `86400`                  | startup cleanup age for leaked temp dirs                |
+| Log level                 | `LOG_LEVEL`                                 | `info`                   |                                                         |
+| Max wide sub-events       | `LOG_MAX_WIDE_EVENTS`                       | `128`                    |                                                         |
+| Pretty logs               | `LOG_PRETTY`                                | dev `true`, prod `false` |                                                         |
+| Redact logs               | `LOG_REDACT`                                | `true`                   | scrub secret-shaped substrings from emitted logs        |
 
 ### External model provider secrets
 

--- a/src/agent/askRun.ts
+++ b/src/agent/askRun.ts
@@ -2,13 +2,9 @@ import type { ReplyTarget } from "../commands/replyTarget.js";
 import type { Config } from "../config.js";
 import type { LocalPrWorkspace } from "../prWorkspace/localPrWorkspace.js";
 import { logInfo } from "../evlog.js";
+import { ASK_META_REFUSAL } from "../settings/index.js";
 import { formatAskReply } from "./formatAskReply.js";
-import {
-  ASK_META_REFUSAL,
-  classifyAskQuestionIntent,
-  wrapTrustedContext,
-  wrapUntrustedBlock,
-} from "./askSafety.js";
+import { classifyAskQuestionIntent, wrapTrustedContext, wrapUntrustedBlock } from "./askSafety.js";
 import { runAskHarness } from "./askRunHarness.js";
 
 export type CodeAnchor = {

--- a/src/agent/askRun.ts
+++ b/src/agent/askRun.ts
@@ -1,73 +1,11 @@
-import type { ReplyTarget } from "../commands/replyTarget.js";
-import type { Config } from "../config.js";
-import type { LocalPrWorkspace } from "../prWorkspace/localPrWorkspace.js";
 import { logInfo } from "../evlog.js";
 import { ASK_META_REFUSAL } from "../settings/index.js";
 import { formatAskReply } from "./formatAskReply.js";
-import { classifyAskQuestionIntent, wrapTrustedContext, wrapUntrustedBlock } from "./askSafety.js";
+import { classifyAskQuestionIntent } from "./askSafety.js";
 import { runAskHarness } from "./askRunHarness.js";
+import type { AskRunParams, AskRunResult } from "./askRunTypes.js";
 
-export type CodeAnchor = {
-  path: string;
-  line: number;
-  startLine?: number;
-  side?: "LEFT" | "RIGHT";
-  diffHunk?: string;
-};
-
-export type AskRunParams = {
-  cfg: Config;
-  token: string;
-  tokenExpiresAtTs: number;
-  tokenTtlMs: number;
-  owner: string;
-  repo: string;
-  prNumber: number;
-  headSha: string;
-  question: string;
-  replyTarget: ReplyTarget;
-  codeAnchor?: CodeAnchor;
-  refreshInstallationToken?: () => Promise<{ token: string; expiresAtTs: number }>;
-  cwd?: string;
-  workspace?: LocalPrWorkspace;
-};
-
-export type AskRunResult = {
-  answer: string;
-  replied: boolean;
-};
-
-export function buildAskUserContent(params: AskRunParams): string {
-  const blocks = [
-    wrapTrustedContext([
-      `Repository: ${params.owner}/${params.repo}`,
-      `Pull request: #${params.prNumber}`,
-      `Head commit SHA: ${params.headSha}`,
-    ]),
-    wrapUntrustedBlock("user_question", params.question),
-  ];
-
-  if (params.codeAnchor) {
-    const { path, line, startLine, side, diffHunk } = params.codeAnchor;
-    const range =
-      startLine != null && startLine !== line ? `lines ${startLine}-${line}` : `line ${line}`;
-    const anchorLines = [`File: ${path}`, `${range}${side ? ` (${side} side of diff)` : ""}`];
-    if (diffHunk?.trim()) {
-      anchorLines.push("", "Diff hunk:", "```diff", diffHunk.trim(), "```");
-    }
-    anchorLines.push(
-      "",
-      "Start from this anchor, then use tools to trace symbols and surrounding context.",
-    );
-    blocks.push(wrapUntrustedBlock("code_anchor", anchorLines.join("\n")));
-  } else {
-    blocks.push(
-      "Use the local PR workspace tools to inspect changed files and related code, then answer the question in user_question.",
-    );
-  }
-
-  return blocks.join("\n\n");
-}
+export type { AskRunParams, AskRunResult } from "./askRunTypes.js";
 
 export async function runAskRun(params: AskRunParams): Promise<AskRunResult> {
   const { owner, repo, prNumber, question, replyTarget } = params;

--- a/src/agent/askRunHarness.ts
+++ b/src/agent/askRunHarness.ts
@@ -4,7 +4,8 @@ import { formatAskFailureReply, formatAskReply } from "./formatAskReply.js";
 import { buildContext7Tools } from "./context7Tools.js";
 import { ASK_FAILURE_MESSAGE, ASK_RETRY_NUDGE } from "../settings/index.js";
 import { resolveAgentRunnerProvider } from "./providers/index.js";
-import { buildAskUserContent, type AskRunParams, type AskRunResult } from "./askRun.js";
+import { buildAskUserContent } from "./askUserContent.js";
+import type { AskRunParams, AskRunResult } from "./askRunTypes.js";
 import { buildAskRunSetup } from "./askRunSetup.js";
 
 export async function runAskHarness(params: AskRunParams): Promise<AskRunResult> {

--- a/src/agent/askRunSetup.ts
+++ b/src/agent/askRunSetup.ts
@@ -3,7 +3,7 @@ import { sanitizeLogMessage } from "../security/sanitizeLogMessage.js";
 import { buildAskGithubTools, createAskPathGate } from "./askSafety.js";
 import { buildLocalWorkspaceTools, workspaceToolLimitsFromConfig } from "./localWorkspaceTools.js";
 import { createRefreshableToolExecutors } from "./providers/cursor/refreshableGithubTools.js";
-import type { AskRunParams } from "./askRun.js";
+import type { AskRunParams } from "./askRunTypes.js";
 
 export function buildAskRunSetup(params: AskRunParams) {
   const { cfg, token, tokenExpiresAtTs, owner, repo, prNumber } = params;

--- a/src/agent/askRunTypes.ts
+++ b/src/agent/askRunTypes.ts
@@ -1,0 +1,33 @@
+import type { ReplyTarget } from "../commands/replyTarget.js";
+import type { Config } from "../config.js";
+import type { LocalPrWorkspace } from "../prWorkspace/localPrWorkspace.js";
+
+export type CodeAnchor = {
+  path: string;
+  line: number;
+  startLine?: number;
+  side?: "LEFT" | "RIGHT";
+  diffHunk?: string;
+};
+
+export type AskRunParams = {
+  cfg: Config;
+  token: string;
+  tokenExpiresAtTs: number;
+  tokenTtlMs: number;
+  owner: string;
+  repo: string;
+  prNumber: number;
+  headSha: string;
+  question: string;
+  replyTarget: ReplyTarget;
+  codeAnchor?: CodeAnchor;
+  refreshInstallationToken?: () => Promise<{ token: string; expiresAtTs: number }>;
+  cwd?: string;
+  workspace?: LocalPrWorkspace;
+};
+
+export type AskRunResult = {
+  answer: string;
+  replied: boolean;
+};

--- a/src/agent/askSafety.ts
+++ b/src/agent/askSafety.ts
@@ -12,7 +12,7 @@ export { redactOutboundSecrets };
 
 export type AskQuestionIntent = "code" | "bot_meta";
 
-export { ASK_META_REFUSAL, MAX_ASK_QUESTION_CHARS } from "../settings/index.js";
+export { MAX_ASK_QUESTION_CHARS } from "../settings/index.js";
 
 export function classifyAskQuestionIntent(question: string): AskQuestionIntent {
   for (const pattern of BOT_META_PATTERNS) {

--- a/src/agent/askSafety.ts
+++ b/src/agent/askSafety.ts
@@ -21,14 +21,6 @@ export function classifyAskQuestionIntent(question: string): AskQuestionIntent {
   return "code";
 }
 
-export function wrapUntrustedBlock(label: string, text: string): string {
-  return [`<${label} untrusted="true">`, text.trim(), `</${label}>`].join("\n");
-}
-
-export function wrapTrustedContext(lines: string[]): string {
-  return ['<context trusted="server">', ...lines, "</context>"].join("\n");
-}
-
 export type AskToolScope = {
   readonly owner: string;
   readonly repo: string;

--- a/src/agent/askUserContent.ts
+++ b/src/agent/askUserContent.ts
@@ -1,0 +1,34 @@
+import type { AskRunParams } from "./askRunTypes.js";
+import { wrapTrustedContext, wrapUntrustedBlock } from "./promptBlocks.js";
+
+export function buildAskUserContent(params: AskRunParams): string {
+  const blocks = [
+    wrapTrustedContext([
+      `Repository: ${params.owner}/${params.repo}`,
+      `Pull request: #${params.prNumber}`,
+      `Head commit SHA: ${params.headSha}`,
+    ]),
+    wrapUntrustedBlock("user_question", params.question),
+  ];
+
+  if (params.codeAnchor) {
+    const { path, line, startLine, side, diffHunk } = params.codeAnchor;
+    const range =
+      startLine != null && startLine !== line ? `lines ${startLine}-${line}` : `line ${line}`;
+    const anchorLines = [`File: ${path}`, `${range}${side ? ` (${side} side of diff)` : ""}`];
+    if (diffHunk?.trim()) {
+      anchorLines.push("", "Diff hunk:", "```diff", diffHunk.trim(), "```");
+    }
+    anchorLines.push(
+      "",
+      "Start from this anchor, then use tools to trace symbols and surrounding context.",
+    );
+    blocks.push(wrapUntrustedBlock("code_anchor", anchorLines.join("\n")));
+  } else {
+    blocks.push(
+      "Use the local PR workspace tools to inspect changed files and related code, then answer the question in user_question.",
+    );
+  }
+
+  return blocks.join("\n\n");
+}

--- a/src/agent/promptBlocks.ts
+++ b/src/agent/promptBlocks.ts
@@ -1,0 +1,7 @@
+export function wrapUntrustedBlock(label: string, text: string): string {
+  return [`<${label} untrusted="true">`, text.trim(), `</${label}>`].join("\n");
+}
+
+export function wrapTrustedContext(lines: string[]): string {
+  return ['<context trusted="server">', ...lines, "</context>"].join("\n");
+}

--- a/src/agentWork/boss.ts
+++ b/src/agentWork/boss.ts
@@ -10,8 +10,8 @@ import {
   DESCRIPTION_QUEUE,
   REVIEW_DEAD_LETTER_QUEUE,
   REVIEW_QUEUE,
-  type QueueConfig,
-} from "./types.js";
+} from "../settings/index.js";
+import type { QueueConfig } from "./types.js";
 
 function queueDefaults(cfg: QueueConfig): QueueOptions {
   return {

--- a/src/agentWork/durableJob.ts
+++ b/src/agentWork/durableJob.ts
@@ -126,112 +126,175 @@ async function finishRescheduledParentWorkItem(
   }
 }
 
+type CancelIfSkippable = () => Promise<boolean>;
+
+function workItemAccepted(item: AgentWorkItem | null, spec: DurableJobSpec): item is AgentWorkItem {
+  if (!item || item.type !== spec.type) return false;
+  return !spec.acceptItem || spec.acceptItem(item);
+}
+
+function makeCancelIfSkippable(pool: Pool, item: AgentWorkItem): CancelIfSkippable {
+  return async () => {
+    if (!(await shouldSkipWork(pool, item))) return false;
+    await markWorkCancelled(pool, item.id);
+    return true;
+  };
+}
+
+async function prepareDurableExecution(
+  spec: DurableJobSpec,
+  item: AgentWorkItem,
+  cancelIfSkippable: CancelIfSkippable,
+): Promise<DurableExecutionContext | undefined> {
+  const installation = await mintInstallationToken(spec.cfg, item.installationId);
+  const commenterId = (item.payload as { commenterId?: number }).commenterId;
+  if (await isBotCommenter(spec.cfg, installation.token, commenterId)) {
+    await markWorkCancelled(spec.pool, item.id);
+    return undefined;
+  }
+
+  const headSha = await spec.resolveHeadSha(installation.token, item);
+  if (await updateRunningWorkHeadSha(spec.pool, item.id, headSha)) {
+    return { installation, headSha };
+  }
+
+  await cancelIfSkippable();
+  return undefined;
+}
+
+async function completeRescheduledResult(
+  spec: DurableJobSpec,
+  item: AgentWorkItem,
+  result: DurableExecutionResult,
+): Promise<void> {
+  try {
+    if (result.afterComplete) {
+      await result.afterComplete(spec.boss, spec.job.id);
+    }
+  } catch (e) {
+    if (result.replacementWorkItemId) {
+      await markWorkFailed(spec.pool, result.replacementWorkItemId, e);
+    }
+    throw e;
+  }
+  await finishRescheduledParentWorkItem(spec.pool, item.id, spec.type);
+}
+
+async function completeDurableExecution(
+  spec: DurableJobSpec,
+  item: AgentWorkItem,
+  result: DurableExecutionResult,
+  cancelIfSkippable: CancelIfSkippable,
+): Promise<void> {
+  if (await cancelIfSkippable()) return;
+  if (result.rescheduled) {
+    await completeRescheduledResult(spec, item, result);
+    return;
+  }
+  if (result.degraded) await markWorkPublishDegraded(spec.pool, item.id);
+  if (!(await markWorkCompleted(spec.pool, item.id))) {
+    await cancelIfSkippable();
+    return;
+  }
+  logInfo("agent_work_completed", { type: spec.type, workItemId: item.id });
+}
+
+async function markRetryingOrCancel(
+  spec: DurableJobSpec,
+  item: AgentWorkItem,
+  error: unknown,
+  message: string,
+  cancelIfSkippable: CancelIfSkippable,
+): Promise<void> {
+  if (await markWorkRetrying(spec.pool, item.id, error)) {
+    logWarn("agent_work_retrying", {
+      type: spec.type,
+      workItemId: item.id,
+      message,
+      providerErrorKind: classifyProviderError(error),
+      pgBossRetryCount: spec.job.retryCount,
+      pgBossRetryLimit: spec.job.retryLimit,
+      dbAttemptCount: item.attemptCount,
+    });
+    throw error;
+  }
+  await cancelIfSkippable();
+}
+
+async function invokeTerminalFailureHook(
+  spec: DurableJobSpec,
+  item: AgentWorkItem,
+  installation: InstallationToken | undefined,
+  error: unknown,
+): Promise<void> {
+  if (!spec.onTerminalFailure) return;
+  try {
+    await spec.onTerminalFailure(item, installation, error);
+  } catch (publishError) {
+    logWarn("agent_work_terminal_failure_hook_failed", {
+      type: spec.type,
+      workItemId: item.id,
+      message: publishError instanceof Error ? publishError.message : String(publishError),
+    });
+  }
+}
+
+async function handleDurableExecutionError(
+  spec: DurableJobSpec,
+  item: AgentWorkItem,
+  installation: InstallationToken | undefined,
+  error: unknown,
+  cancelIfSkippable: CancelIfSkippable,
+): Promise<void> {
+  if (await cancelIfSkippable()) return;
+  const message = error instanceof Error ? error.message : String(error);
+  if (!isTerminalPgBossAttempt(spec.job)) {
+    await markRetryingOrCancel(spec, item, error, message, cancelIfSkippable);
+    return;
+  }
+
+  if (!(await markWorkFailed(spec.pool, item.id, error))) {
+    await cancelIfSkippable();
+    return;
+  }
+  await invokeTerminalFailureHook(spec, item, installation, error);
+  logError("agent_work_failed", {
+    type: spec.type,
+    workItemId: item.id,
+    message: sanitizeLogMessage(message),
+    providerErrorKind: classifyProviderError(error),
+    pgBossRetryCount: spec.job.retryCount,
+    pgBossRetryLimit: spec.job.retryLimit,
+    dbAttemptCount: item.attemptCount,
+  });
+}
+
 /**
  * Shared scaffolding for durable work items: skip/claim/mint-token/bot-skip/head-SHA/transition/retry.
  * Callers supply only the agent-specific execute() and an optional terminal-failure publish hook.
  */
 export async function runDurableWorkItem(spec: DurableJobSpec): Promise<void> {
-  const { cfg, pool, boss, job, type, acceptItem, resolveHeadSha, execute, onTerminalFailure } =
-    spec;
+  const item = await getWorkItem(spec.pool, spec.job.data.workItemId);
+  if (!workItemAccepted(item, spec)) return;
 
-  const item = await getWorkItem(pool, job.data.workItemId);
-  if (!item || item.type !== type) return;
-  if (acceptItem && !acceptItem(item)) return;
-
-  const cancelIfSkippable = async (): Promise<boolean> => {
-    if (!(await shouldSkipWork(pool, item))) return false;
-    await markWorkCancelled(pool, item.id);
-    return true;
-  };
-
+  const cancelIfSkippable = makeCancelIfSkippable(spec.pool, item);
   if (await cancelIfSkippable()) return;
-  if (!(await claimWorkForExecution(pool, item.id))) return;
+  if (!(await claimWorkForExecution(spec.pool, item.id))) return;
 
   let installation: InstallationToken | undefined;
   try {
-    installation = await mintInstallationToken(cfg, item.installationId);
-    if (
-      await isBotCommenter(
-        cfg,
-        installation.token,
-        (item.payload as { commenterId?: number }).commenterId,
-      )
-    ) {
-      await markWorkCancelled(pool, item.id);
-      return;
-    }
+    const execution = await prepareDurableExecution(spec, item, cancelIfSkippable);
+    if (!execution) return;
+    installation = execution.installation;
 
-    const headSha = await resolveHeadSha(installation.token, item);
-    if (!(await updateRunningWorkHeadSha(pool, item.id, headSha))) {
-      await cancelIfSkippable();
-      return;
-    }
-
-    logInfo("agent_work_started", { type, workItemId: item.id, resourceKey: item.resourceKey });
-    const result = await execute(item, { installation, headSha });
-    if (await cancelIfSkippable()) return;
-    if (result.rescheduled) {
-      try {
-        if (result.afterComplete) {
-          await result.afterComplete(boss, job.id);
-        }
-      } catch (e) {
-        if (result.replacementWorkItemId) {
-          await markWorkFailed(pool, result.replacementWorkItemId, e);
-        }
-        throw e;
-      }
-      await finishRescheduledParentWorkItem(pool, item.id, type);
-      return;
-    }
-    if (result.degraded) await markWorkPublishDegraded(pool, item.id);
-    if (!(await markWorkCompleted(pool, item.id))) {
-      await cancelIfSkippable();
-      return;
-    }
-    logInfo("agent_work_completed", { type, workItemId: item.id });
-  } catch (e) {
-    if (await cancelIfSkippable()) return;
-    const message = e instanceof Error ? e.message : String(e);
-    if (!isTerminalPgBossAttempt(job)) {
-      if (await markWorkRetrying(pool, item.id, e)) {
-        logWarn("agent_work_retrying", {
-          type,
-          workItemId: item.id,
-          message,
-          providerErrorKind: classifyProviderError(e),
-          pgBossRetryCount: job.retryCount,
-          pgBossRetryLimit: job.retryLimit,
-          dbAttemptCount: item.attemptCount,
-        });
-        throw e;
-      }
-      await cancelIfSkippable();
-      return;
-    }
-    if (!(await markWorkFailed(pool, item.id, e))) {
-      await cancelIfSkippable();
-      return;
-    }
-    if (onTerminalFailure) {
-      try {
-        await onTerminalFailure(item, installation, e);
-      } catch (publishError) {
-        logWarn("agent_work_terminal_failure_hook_failed", {
-          type,
-          workItemId: item.id,
-          message: publishError instanceof Error ? publishError.message : String(publishError),
-        });
-      }
-    }
-    logError("agent_work_failed", {
-      type,
+    logInfo("agent_work_started", {
+      type: spec.type,
       workItemId: item.id,
-      message: sanitizeLogMessage(message),
-      providerErrorKind: classifyProviderError(e),
-      pgBossRetryCount: job.retryCount,
-      pgBossRetryLimit: job.retryLimit,
-      dbAttemptCount: item.attemptCount,
+      resourceKey: item.resourceKey,
     });
+    const result = await spec.execute(item, execution);
+    await completeDurableExecution(spec, item, result, cancelIfSkippable);
+  } catch (error) {
+    await handleDurableExecutionError(spec, item, installation, error, cancelIfSkippable);
   }
 }

--- a/src/agentWork/durableJob.ts
+++ b/src/agentWork/durableJob.ts
@@ -136,8 +136,9 @@ function workItemAccepted(item: AgentWorkItem | null, spec: DurableJobSpec): ite
  * Callers supply only the agent-specific execute() and an optional terminal-failure publish hook.
  */
 export async function runDurableWorkItem(spec: DurableJobSpec): Promise<void> {
-  const item = await getWorkItem(spec.pool, spec.job.data.workItemId);
-  if (!workItemAccepted(item, spec)) return;
+  const fetched = await getWorkItem(spec.pool, spec.job.data.workItemId);
+  if (!workItemAccepted(fetched, spec)) return;
+  const item = fetched;
 
   const cancelIfSkippable = async () => {
     if (!(await shouldSkipWork(spec.pool, item))) return false;

--- a/src/agentWork/durableJob.ts
+++ b/src/agentWork/durableJob.ts
@@ -126,147 +126,9 @@ async function finishRescheduledParentWorkItem(
   }
 }
 
-type CancelIfSkippable = () => Promise<boolean>;
-
 function workItemAccepted(item: AgentWorkItem | null, spec: DurableJobSpec): item is AgentWorkItem {
   if (!item || item.type !== spec.type) return false;
   return !spec.acceptItem || spec.acceptItem(item);
-}
-
-function makeCancelIfSkippable(pool: Pool, item: AgentWorkItem): CancelIfSkippable {
-  return async () => {
-    if (!(await shouldSkipWork(pool, item))) return false;
-    await markWorkCancelled(pool, item.id);
-    return true;
-  };
-}
-
-async function prepareDurableExecution(
-  spec: DurableJobSpec,
-  item: AgentWorkItem,
-  cancelIfSkippable: CancelIfSkippable,
-): Promise<DurableExecutionContext | undefined> {
-  const installation = await mintInstallationToken(spec.cfg, item.installationId);
-  const commenterId = (item.payload as { commenterId?: number }).commenterId;
-  if (await isBotCommenter(spec.cfg, installation.token, commenterId)) {
-    await markWorkCancelled(spec.pool, item.id);
-    return undefined;
-  }
-
-  const headSha = await spec.resolveHeadSha(installation.token, item);
-  if (await updateRunningWorkHeadSha(spec.pool, item.id, headSha)) {
-    return { installation, headSha };
-  }
-
-  await cancelIfSkippable();
-  return undefined;
-}
-
-async function completeRescheduledResult(
-  spec: DurableJobSpec,
-  item: AgentWorkItem,
-  result: DurableExecutionResult,
-): Promise<void> {
-  try {
-    if (result.afterComplete) {
-      await result.afterComplete(spec.boss, spec.job.id);
-    }
-  } catch (e) {
-    if (result.replacementWorkItemId) {
-      await markWorkFailed(spec.pool, result.replacementWorkItemId, e);
-    }
-    throw e;
-  }
-  await finishRescheduledParentWorkItem(spec.pool, item.id, spec.type);
-}
-
-async function completeDurableExecution(
-  spec: DurableJobSpec,
-  item: AgentWorkItem,
-  result: DurableExecutionResult,
-  cancelIfSkippable: CancelIfSkippable,
-): Promise<void> {
-  if (await cancelIfSkippable()) return;
-  if (result.rescheduled) {
-    await completeRescheduledResult(spec, item, result);
-    return;
-  }
-  if (result.degraded) await markWorkPublishDegraded(spec.pool, item.id);
-  if (!(await markWorkCompleted(spec.pool, item.id))) {
-    await cancelIfSkippable();
-    return;
-  }
-  logInfo("agent_work_completed", { type: spec.type, workItemId: item.id });
-}
-
-async function markRetryingOrCancel(
-  spec: DurableJobSpec,
-  item: AgentWorkItem,
-  error: unknown,
-  message: string,
-  cancelIfSkippable: CancelIfSkippable,
-): Promise<void> {
-  if (await markWorkRetrying(spec.pool, item.id, error)) {
-    logWarn("agent_work_retrying", {
-      type: spec.type,
-      workItemId: item.id,
-      message,
-      providerErrorKind: classifyProviderError(error),
-      pgBossRetryCount: spec.job.retryCount,
-      pgBossRetryLimit: spec.job.retryLimit,
-      dbAttemptCount: item.attemptCount,
-    });
-    throw error;
-  }
-  await cancelIfSkippable();
-}
-
-async function invokeTerminalFailureHook(
-  spec: DurableJobSpec,
-  item: AgentWorkItem,
-  installation: InstallationToken | undefined,
-  error: unknown,
-): Promise<void> {
-  if (!spec.onTerminalFailure) return;
-  try {
-    await spec.onTerminalFailure(item, installation, error);
-  } catch (publishError) {
-    logWarn("agent_work_terminal_failure_hook_failed", {
-      type: spec.type,
-      workItemId: item.id,
-      message: publishError instanceof Error ? publishError.message : String(publishError),
-    });
-  }
-}
-
-async function handleDurableExecutionError(
-  spec: DurableJobSpec,
-  item: AgentWorkItem,
-  installation: InstallationToken | undefined,
-  error: unknown,
-  cancelIfSkippable: CancelIfSkippable,
-): Promise<void> {
-  if (await cancelIfSkippable()) return;
-  const message = error instanceof Error ? error.message : String(error);
-  if (!isTerminalPgBossAttempt(spec.job)) {
-    await markRetryingOrCancel(spec, item, error, message, cancelIfSkippable);
-    return;
-  }
-
-  if (!(await markWorkFailed(spec.pool, item.id, error))) {
-    await cancelIfSkippable();
-    return;
-  }
-  await invokeTerminalFailureHook(spec, item, installation, error);
-  logError("agent_work_failed", {
-    type: spec.type,
-    workItemId: item.id,
-    message: sanitizeLogMessage(message),
-    providerErrorKind: classifyProviderError(error),
-    pgBossRetryCount: spec.job.retryCount,
-    pgBossRetryLimit: spec.job.retryLimit,
-    dbAttemptCount: item.attemptCount,
-  });
 }
 
 /**
@@ -277,15 +139,120 @@ export async function runDurableWorkItem(spec: DurableJobSpec): Promise<void> {
   const item = await getWorkItem(spec.pool, spec.job.data.workItemId);
   if (!workItemAccepted(item, spec)) return;
 
-  const cancelIfSkippable = makeCancelIfSkippable(spec.pool, item);
+  const cancelIfSkippable = async () => {
+    if (!(await shouldSkipWork(spec.pool, item))) return false;
+    await markWorkCancelled(spec.pool, item.id);
+    return true;
+  };
+
   if (await cancelIfSkippable()) return;
   if (!(await claimWorkForExecution(spec.pool, item.id))) return;
 
   let installation: InstallationToken | undefined;
+
+  async function prepareDurableExecution(
+    installationToken: InstallationToken,
+  ): Promise<DurableExecutionContext | undefined> {
+    const commenterId = (item.payload as { commenterId?: number }).commenterId;
+    if (await isBotCommenter(spec.cfg, installationToken.token, commenterId)) {
+      await markWorkCancelled(spec.pool, item.id);
+      return undefined;
+    }
+
+    const headSha = await spec.resolveHeadSha(installationToken.token, item);
+    if (await updateRunningWorkHeadSha(spec.pool, item.id, headSha)) {
+      return { installation: installationToken, headSha };
+    }
+
+    await cancelIfSkippable();
+    return undefined;
+  }
+
+  async function completeRescheduledResult(result: DurableExecutionResult): Promise<void> {
+    try {
+      if (result.afterComplete) {
+        await result.afterComplete(spec.boss, spec.job.id);
+      }
+    } catch (e) {
+      if (result.replacementWorkItemId) {
+        await markWorkFailed(spec.pool, result.replacementWorkItemId, e);
+      }
+      throw e;
+    }
+    await finishRescheduledParentWorkItem(spec.pool, item.id, spec.type);
+  }
+
+  async function completeDurableExecution(result: DurableExecutionResult): Promise<void> {
+    if (await cancelIfSkippable()) return;
+    if (result.rescheduled) {
+      await completeRescheduledResult(result);
+      return;
+    }
+    if (result.degraded) await markWorkPublishDegraded(spec.pool, item.id);
+    if (!(await markWorkCompleted(spec.pool, item.id))) {
+      await cancelIfSkippable();
+      return;
+    }
+    logInfo("agent_work_completed", { type: spec.type, workItemId: item.id });
+  }
+
+  async function markRetryingOrCancel(error: unknown, message: string): Promise<void> {
+    if (await markWorkRetrying(spec.pool, item.id, error)) {
+      logWarn("agent_work_retrying", {
+        type: spec.type,
+        workItemId: item.id,
+        message,
+        providerErrorKind: classifyProviderError(error),
+        pgBossRetryCount: spec.job.retryCount,
+        pgBossRetryLimit: spec.job.retryLimit,
+        dbAttemptCount: item.attemptCount,
+      });
+      throw error;
+    }
+    await cancelIfSkippable();
+  }
+
+  async function invokeTerminalFailureHook(error: unknown): Promise<void> {
+    if (!spec.onTerminalFailure) return;
+    try {
+      await spec.onTerminalFailure(item, installation, error);
+    } catch (publishError) {
+      logWarn("agent_work_terminal_failure_hook_failed", {
+        type: spec.type,
+        workItemId: item.id,
+        message: publishError instanceof Error ? publishError.message : String(publishError),
+      });
+    }
+  }
+
+  async function handleDurableExecutionError(error: unknown): Promise<void> {
+    if (await cancelIfSkippable()) return;
+    const message = error instanceof Error ? error.message : String(error);
+    if (!isTerminalPgBossAttempt(spec.job)) {
+      await markRetryingOrCancel(error, message);
+      return;
+    }
+
+    if (!(await markWorkFailed(spec.pool, item.id, error))) {
+      await cancelIfSkippable();
+      return;
+    }
+    await invokeTerminalFailureHook(error);
+    logError("agent_work_failed", {
+      type: spec.type,
+      workItemId: item.id,
+      message: sanitizeLogMessage(message),
+      providerErrorKind: classifyProviderError(error),
+      pgBossRetryCount: spec.job.retryCount,
+      pgBossRetryLimit: spec.job.retryLimit,
+      dbAttemptCount: item.attemptCount,
+    });
+  }
+
   try {
-    const execution = await prepareDurableExecution(spec, item, cancelIfSkippable);
+    installation = await mintInstallationToken(spec.cfg, item.installationId);
+    const execution = await prepareDurableExecution(installation);
     if (!execution) return;
-    installation = execution.installation;
 
     logInfo("agent_work_started", {
       type: spec.type,
@@ -293,8 +260,8 @@ export async function runDurableWorkItem(spec: DurableJobSpec): Promise<void> {
       resourceKey: item.resourceKey,
     });
     const result = await spec.execute(item, execution);
-    await completeDurableExecution(spec, item, result, cancelIfSkippable);
+    await completeDurableExecution(result);
   } catch (error) {
-    await handleDurableExecutionError(spec, item, installation, error, cancelIfSkippable);
+    await handleDurableExecutionError(error);
   }
 }

--- a/src/agentWork/durableJob.ts
+++ b/src/agentWork/durableJob.ts
@@ -3,10 +3,15 @@ import type { Pool } from "pg";
 import type { PgBoss } from "pg-boss";
 import type { Config } from "../config.js";
 import { logError, logInfo, logWarn } from "../evlog.js";
-import { mintBotIdentity, mintInstallationAuth } from "../github/appAuth.js";
+import {
+  mintBotIdentity,
+  mintInstallationAuth,
+  type InstallationToken,
+} from "../github/appAuth.js";
 import { INSTALLATION_TOKEN_FALLBACK_TTL_MS } from "../github/githubRequestError.js";
 import { sanitizeLogMessage } from "../security/sanitizeLogMessage.js";
 import { classifyProviderError } from "../agent/providerErrors.js";
+import { DEFERRED_HEAD_SHA } from "../settings/index.js";
 import {
   claimWorkForExecution,
   forceMarkRescheduledParentCompleted,
@@ -20,9 +25,7 @@ import {
   updateRunningWorkHeadSha,
 } from "./repository.js";
 import { getPullRequestHeadSha } from "./githubPrSurface.js";
-import { DEFERRED_HEAD_SHA, type AgentWorkItem, type ReviewWorkPayload } from "./types.js";
-
-export type InstallationToken = { token: string; expiresAtTs: number; ttlMs: number };
+import type { AgentWorkItem, ReviewWorkPayload } from "./types.js";
 
 type DurableExecutionContext = {
   installation: InstallationToken;

--- a/src/agentWork/executors/ackExecutor.ts
+++ b/src/agentWork/executors/ackExecutor.ts
@@ -3,6 +3,7 @@ import type { Config } from "../../config.js";
 import { upsertReviewSummaryComment } from "../../github/reviewPublish.js";
 import { logDebug, logWarn } from "../../evlog.js";
 import { reviewSummarySentinelForMode } from "../../review/reviewSchema.js";
+import { DEFERRED_HEAD_SHA } from "../../settings/index.js";
 import { mintInstallationToken } from "../durableJob.js";
 import { recordPublishStep } from "../repository.js";
 import { renderReviewProgressComment } from "../../review/progressComment.js";
@@ -12,7 +13,7 @@ import {
   postAckReply,
   safeReaction,
 } from "../githubPrSurface.js";
-import { DEFERRED_HEAD_SHA, type AckJobData } from "../types.js";
+import type { AckJobData } from "../types.js";
 
 /** Fire-and-forget ack (reactions, progress stub, slash replies); not a durable work item. */
 export async function executeAckJob(cfg: Config, pool: Pool, data: AckJobData): Promise<void> {

--- a/src/agentWork/intake/applier.ts
+++ b/src/agentWork/intake/applier.ts
@@ -1,6 +1,6 @@
 import type { PoolClient } from "pg";
 import type { PgBoss } from "pg-boss";
-import { AUTOMATED_REVIEW_LENS } from "../../settings/index.js";
+import { AUTOMATED_REVIEW_LENS, DESCRIPTION_QUEUE, REVIEW_QUEUE } from "../../settings/index.js";
 import {
   replaceAutoWorkItem,
   releaseSingletonIfSuperseded,
@@ -10,8 +10,6 @@ import { releaseSingletonSlot, reviewSingletonSlotDb } from "../singletonQueue.j
 import type { RequestLogger } from "../../evlog.js";
 import { recordEvent } from "../../evlog.js";
 import {
-  DESCRIPTION_QUEUE,
-  REVIEW_QUEUE,
   type AckJobData,
   type AckTarget,
   type PrRef,

--- a/src/agentWork/intake/queueing.ts
+++ b/src/agentWork/intake/queueing.ts
@@ -2,11 +2,8 @@ import type { PoolClient } from "pg";
 import type { PgBoss } from "pg-boss";
 import type { ReviewMode } from "../../review/reviewSchema.js";
 import { pgBossDb } from "../../db/postgres.js";
+import { ACK_QUEUE, ASK_QUEUE, DESCRIPTION_QUEUE, REVIEW_QUEUE } from "../../settings/index.js";
 import {
-  ACK_QUEUE,
-  ASK_QUEUE,
-  DESCRIPTION_QUEUE,
-  REVIEW_QUEUE,
   descriptionSingletonKey,
   installationGroupId,
   prResourceKey,

--- a/src/agentWork/intake/slashIntake.ts
+++ b/src/agentWork/intake/slashIntake.ts
@@ -3,10 +3,11 @@ import type { PgBoss } from "pg-boss";
 import {
   parseAskQuestionResult,
   ASK_QUESTION_TOO_LONG_HINT,
-  ASK_USAGE_HINT,
 } from "../../commands/parseAskQuestion.js";
 import { parseSlashCommand } from "../../commands/parseSlashCommand.js";
 import {
+  ASK_USAGE_HINT,
+  DEFERRED_HEAD_SHA,
   DESCRIPTION_ALREADY_IN_PROGRESS,
   MAX_STORED_COMMENT_TEXT_LEN,
   SLASH_HELP_BODY,
@@ -15,7 +16,6 @@ import type { ReviewMode } from "../../review/reviewSchema.js";
 import type { RequestLogger } from "../../evlog.js";
 import { recordEvent } from "../../evlog.js";
 import {
-  DEFERRED_HEAD_SHA,
   type AckJobData,
   type AckTarget,
   type JobCorrelation,

--- a/src/agentWork/intake/slashIntake.ts
+++ b/src/agentWork/intake/slashIntake.ts
@@ -23,7 +23,7 @@ import {
   type WebhookHeaders,
   prResourceKey,
 } from "../types.js";
-import type { CodeAnchor } from "../../agent/askRun.js";
+import type { CodeAnchor } from "../../agent/askRunTypes.js";
 import type { ReplyTarget } from "../../commands/replyTarget.js";
 import { dedupeKey, insertWebhookEvent } from "./webhookEvents.js";
 

--- a/src/agentWork/intake/workItemRepository.ts
+++ b/src/agentWork/intake/workItemRepository.ts
@@ -1,6 +1,6 @@
 import crypto from "node:crypto";
 import type { PoolClient } from "pg";
-import type { CodeAnchor } from "../../agent/askRun.js";
+import type { CodeAnchor } from "../../agent/askRunTypes.js";
 import type { ReplyTarget } from "../../commands/replyTarget.js";
 import type { ReviewMode, WorkSource } from "../../review/reviewSchema.js";
 import type { AutoWorkSupersedeTarget } from "../autoWorkEnqueue.js";

--- a/src/agentWork/reviewReschedule.ts
+++ b/src/agentWork/reviewReschedule.ts
@@ -2,12 +2,11 @@ import crypto from "node:crypto";
 import type { Pool } from "pg";
 import type { PgBoss } from "pg-boss";
 import { logInfo } from "../evlog.js";
+import { ACK_QUEUE, REVIEW_QUEUE } from "../settings/index.js";
 import { getPullRequestHeadSha } from "./githubPrSurface.js";
 import { getWorkItem } from "./repository.js";
 import { releaseReviewSingletonSlot } from "./singletonQueue.js";
 import {
-  ACK_QUEUE,
-  REVIEW_QUEUE,
   installationGroupId,
   reviewSingletonKey,
   type AgentWorkItem,

--- a/src/agentWork/runtime.ts
+++ b/src/agentWork/runtime.ts
@@ -8,8 +8,8 @@ import { createStartedBoss, ensureAgentQueues, stopBoss } from "./boss.js";
 import { AgentWorkScheduler, makeAgentWorkScheduler } from "./scheduler.js";
 import { AgentWorkerLive } from "./worker.js";
 
-export class AgentWorkPool extends Context.Tag("AgentWorkPool")<AgentWorkPool, Pool>() {}
-export class AgentWorkBoss extends Context.Tag("AgentWorkBoss")<AgentWorkBoss, PgBoss>() {}
+class AgentWorkPool extends Context.Tag("AgentWorkPool")<AgentWorkPool, Pool>() {}
+class AgentWorkBoss extends Context.Tag("AgentWorkBoss")<AgentWorkBoss, PgBoss>() {}
 
 const AgentWorkPoolLive = (cfg: Config) =>
   Layer.scoped(

--- a/src/agentWork/singletonQueue.ts
+++ b/src/agentWork/singletonQueue.ts
@@ -2,7 +2,8 @@ import type { PgBoss } from "pg-boss";
 import type { PoolClient } from "pg";
 import { pgBossDb } from "../db/postgres.js";
 import type { ReviewMode } from "../review/reviewSchema.js";
-import { REVIEW_QUEUE, reviewSingletonKey } from "./types.js";
+import { REVIEW_QUEUE } from "../settings/index.js";
+import { reviewSingletonKey } from "./types.js";
 
 export type SingletonSlotDb = ReturnType<typeof pgBossDb>;
 

--- a/src/agentWork/types.ts
+++ b/src/agentWork/types.ts
@@ -1,5 +1,5 @@
 import type { Config } from "../config.js";
-import type { CodeAnchor } from "../agent/askRun.js";
+import type { CodeAnchor } from "../agent/askRunTypes.js";
 import type { ReviewMode } from "../review/reviewSchema.js";
 import type { WorkSource } from "../review/reviewSchema.js";
 import type { ReplyTarget } from "../commands/replyTarget.js";

--- a/src/agentWork/types.ts
+++ b/src/agentWork/types.ts
@@ -3,18 +3,6 @@ import type { CodeAnchor } from "../agent/askRun.js";
 import type { ReviewMode } from "../review/reviewSchema.js";
 import type { WorkSource } from "../review/reviewSchema.js";
 import type { ReplyTarget } from "../commands/replyTarget.js";
-export {
-  ACK_DEAD_LETTER_QUEUE,
-  ACK_QUEUE,
-  ASK_DEAD_LETTER_QUEUE,
-  ASK_QUEUE,
-  DEFERRED_HEAD_SHA,
-  DESCRIPTION_DEAD_LETTER_QUEUE,
-  DESCRIPTION_QUEUE,
-  REVIEW_DEAD_LETTER_QUEUE,
-  REVIEW_QUEUE,
-  RETENTION_QUEUE,
-} from "../settings/index.js";
 
 type WorkType = "review" | "ask" | "description";
 export type WorkStatus = "queued" | "running" | "superseded" | "cancelled" | "completed" | "failed";

--- a/src/agentWork/worker.ts
+++ b/src/agentWork/worker.ts
@@ -5,17 +5,19 @@ import type { Config } from "../config.js";
 import { logDebug, logError, logInfo, logWarn, runWithOperationLogger } from "../evlog.js";
 import { cleanupStaleLocalPrWorkspaces } from "../prWorkspace/index.js";
 import {
+  ACK_QUEUE,
+  ASK_QUEUE,
+  DESCRIPTION_QUEUE,
+  RETENTION_QUEUE,
+  REVIEW_QUEUE,
+} from "../settings/index.js";
+import {
   executeAckJob,
   executeAskJob,
   executeDescriptionJob,
   executeReviewJob,
 } from "./executors/index.js";
 import {
-  ACK_QUEUE,
-  ASK_QUEUE,
-  DESCRIPTION_QUEUE,
-  RETENTION_QUEUE,
-  REVIEW_QUEUE,
   type AckJobData,
   type AskJobData,
   type DescriptionJobData,

--- a/src/commands/parseAskQuestion.ts
+++ b/src/commands/parseAskQuestion.ts
@@ -1,7 +1,5 @@
 import { MAX_ASK_QUESTION_CHARS, askQuestionTooLongHint } from "../settings/index.js";
 
-export { ASK_USAGE_HINT } from "../settings/index.js";
-
 export const ASK_QUESTION_TOO_LONG_HINT = askQuestionTooLongHint();
 
 /**

--- a/src/db/postgres.ts
+++ b/src/db/postgres.ts
@@ -2,8 +2,6 @@ import { Pool, type PoolClient, type QueryResult, type QueryResultRow } from "pg
 import type { Db } from "pg-boss";
 import type { Config } from "../config.js";
 
-export type DbPool = Pool;
-
 export function createPgPool(cfg: Pick<Config, "databaseUrl">): Pool {
   return new Pool({ connectionString: cfg.databaseUrl, max: 10 });
 }

--- a/src/effect/services/webhookDispatcher.ts
+++ b/src/effect/services/webhookDispatcher.ts
@@ -7,7 +7,7 @@ import { IntakeLogger } from "../intakeLogger.js";
 import { dispatchGithubEventEffect } from "../programs/dispatchEffect.js";
 import { WebhookHandlers, WebhookHandlersLive } from "./webhookHandlers.js";
 
-export type DispatchInput = {
+type DispatchInput = {
   cfg: Config;
   headers: {
     delivery?: string;

--- a/src/effect/services/webhookHandlers.ts
+++ b/src/effect/services/webhookHandlers.ts
@@ -1,6 +1,6 @@
 import { Context, Effect, Layer } from "effect";
 import type { Config } from "../../config.js";
-import type { CodeAnchor } from "../../agent/askRun.js";
+import type { CodeAnchor } from "../../agent/askRunTypes.js";
 import { parseSlashCommand } from "../../commands/parseSlashCommand.js";
 import { AgentWorkScheduler } from "../../agentWork/scheduler.js";
 import type { WebhookHeaders } from "../../agentWork/types.js";

--- a/src/review/reviewDiffIndex.ts
+++ b/src/review/reviewDiffIndex.ts
@@ -1,5 +1,5 @@
 import { REVIEW_ANCHOR_MENU_BLOCK_LABEL } from "../settings/index.js";
-import { wrapUntrustedBlock } from "../agent/askSafety.js";
+import { wrapUntrustedBlock } from "../agent/promptBlocks.js";
 
 export type CommentableRightLineRanges = Array<[number, number]>;
 

--- a/src/review/reviewSchema.ts
+++ b/src/review/reviewSchema.ts
@@ -57,7 +57,7 @@ export function reviewRetrySlashCommandForMode(mode: ReviewMode): string {
 
 const severitySchema = z.enum(["P0", "P1", "P2", "P3"]);
 
-export const reviewFindingSchema = z
+const reviewFindingSchema = z
   .object({
     severity: severitySchema,
     file: z.string().min(1),

--- a/src/review/reviewSchema.ts
+++ b/src/review/reviewSchema.ts
@@ -211,92 +211,111 @@ function unwrapPayloadEnvelope(raw: unknown): { value: unknown; coercions: strin
   return { value: raw, coercions: [] };
 }
 
+type FindingDraft = {
+  readonly raw: Record<string, unknown>;
+  value: Record<string, unknown>;
+  mutated: boolean;
+  readonly coercions: string[];
+};
+
+function makeFindingDraft(raw: Record<string, unknown>, coercions: string[]): FindingDraft {
+  return { raw, value: raw, mutated: false, coercions };
+}
+
+function touchFindingDraft(draft: FindingDraft): void {
+  if (draft.mutated) return;
+  draft.value = { ...draft.raw };
+  draft.mutated = true;
+}
+
+function setFindingField(
+  draft: FindingDraft,
+  field: string,
+  value: unknown,
+  coercion: string,
+): void {
+  touchFindingDraft(draft);
+  draft.value[field] = value;
+  draft.coercions.push(coercion);
+}
+
+function coerceFindingLineAlias(draft: FindingDraft): void {
+  if (!("line" in draft.raw) || "startLine" in draft.raw) return;
+  const line = coercePositiveInt(draft.raw.line);
+  if (line == null || line <= 0) return;
+  touchFindingDraft(draft);
+  draft.value.startLine = line;
+  draft.value.endLine = line;
+  draft.coercions.push("finding_line_to_start_end");
+}
+
+function coerceFindingLinesArray(draft: FindingDraft): void {
+  const lines = draft.raw.lines;
+  if (!Array.isArray(lines) || lines.length < 1) return;
+  const start = coercePositiveInt(lines[0]);
+  const end = lines.length >= 2 ? coercePositiveInt(lines[1]) : start;
+  if (start == null || start <= 0 || end == null || end <= 0) return;
+  touchFindingDraft(draft);
+  draft.value.startLine = start;
+  draft.value.endLine = end;
+  draft.coercions.push("finding_lines_array_to_start_end");
+}
+
+function coerceFindingSeverityField(draft: FindingDraft): void {
+  if (!("severity" in draft.raw)) return;
+  const coerced = coerceSeverity(draft.raw.severity);
+  if (!coerced || coerced === draft.raw.severity) return;
+  setFindingField(draft, "severity", coerced, "finding_severity_alias");
+}
+
+function coerceFindingNumberField(
+  draft: FindingDraft,
+  field: "startLine" | "endLine",
+  coercion: string,
+): void {
+  if (!(field in draft.raw)) return;
+  const coerced = coercePositiveInt(draft.raw[field]);
+  if (coerced == null || coerced <= 0 || coerced === draft.raw[field]) return;
+  setFindingField(draft, field, coerced, coercion);
+}
+
+function coerceFindingTextFields(
+  draft: FindingDraft,
+  fields: readonly [
+    "file" | "title" | "detail" | "fixPrompt",
+    ...Array<"file" | "title" | "detail" | "fixPrompt">,
+  ],
+): void {
+  for (const field of fields) {
+    const rawValue = draft.raw[field];
+    if (typeof rawValue !== "string") continue;
+    const { text, changed } = coerceReviewTextField(rawValue, `finding_${field}`, draft.coercions);
+    if (!changed) continue;
+    touchFindingDraft(draft);
+    draft.value[field] = text;
+  }
+}
+
+function removeEmptyFixPrompt(draft: FindingDraft): void {
+  if (!("fixPrompt" in draft.raw) || typeof draft.raw.fixPrompt !== "string") return;
+  const rawFix = (draft.mutated ? draft.value.fixPrompt : draft.raw.fixPrompt) as string;
+  if (rawFix.trim().length > 0) return;
+  touchFindingDraft(draft);
+  delete draft.value.fixPrompt;
+  draft.coercions.push("finding_fixPrompt_empty_removed");
+}
+
 function coerceFinding(raw: unknown, coercions: string[]): unknown {
   if (typeof raw !== "object" || raw == null) return raw;
-  const r = raw as Record<string, unknown>;
-  let mutated = false;
-  let f: Record<string, unknown> = r;
-
-  const touch = (): void => {
-    if (!mutated) {
-      f = { ...r };
-      mutated = true;
-    }
-  };
-
-  if ("line" in r && !("startLine" in r)) {
-    const n = coercePositiveInt(r.line);
-    if (n != null && n > 0) {
-      touch();
-      f.startLine = n;
-      f.endLine = n;
-      coercions.push("finding_line_to_start_end");
-    }
-  }
-
-  if ("lines" in r && Array.isArray(r.lines) && r.lines.length >= 1) {
-    const start = coercePositiveInt(r.lines[0]);
-    const end = r.lines.length >= 2 ? coercePositiveInt(r.lines[1]) : start;
-    if (start != null && start > 0 && end != null && end > 0) {
-      touch();
-      f.startLine = start;
-      f.endLine = end;
-      coercions.push("finding_lines_array_to_start_end");
-    }
-  }
-
-  if ("severity" in r) {
-    const coerced = coerceSeverity(r.severity);
-    if (coerced && coerced !== r.severity) {
-      touch();
-      f.severity = coerced;
-      coercions.push("finding_severity_alias");
-    }
-  }
-  if ("startLine" in r) {
-    const n = coercePositiveInt(r.startLine);
-    if (n != null && n > 0 && n !== r.startLine) {
-      touch();
-      f.startLine = n;
-      coercions.push("finding_startLine_number");
-    }
-  }
-  if ("endLine" in r) {
-    const n = coercePositiveInt(r.endLine);
-    if (n != null && n > 0 && n !== r.endLine) {
-      touch();
-      f.endLine = n;
-      coercions.push("finding_endLine_number");
-    }
-  }
-  for (const field of ["file", "title"] as const) {
-    if (field in r && typeof r[field] === "string") {
-      const { text, changed } = coerceReviewTextField(r[field], `finding_${field}`, coercions);
-      if (changed) {
-        touch();
-        f[field] = text;
-      }
-    }
-  }
-  for (const field of ["detail", "fixPrompt"] as const) {
-    if (field in r && typeof r[field] === "string") {
-      const { text, changed } = coerceReviewTextField(r[field], `finding_${field}`, coercions);
-      if (changed) {
-        touch();
-        f[field] = text;
-      }
-    }
-  }
-  if ("fixPrompt" in r && typeof r.fixPrompt === "string") {
-    const rawFix = (mutated ? f.fixPrompt : r.fixPrompt) as string;
-    const trimmed = rawFix.trim();
-    if (trimmed.length === 0) {
-      touch();
-      delete f.fixPrompt;
-      coercions.push("finding_fixPrompt_empty_removed");
-    }
-  }
-  return mutated ? f : raw;
+  const draft = makeFindingDraft(raw as Record<string, unknown>, coercions);
+  coerceFindingLineAlias(draft);
+  coerceFindingLinesArray(draft);
+  coerceFindingSeverityField(draft);
+  coerceFindingNumberField(draft, "startLine", "finding_startLine_number");
+  coerceFindingNumberField(draft, "endLine", "finding_endLine_number");
+  coerceFindingTextFields(draft, ["file", "title", "detail", "fixPrompt"]);
+  removeEmptyFixPrompt(draft);
+  return draft.mutated ? draft.value : raw;
 }
 
 export function coerceReviewPayloadInput(raw: unknown): {

--- a/src/review/reviewSchema.ts
+++ b/src/review/reviewSchema.ts
@@ -211,111 +211,91 @@ function unwrapPayloadEnvelope(raw: unknown): { value: unknown; coercions: strin
   return { value: raw, coercions: [] };
 }
 
-type FindingDraft = {
-  readonly raw: Record<string, unknown>;
-  value: Record<string, unknown>;
-  mutated: boolean;
-  readonly coercions: string[];
-};
-
-function makeFindingDraft(raw: Record<string, unknown>, coercions: string[]): FindingDraft {
-  return { raw, value: raw, mutated: false, coercions };
-}
-
-function touchFindingDraft(draft: FindingDraft): void {
-  if (draft.mutated) return;
-  draft.value = { ...draft.raw };
-  draft.mutated = true;
-}
-
-function setFindingField(
-  draft: FindingDraft,
-  field: string,
-  value: unknown,
-  coercion: string,
-): void {
-  touchFindingDraft(draft);
-  draft.value[field] = value;
-  draft.coercions.push(coercion);
-}
-
-function coerceFindingLineAlias(draft: FindingDraft): void {
-  if (!("line" in draft.raw) || "startLine" in draft.raw) return;
-  const line = coercePositiveInt(draft.raw.line);
-  if (line == null || line <= 0) return;
-  touchFindingDraft(draft);
-  draft.value.startLine = line;
-  draft.value.endLine = line;
-  draft.coercions.push("finding_line_to_start_end");
-}
-
-function coerceFindingLinesArray(draft: FindingDraft): void {
-  const lines = draft.raw.lines;
-  if (!Array.isArray(lines) || lines.length < 1) return;
-  const start = coercePositiveInt(lines[0]);
-  const end = lines.length >= 2 ? coercePositiveInt(lines[1]) : start;
-  if (start == null || start <= 0 || end == null || end <= 0) return;
-  touchFindingDraft(draft);
-  draft.value.startLine = start;
-  draft.value.endLine = end;
-  draft.coercions.push("finding_lines_array_to_start_end");
-}
-
-function coerceFindingSeverityField(draft: FindingDraft): void {
-  if (!("severity" in draft.raw)) return;
-  const coerced = coerceSeverity(draft.raw.severity);
-  if (!coerced || coerced === draft.raw.severity) return;
-  setFindingField(draft, "severity", coerced, "finding_severity_alias");
-}
-
-function coerceFindingNumberField(
-  draft: FindingDraft,
-  field: "startLine" | "endLine",
-  coercion: string,
-): void {
-  if (!(field in draft.raw)) return;
-  const coerced = coercePositiveInt(draft.raw[field]);
-  if (coerced == null || coerced <= 0 || coerced === draft.raw[field]) return;
-  setFindingField(draft, field, coerced, coercion);
-}
-
-function coerceFindingTextFields(
-  draft: FindingDraft,
-  fields: readonly [
-    "file" | "title" | "detail" | "fixPrompt",
-    ...Array<"file" | "title" | "detail" | "fixPrompt">,
-  ],
-): void {
-  for (const field of fields) {
-    const rawValue = draft.raw[field];
-    if (typeof rawValue !== "string") continue;
-    const { text, changed } = coerceReviewTextField(rawValue, `finding_${field}`, draft.coercions);
-    if (!changed) continue;
-    touchFindingDraft(draft);
-    draft.value[field] = text;
-  }
-}
-
-function removeEmptyFixPrompt(draft: FindingDraft): void {
-  if (!("fixPrompt" in draft.raw) || typeof draft.raw.fixPrompt !== "string") return;
-  const rawFix = (draft.mutated ? draft.value.fixPrompt : draft.raw.fixPrompt) as string;
-  if (rawFix.trim().length > 0) return;
-  touchFindingDraft(draft);
-  delete draft.value.fixPrompt;
-  draft.coercions.push("finding_fixPrompt_empty_removed");
-}
-
 function coerceFinding(raw: unknown, coercions: string[]): unknown {
   if (typeof raw !== "object" || raw == null) return raw;
-  const draft = makeFindingDraft(raw as Record<string, unknown>, coercions);
-  coerceFindingLineAlias(draft);
-  coerceFindingLinesArray(draft);
-  coerceFindingSeverityField(draft);
-  coerceFindingNumberField(draft, "startLine", "finding_startLine_number");
-  coerceFindingNumberField(draft, "endLine", "finding_endLine_number");
-  coerceFindingTextFields(draft, ["file", "title", "detail", "fixPrompt"]);
-  removeEmptyFixPrompt(draft);
-  return draft.mutated ? draft.value : raw;
+  const r = raw as Record<string, unknown>;
+  let mutated = false;
+  let f: Record<string, unknown> = r;
+
+  const touch = (): void => {
+    if (!mutated) {
+      f = { ...r };
+      mutated = true;
+    }
+  };
+
+  if ("line" in r && !("startLine" in r)) {
+    const n = coercePositiveInt(r.line);
+    if (n != null && n > 0) {
+      touch();
+      f.startLine = n;
+      f.endLine = n;
+      coercions.push("finding_line_to_start_end");
+    }
+  }
+
+  if ("lines" in r && Array.isArray(r.lines) && r.lines.length >= 1) {
+    const start = coercePositiveInt(r.lines[0]);
+    const end = r.lines.length >= 2 ? coercePositiveInt(r.lines[1]) : start;
+    if (start != null && start > 0 && end != null && end > 0) {
+      touch();
+      f.startLine = start;
+      f.endLine = end;
+      coercions.push("finding_lines_array_to_start_end");
+    }
+  }
+
+  if ("severity" in r) {
+    const coerced = coerceSeverity(r.severity);
+    if (coerced && coerced !== r.severity) {
+      touch();
+      f.severity = coerced;
+      coercions.push("finding_severity_alias");
+    }
+  }
+  if ("startLine" in r) {
+    const n = coercePositiveInt(r.startLine);
+    if (n != null && n > 0 && n !== r.startLine) {
+      touch();
+      f.startLine = n;
+      coercions.push("finding_startLine_number");
+    }
+  }
+  if ("endLine" in r) {
+    const n = coercePositiveInt(r.endLine);
+    if (n != null && n > 0 && n !== r.endLine) {
+      touch();
+      f.endLine = n;
+      coercions.push("finding_endLine_number");
+    }
+  }
+  for (const field of ["file", "title"] as const) {
+    if (field in r && typeof r[field] === "string") {
+      const { text, changed } = coerceReviewTextField(r[field], `finding_${field}`, coercions);
+      if (changed) {
+        touch();
+        f[field] = text;
+      }
+    }
+  }
+  for (const field of ["detail", "fixPrompt"] as const) {
+    if (field in r && typeof r[field] === "string") {
+      const { text, changed } = coerceReviewTextField(r[field], `finding_${field}`, coercions);
+      if (changed) {
+        touch();
+        f[field] = text;
+      }
+    }
+  }
+  if ("fixPrompt" in r && typeof r.fixPrompt === "string") {
+    const rawFix = (mutated ? f.fixPrompt : r.fixPrompt) as string;
+    if (rawFix.trim().length === 0) {
+      touch();
+      delete f.fixPrompt;
+      coercions.push("finding_fixPrompt_empty_removed");
+    }
+  }
+  return mutated ? f : raw;
 }
 
 export function coerceReviewPayloadInput(raw: unknown): {

--- a/test/cursorMcpBridge.test.ts
+++ b/test/cursorMcpBridge.test.ts
@@ -5,6 +5,31 @@ import * as evlog from "../src/evlog.js";
 import { checkMcpBearerAuth, createMcpBridge } from "../src/agent/providers/cursor/mcpBridge.js";
 import { initReviewRunMetrics, snapshotReviewRunMetrics } from "../src/review/reviewRunMetrics.js";
 
+type NoopBridge = Awaited<ReturnType<typeof createMcpBridge>>;
+
+const noopBridgeSpec = {
+  tools: [{ name: "noop", description: "noop", parameters: { type: "object" } }],
+  executors: { noop: async () => "ok" },
+};
+
+async function withNoopBridge<T>(fn: (bridge: NoopBridge) => Promise<T>): Promise<T> {
+  const bridge = await createMcpBridge(noopBridgeSpec);
+  try {
+    return await fn(bridge);
+  } finally {
+    await bridge.dispose();
+  }
+}
+
+async function connectClient(config: NoopBridge["mcpServers"]["pr-agent"]): Promise<Client> {
+  const transport = new StreamableHTTPClientTransport(new URL(config.url), {
+    requestInit: { headers: config.headers },
+  });
+  const client = new Client({ name: "test", version: "1.0.0" });
+  await client.connect(transport);
+  return client;
+}
+
 describe("checkMcpBearerAuth", () => {
   it("accepts matching bearer token", () => {
     expect(checkMcpBearerAuth("Bearer abc123", "abc123")).toBe(true);
@@ -19,56 +44,32 @@ describe("createMcpBridge", () => {
   });
 
   it("exposes http mcp server config on loopback", async () => {
-    const bridge = await createMcpBridge({
-      tools: [{ name: "noop", description: "noop", parameters: { type: "object" } }],
-      executors: { noop: async () => "ok" },
-    });
-    try {
+    await withNoopBridge(async (bridge) => {
       const config = bridge.mcpServers["pr-agent"];
       expect(config?.type).toBe("http");
       expect(config?.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/mcp\//);
       expect(config?.headers?.Authorization).toMatch(/^Bearer /);
-    } finally {
-      await bridge.dispose();
-    }
+    });
   });
 
   it("rejects requests without bearer token", async () => {
-    const bridge = await createMcpBridge({
-      tools: [{ name: "noop", description: "noop", parameters: { type: "object" } }],
-      executors: { noop: async () => "ok" },
-    });
-    try {
-      const config = bridge.mcpServers["pr-agent"];
-      const res = await fetch(config.url, { method: "POST" });
+    await withNoopBridge(async (bridge) => {
+      const res = await fetch(bridge.mcpServers["pr-agent"].url, { method: "POST" });
       expect(res.status).toBe(401);
-    } finally {
-      await bridge.dispose();
-    }
+    });
   });
 
   it("records tool_call metrics via ambient logger", async () => {
     evlog.initEvlog("info", { silent: true, suppressDrainWarning: true });
     await evlog.runWithOperationLogger({ method: "JOB", path: "/mcp" }, async () => {
       initReviewRunMetrics({ provider: "cursor", model: "composer-2.5", mode: "review" });
-      const bridge = await createMcpBridge({
-        tools: [{ name: "noop", description: "noop", parameters: { type: "object" } }],
-        executors: { noop: async () => "ok" },
-      });
-      try {
-        const config = bridge.mcpServers["pr-agent"];
-        const transport = new StreamableHTTPClientTransport(new URL(config.url), {
-          requestInit: { headers: config.headers },
-        });
-        const client = new Client({ name: "test", version: "1.0.0" });
-        await client.connect(transport);
+      await withNoopBridge(async (bridge) => {
+        const client = await connectClient(bridge.mcpServers["pr-agent"]);
         const result = await client.callTool({ name: "noop", arguments: {} });
         expect(result.isError).not.toBe(true);
         expect(snapshotReviewRunMetrics()?.toolCallCount).toBe(1);
         await client.close();
-      } finally {
-        await bridge.dispose();
-      }
+      });
     });
   });
 
@@ -76,44 +77,22 @@ describe("createMcpBridge", () => {
     evlog.initEvlog("info", { silent: true, suppressDrainWarning: true });
     await evlog.runWithOperationLogger({ method: "JOB", path: "/mcp" }, async () => {
       initReviewRunMetrics({ provider: "cursor", model: "composer-2.5", mode: "review" });
-      const bridge = await createMcpBridge({
-        tools: [{ name: "noop", description: "noop", parameters: { type: "object" } }],
-        executors: { noop: async () => "ok" },
-      });
-      try {
-        const config = bridge.mcpServers["pr-agent"];
-        const transport = new StreamableHTTPClientTransport(new URL(config.url), {
-          requestInit: { headers: config.headers },
-        });
-        const client = new Client({ name: "test", version: "1.0.0" });
-        await client.connect(transport);
+      await withNoopBridge(async (bridge) => {
+        const client = await connectClient(bridge.mcpServers["pr-agent"]);
         const result = await client.callTool({ name: "missing", arguments: {} });
         expect(result.isError).toBe(true);
         expect(snapshotReviewRunMetrics()).toMatchObject({ toolCallCount: 1, toolCallErrors: 1 });
         await client.close();
-      } finally {
-        await bridge.dispose();
-      }
+      });
     });
   });
 
   it("completes tool RPC without operation logger", async () => {
-    const bridge = await createMcpBridge({
-      tools: [{ name: "noop", description: "noop", parameters: { type: "object" } }],
-      executors: { noop: async () => "ok" },
-    });
-    try {
-      const config = bridge.mcpServers["pr-agent"];
-      const transport = new StreamableHTTPClientTransport(new URL(config.url), {
-        requestInit: { headers: config.headers },
-      });
-      const client = new Client({ name: "test", version: "1.0.0" });
-      await client.connect(transport);
+    await withNoopBridge(async (bridge) => {
+      const client = await connectClient(bridge.mcpServers["pr-agent"]);
       const result = await client.callTool({ name: "noop", arguments: {} });
       expect(result.isError).not.toBe(true);
       await client.close();
-    } finally {
-      await bridge.dispose();
-    }
+    });
   });
 });

--- a/test/durableJob.test.ts
+++ b/test/durableJob.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { JobWithMetadata, PgBoss } from "pg-boss";
 import type { Pool } from "pg";
 import type { Config } from "../src/config.js";
-import { runDurableWorkItem } from "../src/agentWork/durableJob.js";
+import { runDurableWorkItem, type DurableJobSpec } from "../src/agentWork/durableJob.js";
 import type { AgentWorkItem } from "../src/agentWork/types.js";
 
 vi.mock("../src/agentWork/repository.js", () => ({
@@ -60,6 +60,20 @@ function makeJob(retryCount = 0, retryLimit = 3): JobWithMetadata<{ workItemId: 
   } as unknown as JobWithMetadata<{ workItemId: string }>;
 }
 
+function runReviewWorkItem(
+  overrides: Partial<DurableJobSpec> & Pick<DurableJobSpec, "execute">,
+): Promise<void> {
+  return runDurableWorkItem({
+    cfg,
+    pool,
+    boss,
+    job: makeJob(),
+    type: "review",
+    resolveHeadSha: async () => "x",
+    ...overrides,
+  });
+}
+
 function defaultMocks() {
   vi.mocked(repo.shouldSkipWork).mockResolvedValue(false);
   vi.mocked(repo.claimWorkForExecution).mockResolvedValue(true);
@@ -93,15 +107,7 @@ describe("runDurableWorkItem", () => {
     vi.mocked(repo.getWorkItem).mockResolvedValue(item);
     const execute = vi.fn().mockResolvedValue({});
 
-    await runDurableWorkItem({
-      cfg,
-      pool,
-      boss,
-      job: makeJob(),
-      type: "review",
-      resolveHeadSha: async () => "abc123",
-      execute,
-    });
+    await runReviewWorkItem({ resolveHeadSha: async () => "abc123", execute });
 
     expect(repo.claimWorkForExecution).toHaveBeenCalledWith(pool, "wi-1");
     expect(execute).toHaveBeenCalledTimes(1);
@@ -115,15 +121,7 @@ describe("runDurableWorkItem", () => {
   it("returns without executing when item is null", async () => {
     vi.mocked(repo.getWorkItem).mockResolvedValue(null);
     const execute = vi.fn();
-    await runDurableWorkItem({
-      cfg,
-      pool,
-      boss,
-      job: makeJob(),
-      type: "review",
-      resolveHeadSha: async () => "x",
-      execute,
-    });
+    await runReviewWorkItem({ execute });
     expect(execute).not.toHaveBeenCalled();
     expect(repo.claimWorkForExecution).not.toHaveBeenCalled();
   });
@@ -131,31 +129,14 @@ describe("runDurableWorkItem", () => {
   it("returns without executing when item type mismatches", async () => {
     vi.mocked(repo.getWorkItem).mockResolvedValue(makeItem({ type: "ask" }));
     const execute = vi.fn();
-    await runDurableWorkItem({
-      cfg,
-      pool,
-      boss,
-      job: makeJob(),
-      type: "review",
-      resolveHeadSha: async () => "x",
-      execute,
-    });
+    await runReviewWorkItem({ execute });
     expect(execute).not.toHaveBeenCalled();
   });
 
   it("returns without executing when acceptItem rejects", async () => {
     vi.mocked(repo.getWorkItem).mockResolvedValue(makeItem({ reviewLens: null }));
     const execute = vi.fn();
-    await runDurableWorkItem({
-      cfg,
-      pool,
-      boss,
-      job: makeJob(),
-      type: "review",
-      acceptItem: (it) => it.reviewLens != null,
-      resolveHeadSha: async () => "x",
-      execute,
-    });
+    await runReviewWorkItem({ acceptItem: (it) => it.reviewLens != null, execute });
     expect(execute).not.toHaveBeenCalled();
   });
 
@@ -164,15 +145,7 @@ describe("runDurableWorkItem", () => {
     vi.mocked(repo.shouldSkipWork).mockResolvedValueOnce(true);
     const execute = vi.fn();
 
-    await runDurableWorkItem({
-      cfg,
-      pool,
-      boss,
-      job: makeJob(),
-      type: "review",
-      resolveHeadSha: async () => "x",
-      execute,
-    });
+    await runReviewWorkItem({ execute });
 
     expect(repo.markWorkCancelled).toHaveBeenCalledWith(pool, "wi-1");
     expect(repo.claimWorkForExecution).not.toHaveBeenCalled();
@@ -184,15 +157,7 @@ describe("runDurableWorkItem", () => {
     vi.mocked(repo.claimWorkForExecution).mockResolvedValue(false);
     const execute = vi.fn();
 
-    await runDurableWorkItem({
-      cfg,
-      pool,
-      boss,
-      job: makeJob(),
-      type: "review",
-      resolveHeadSha: async () => "x",
-      execute,
-    });
+    await runReviewWorkItem({ execute });
 
     expect(execute).not.toHaveBeenCalled();
     expect(repo.markWorkCancelled).not.toHaveBeenCalled();
@@ -204,15 +169,7 @@ describe("runDurableWorkItem", () => {
     );
     const execute = vi.fn();
 
-    await runDurableWorkItem({
-      cfg,
-      pool,
-      boss,
-      job: makeJob(),
-      type: "review",
-      resolveHeadSha: async () => "x",
-      execute,
-    });
+    await runReviewWorkItem({ execute });
 
     expect(execute).not.toHaveBeenCalled();
     expect(repo.markWorkCancelled).toHaveBeenCalledWith(pool, "wi-1");
@@ -224,15 +181,7 @@ describe("runDurableWorkItem", () => {
     vi.mocked(repo.shouldSkipWork).mockResolvedValueOnce(false).mockResolvedValueOnce(true);
     const execute = vi.fn();
 
-    await runDurableWorkItem({
-      cfg,
-      pool,
-      boss,
-      job: makeJob(),
-      type: "review",
-      resolveHeadSha: async () => "x",
-      execute,
-    });
+    await runReviewWorkItem({ execute });
 
     expect(execute).not.toHaveBeenCalled();
     expect(repo.markWorkCancelled).toHaveBeenCalledWith(pool, "wi-1");
@@ -243,15 +192,7 @@ describe("runDurableWorkItem", () => {
     vi.mocked(repo.getWorkItem).mockResolvedValue(makeItem());
     const execute = vi.fn().mockResolvedValue({ degraded: true });
 
-    await runDurableWorkItem({
-      cfg,
-      pool,
-      boss,
-      job: makeJob(),
-      type: "review",
-      resolveHeadSha: async () => "x",
-      execute,
-    });
+    await runReviewWorkItem({ execute });
 
     expect(repo.markWorkPublishDegraded).toHaveBeenCalledWith(pool, "wi-1");
     expect(repo.markWorkCompleted).toHaveBeenCalled();
@@ -262,16 +203,7 @@ describe("runDurableWorkItem", () => {
     const boom = new Error("transient");
     const execute = vi.fn().mockRejectedValue(boom);
 
-    await expect(
-      runDurableWorkItem({
-        cfg,
-        pool,
-        job: makeJob(0, 3),
-        type: "review",
-        resolveHeadSha: async () => "x",
-        execute,
-      }),
-    ).rejects.toBe(boom);
+    await expect(runReviewWorkItem({ job: makeJob(0, 3), execute })).rejects.toBe(boom);
 
     expect(repo.markWorkRetrying).toHaveBeenCalledWith(pool, "wi-1", boom);
     expect(repo.markWorkFailed).not.toHaveBeenCalled();
@@ -283,16 +215,7 @@ describe("runDurableWorkItem", () => {
     const execute = vi.fn().mockRejectedValue(boom);
     const onTerminalFailure = vi.fn().mockResolvedValue(undefined);
 
-    await runDurableWorkItem({
-      cfg,
-      pool,
-      boss,
-      job: makeJob(3, 3),
-      type: "review",
-      resolveHeadSha: async () => "x",
-      execute,
-      onTerminalFailure,
-    });
+    await runReviewWorkItem({ job: makeJob(3, 3), execute, onTerminalFailure });
 
     expect(repo.markWorkFailed).toHaveBeenCalledWith(pool, "wi-1", boom);
     expect(onTerminalFailure).toHaveBeenCalledTimes(1);
@@ -308,15 +231,7 @@ describe("runDurableWorkItem", () => {
     const onTerminalFailure = vi.fn().mockRejectedValue(new Error("hook boom"));
 
     await expect(
-      runDurableWorkItem({
-        cfg,
-        pool,
-        job: makeJob(3, 3),
-        type: "review",
-        resolveHeadSha: async () => "x",
-        execute,
-        onTerminalFailure,
-      }),
+      runReviewWorkItem({ job: makeJob(3, 3), execute, onTerminalFailure }),
     ).resolves.toBeUndefined();
   });
 
@@ -326,16 +241,7 @@ describe("runDurableWorkItem", () => {
     const execute = vi.fn().mockRejectedValue(new Error("dead"));
     const onTerminalFailure = vi.fn();
 
-    await runDurableWorkItem({
-      cfg,
-      pool,
-      boss,
-      job: makeJob(3, 3),
-      type: "review",
-      resolveHeadSha: async () => "x",
-      execute,
-      onTerminalFailure,
-    });
+    await runReviewWorkItem({ job: makeJob(3, 3), execute, onTerminalFailure });
 
     expect(onTerminalFailure).not.toHaveBeenCalled();
   });
@@ -360,15 +266,7 @@ describe("runDurableWorkItem", () => {
       afterComplete,
     });
 
-    await runDurableWorkItem({
-      cfg,
-      pool,
-      boss,
-      job: makeJob(),
-      type: "review",
-      resolveHeadSha: async () => "x",
-      execute,
-    });
+    await runReviewWorkItem({ execute });
 
     expect(afterComplete).toHaveBeenCalledWith(boss, "job-1");
     expect(repo.forceMarkRescheduledParentCompleted).toHaveBeenCalledWith(pool, "wi-1");
@@ -394,17 +292,9 @@ describe("runDurableWorkItem", () => {
       afterComplete: vi.fn().mockResolvedValue(undefined),
     });
 
-    await expect(
-      runDurableWorkItem({
-        cfg,
-        pool,
-        boss,
-        job: makeJob(0, 3),
-        type: "review",
-        resolveHeadSha: async () => "x",
-        execute,
-      }),
-    ).rejects.toThrow(/Failed to complete rescheduled parent/);
+    await expect(runReviewWorkItem({ job: makeJob(0, 3), execute })).rejects.toThrow(
+      /Failed to complete rescheduled parent/,
+    );
 
     expect(repo.markWorkRetrying).toHaveBeenCalled();
   });

--- a/test/githubTools.test.ts
+++ b/test/githubTools.test.ts
@@ -8,7 +8,9 @@ async function runListPullRequestFiles(
   executors: GithubExecutors,
   args: { owner: string; repo: string; pullNumber: number },
 ): Promise<ListPullRequestFilesToolOutput> {
-  return (await executors.listPullRequestFiles!(args)) as ListPullRequestFilesToolOutput;
+  const listFiles = executors.listPullRequestFiles;
+  if (!listFiles) throw new Error("listPullRequestFiles executor missing");
+  return await listFiles(args);
 }
 
 type FnMap = Partial<{

--- a/test/integration/db.ts
+++ b/test/integration/db.ts
@@ -1,6 +1,6 @@
 import { Pool } from "pg";
 
-export const DATABASE_URL = process.env.DATABASE_URL;
+const DATABASE_URL = process.env.DATABASE_URL;
 export const hasDatabase = typeof DATABASE_URL === "string" && DATABASE_URL.length > 0;
 
 export function integrationPool(): Pool {

--- a/test/parseAskQuestion.test.ts
+++ b/test/parseAskQuestion.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { MAX_ASK_QUESTION_CHARS } from "../src/agent/askSafety.js";
+import { ASK_USAGE_HINT } from "../src/settings/index.js";
 import {
   ASK_QUESTION_TOO_LONG_HINT,
-  ASK_USAGE_HINT,
   askQuestionParseFailure,
   parseAskQuestion,
 } from "../src/commands/parseAskQuestion.js";

--- a/test/reviewPrePublish.test.ts
+++ b/test/reviewPrePublish.test.ts
@@ -3,35 +3,57 @@ import { prepareReviewPayloadForPublish } from "../src/review/reviewPrePublish.j
 import { planInlinePlacements } from "../src/review/reviewDiffPlacement.js";
 import type { ReviewPayload } from "../src/review/reviewSchema.js";
 
+type ReviewFinding = ReviewPayload["findings"][number];
+
+function makeFinding(overrides: Partial<ReviewFinding> = {}): ReviewFinding {
+  return {
+    severity: "P1",
+    file: "src/a.ts",
+    startLine: 1,
+    endLine: 1,
+    title: "Issue",
+    detail: "Details.",
+    fixPrompt: "Fix it.",
+    ...overrides,
+  };
+}
+
+function makePayload(overrides: Partial<ReviewPayload> = {}): ReviewPayload {
+  return {
+    prCharacter: "Test.",
+    findings: [],
+    estimatedEffort: 2,
+    relevantTests: "no",
+    securityConcerns: null,
+    followUps: [],
+    ...overrides,
+  };
+}
+
+const secretDetail = "Found DATABASE_URL=postgres://pr_agent:pr_agent@localhost:5432/pr_agent";
+
 describe("prepareReviewPayloadForPublish", () => {
   it("dedupes overlapping findings before publish", () => {
-    const payload: ReviewPayload = {
-      prCharacter: "Test.",
+    const payload = makePayload({
       findings: [
-        {
+        makeFinding({
           severity: "P1",
-          file: "src/a.ts",
           startLine: 10,
           endLine: 12,
           title: "Race",
           detail: "Same issue",
           fixPrompt: "fix 2",
-        },
-        {
+        }),
+        makeFinding({
           severity: "P0",
-          file: "src/a.ts",
           startLine: 11,
           endLine: 13,
           title: "Race",
           detail: "Same issue",
           fixPrompt: "fix 1",
-        },
+        }),
       ],
-      estimatedEffort: 2,
-      relevantTests: "no",
-      securityConcerns: null,
-      followUps: [],
-    };
+    });
 
     const result = prepareReviewPayloadForPublish({ payload, mode: "review" });
     expect(result.ok).toBe(true);
@@ -42,42 +64,21 @@ describe("prepareReviewPayloadForPublish", () => {
   });
 
   it("passes finding detail with internal failure phrasing through after secret scrub", () => {
-    const payload: ReviewPayload = {
-      prCharacter: "Test.",
-      findings: [
-        {
-          severity: "P2",
-          file: "src/a.ts",
-          startLine: 1,
-          endLine: 1,
-          title: "Echoed failure",
-          detail: "Structured publish failed after 1/3 attempt(s).",
-          fixPrompt: "Fix the handler.",
-        },
-      ],
-      estimatedEffort: 2,
-      relevantTests: "no",
-      securityConcerns: null,
-      followUps: [],
-    };
+    const detail = "Structured publish failed after 1/3 attempt(s).";
+    const payload = makePayload({
+      findings: [makeFinding({ severity: "P2", detail, fixPrompt: "Fix the handler." })],
+    });
 
     const result = prepareReviewPayloadForPublish({ payload, mode: "review" });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.prepared.payload.findings[0]?.detail).toBe(
-      "Structured publish failed after 1/3 attempt(s).",
-    );
+    expect(result.prepared.payload.findings[0]?.detail).toBe(detail);
   });
 
   it("rejects overview with internal failure phrasing instead of redacting", () => {
-    const payload: ReviewPayload = {
+    const payload = makePayload({
       prCharacter: "Structured publish failed after 3/3 attempt(s). Check server logs.",
-      findings: [],
-      estimatedEffort: 2,
-      relevantTests: "no",
-      securityConcerns: null,
-      followUps: [],
-    };
+    });
 
     const result = prepareReviewPayloadForPublish({ payload, mode: "review" });
     expect(result.ok).toBe(false);
@@ -86,24 +87,15 @@ describe("prepareReviewPayloadForPublish", () => {
   });
 
   it("scrubs secret assignments in prepared payload", () => {
-    const payload: ReviewPayload = {
-      prCharacter: "Test.",
+    const payload = makePayload({
       findings: [
-        {
-          severity: "P1",
-          file: "src/a.ts",
-          startLine: 1,
-          endLine: 1,
+        makeFinding({
           title: "Secret in detail",
-          detail: "Found DATABASE_URL=postgres://pr_agent:pr_agent@localhost:5432/pr_agent",
+          detail: secretDetail,
           fixPrompt: "Rotate credentials.",
-        },
+        }),
       ],
-      estimatedEffort: 2,
-      relevantTests: "no",
-      securityConcerns: null,
-      followUps: [],
-    };
+    });
 
     const result = prepareReviewPayloadForPublish({ payload, mode: "review" });
     expect(result.ok).toBe(true);
@@ -113,24 +105,15 @@ describe("prepareReviewPayloadForPublish", () => {
   });
 
   it("threads placements aligned to the redacted findings", () => {
-    const payload: ReviewPayload = {
-      prCharacter: "Test.",
+    const payload = makePayload({
       findings: [
-        {
-          severity: "P1",
-          file: "src/a.ts",
-          startLine: 1,
-          endLine: 1,
+        makeFinding({
           title: "Secret in detail",
-          detail: "Found DATABASE_URL=postgres://pr_agent:pr_agent@localhost:5432/pr_agent",
+          detail: secretDetail,
           fixPrompt: "Rotate credentials.",
-        },
+        }),
       ],
-      estimatedEffort: 2,
-      relevantTests: "no",
-      securityConcerns: null,
-      followUps: [],
-    };
+    });
 
     const result = prepareReviewPayloadForPublish({ payload, mode: "review" });
     expect(result.ok).toBe(true);

--- a/test/schedulerAsk.test.ts
+++ b/test/schedulerAsk.test.ts
@@ -4,9 +4,9 @@ import type { Pool, PoolClient } from "pg";
 import type { PgBoss } from "pg-boss";
 import { createOperationLogger } from "../src/evlog.js";
 import { makeAgentWorkScheduler } from "../src/agentWork/scheduler.js";
-import { ACK_QUEUE } from "../src/agentWork/types.js";
 import { MAX_ASK_QUESTION_CHARS } from "../src/agent/askSafety.js";
-import { ASK_QUESTION_TOO_LONG_HINT, ASK_USAGE_HINT } from "../src/commands/parseAskQuestion.js";
+import { ASK_QUESTION_TOO_LONG_HINT } from "../src/commands/parseAskQuestion.js";
+import { ACK_QUEUE, ASK_USAGE_HINT } from "../src/settings/index.js";
 import * as postgres from "../src/db/postgres.js";
 
 function makeSlashInput(body: string) {

--- a/test/schedulerAutomatedDescribe.test.ts
+++ b/test/schedulerAutomatedDescribe.test.ts
@@ -4,7 +4,7 @@ import type { Pool, PoolClient } from "pg";
 import type { PgBoss } from "pg-boss";
 import { createOperationLogger } from "../src/evlog.js";
 import { makeAgentWorkScheduler } from "../src/agentWork/scheduler.js";
-import { ACK_QUEUE, DESCRIPTION_QUEUE, REVIEW_QUEUE } from "../src/agentWork/types.js";
+import { ACK_QUEUE, DESCRIPTION_QUEUE, REVIEW_QUEUE } from "../src/settings/index.js";
 import * as postgres from "../src/db/postgres.js";
 
 function makeAutomatedHeaders() {

--- a/test/submitReviewTool.test.ts
+++ b/test/submitReviewTool.test.ts
@@ -45,6 +45,31 @@ const cfg = {
   reviewAnchorMenuMaxRangesPerFile: 20,
 };
 
+function validPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    prCharacter: "Does things.",
+    findings: [],
+    estimatedEffort: 1,
+    relevantTests: "no" as const,
+    securityConcerns: null,
+    followUps: [],
+    ...overrides,
+  };
+}
+
+function finding(overrides: Record<string, unknown> = {}) {
+  return {
+    severity: "P1" as const,
+    file: "a.ts",
+    startLine: 99,
+    endLine: 99,
+    title: "Finding",
+    detail: "d",
+    fixPrompt: "fix",
+    ...overrides,
+  };
+}
+
 describe("submitReview tool", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -60,14 +85,7 @@ describe("submitReview tool", () => {
       state,
     });
 
-    const valid = {
-      prCharacter: "Does things.",
-      findings: [],
-      estimatedEffort: 1,
-      relevantTests: "no" as const,
-      securityConcerns: null,
-      followUps: [],
-    };
+    const valid = validPayload();
 
     await executor(valid);
     expect(publishReview).toHaveBeenCalledTimes(1);
@@ -103,14 +121,7 @@ describe("submitReview tool", () => {
       ctx: { owner: "o", repo: "r", prNumber: 1, headSha: "sha" },
       state,
     });
-    const valid = {
-      prCharacter: "Does things.",
-      findings: [],
-      estimatedEffort: 1,
-      relevantTests: "no" as const,
-      securityConcerns: null,
-      followUps: [],
-    };
+    const valid = validPayload();
 
     await expect(executor(valid)).rejects.toThrow(/publish budget exhausted/i);
     expect(publishReview).toHaveBeenCalledTimes(1);
@@ -128,14 +139,7 @@ describe("submitReview tool", () => {
         throw new Error("db unavailable");
       },
     });
-    const valid = {
-      prCharacter: "Does things.",
-      findings: [],
-      estimatedEffort: 1,
-      relevantTests: "no" as const,
-      securityConcerns: null,
-      followUps: [],
-    };
+    const valid = validPayload();
 
     await expect(executor(valid)).rejects.toThrow(/superseded or cancelled/i);
     expect(publishReview).not.toHaveBeenCalled();
@@ -153,14 +157,7 @@ describe("submitReview tool", () => {
       canEnforceDiffCacheBeforeSubmit: () => false,
       shouldAbortPublish: async () => true,
     });
-    const valid = {
-      prCharacter: "Does things.",
-      findings: [],
-      estimatedEffort: 1,
-      relevantTests: "no" as const,
-      securityConcerns: null,
-      followUps: [],
-    };
+    const valid = validPayload();
 
     await expect(executor(valid)).rejects.toThrow(/superseded or cancelled/i);
     expect(state.publishSuperseded).toBe(true);
@@ -191,14 +188,7 @@ describe("submitReview tool", () => {
 
   it("blocks submit when listPullRequestFiles was not ingested", async () => {
     evlog.initEvlog("info", { silent: true, suppressDrainWarning: true });
-    const valid = {
-      prCharacter: "Does things.",
-      findings: [],
-      estimatedEffort: 1,
-      relevantTests: "no" as const,
-      securityConcerns: null,
-      followUps: [],
-    };
+    const valid = validPayload();
     await evlog.runWithOperationLogger({ method: "JOB", path: "/test" }, async () => {
       initReviewRunMetrics({ provider: "openai", model: "gpt-4o-mini", mode: "review" });
       const state = createSubmitReviewState();
@@ -226,14 +216,7 @@ describe("submitReview tool", () => {
       cachedDiffIndex: index,
       canEnforceDiffCacheBeforeSubmit: () => false,
     });
-    const valid = {
-      prCharacter: "Does things.",
-      findings: [],
-      estimatedEffort: 1,
-      relevantTests: "no" as const,
-      securityConcerns: null,
-      followUps: [],
-    };
+    const valid = validPayload();
     await executor(valid);
     expect(publishReview).toHaveBeenCalledTimes(1);
   });
@@ -252,24 +235,7 @@ describe("submitReview tool", () => {
       cachedDiffIndex: index,
       canEnforceDiffCacheBeforeSubmit: () => false,
     });
-    const payload = {
-      prCharacter: "Does things.",
-      findings: [
-        {
-          severity: "P1" as const,
-          file: "a.ts",
-          startLine: 99,
-          endLine: 99,
-          title: "Bad anchor",
-          detail: "d",
-          fixPrompt: "fix",
-        },
-      ],
-      estimatedEffort: 1,
-      relevantTests: "no" as const,
-      securityConcerns: null,
-      followUps: [],
-    };
+    const payload = validPayload({ findings: [finding({ title: "Bad anchor" })] });
     await executor(payload);
     expect(publishReview).toHaveBeenCalledTimes(1);
   });
@@ -285,24 +251,9 @@ describe("submitReview tool", () => {
       state,
       cachedDiffIndex: index,
     });
-    const valid = {
-      prCharacter: "Does things.",
-      findings: [
-        {
-          severity: "P1" as const,
-          file: "src/x.ts",
-          startLine: 1,
-          endLine: 1,
-          title: "Zero-file PR",
-          detail: "d",
-          fixPrompt: "fix",
-        },
-      ],
-      estimatedEffort: 1,
-      relevantTests: "no" as const,
-      securityConcerns: null,
-      followUps: [],
-    };
+    const valid = validPayload({
+      findings: [finding({ file: "src/x.ts", startLine: 1, endLine: 1, title: "Zero-file PR" })],
+    });
     await executor(valid);
     expect(publishReview).toHaveBeenCalledTimes(1);
   });
@@ -316,33 +267,12 @@ describe("submitReview tool", () => {
         { filename: "b.ts", patch: ["@@ -2,1 +2,2 @@", " x", "+y"].join("\n") },
       ],
     });
-    const payload = {
-      prCharacter: "Does things.",
+    const payload = validPayload({
       findings: [
-        {
-          severity: "P1" as const,
-          file: "a.ts",
-          startLine: 99,
-          endLine: 99,
-          title: "Bad a",
-          detail: "d",
-          fixPrompt: "fix",
-        },
-        {
-          severity: "P1" as const,
-          file: "b.ts",
-          startLine: 88,
-          endLine: 88,
-          title: "Bad b",
-          detail: "d",
-          fixPrompt: "fix",
-        },
+        finding({ title: "Bad a" }),
+        finding({ file: "b.ts", startLine: 88, endLine: 88, title: "Bad b" }),
       ],
-      estimatedEffort: 1,
-      relevantTests: "no" as const,
-      securityConcerns: null,
-      followUps: [],
-    };
+    });
     await evlog.runWithOperationLogger({ method: "JOB", path: "/test" }, async () => {
       initReviewRunMetrics({ provider: "openai", model: "gpt-4o-mini", mode: "review" });
       const state = createSubmitReviewState();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Removed unused exports and duplicate public API surfaces flagged by Fallow
- Broke import cycles by extracting shared ask-run types, prompt block helpers, and ask user-content building
- Reduced duplicated test setup across review publish, durable job, submit review, and Cursor MCP bridge tests
- Split complex durable work execution and review finding coercion into focused helper functions

## Validation
- `pnpm run build`
- `pnpm test`
- `npx fallow --format json --quiet --score --summary`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-158a4425-f279-482f-b1a2-e62e8a1d307b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-158a4425-f279-482f-b1a2-e62e8a1d307b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

