### PR TITLE
Add Vercel Web Analytics to landing site

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
 
   site:
     dependencies:
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       lucide-react:
         specifier: ^0.468.0
         version: 0.468.0(react@19.2.6)
@@ -1902,6 +1905,35 @@ packages:
 
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
@@ -5293,6 +5325,11 @@ snapshots:
       csstype: 3.2.3
 
   '@types/retry@0.12.0': {}
+
+  '@vercel/analytics@2.0.1(next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+    optionalDependencies:
+      next: 16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
   '@vitest/expect@3.2.4':
     dependencies:

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Analytics } from "@vercel/analytics/next";
 import { PRODUCT_NAME, SEO_DESCRIPTION, SEO_KEYWORDS, SEO_TITLE } from "@/lib/seo";
 import "./globals.css";
 
@@ -54,7 +55,10 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className="bg-white text-neutral-800 min-h-screen">{children}</body>
+      <body className="bg-white text-neutral-800 min-h-screen">
+        {children}
+        <Analytics />
+      </body>
     </html>
   );
 }

--- a/site/package.json
+++ b/site/package.json
@@ -11,6 +11,7 @@
     "generate:og": "node scripts/generate-og-image.mjs"
   },
   "dependencies": {
+    "@vercel/analytics": "^2.0.1",
     "lucide-react": "^0.468.0",
     "next": "^16.0.0",
     "react": "^19.0.0",


### PR DESCRIPTION
Adds Vercel Web Analytics to the `site/` Next.js landing page.

- Add `@vercel/analytics` to the site workspace
- Mount `<Analytics />` in the root layout for page view tracking on Vercel deploys

Enable Web Analytics in the Vercel project dashboard after merge, then redeploy to start collecting data.

___

## PR Agent Description

### PR Type

Enhancement

### Description

- Add @vercel/analytics dependency to site package
- Import Analytics component in root layout
- Render Analytics alongside children in body

### Changes Diagram

```mermaid
flowchart LR
  A["Install @vercel/analytics"] --> B["Import Analytics in layout"]
  B --> C["Render Analytics component in body"]
```

### File Walkthrough

<details>
<summary>Enhancement (3 files)</summary>

<details>
<summary>Add @vercel/analytics dependency</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/61/files#diff-35f15d66f9b39b506a11ac9b5c6b9a80e11b41bfd56832ab130372902258ccf7"><code>site/package.json</code></a>

- Add @vercel/analytics ^2.0.1 to site dependencies

</details>

<details>
<summary>Integrate Vercel Analytics in root layout</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/61/files#diff-b5f0a9f3ed9cd07c1505f2bd1cb33a6b469602b6c7b2ec55a60a365db442c587"><code>site/app/layout.tsx</code></a>

- Import Analytics from @vercel/analytics/next
- Render Analytics component inside body alongside children

</details>

<details>
<summary>Lockfile update for @vercel/analytics</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/61/files#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bb"><code>pnpm-lock.yaml</code></a>

- Add resolved version 2.0.1 with next and react peer dependencies

</details>

</details>