### PR TITLE
docs: cloud VM Docker and Node version gotchas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,8 @@ When a change alters **runtime topology**, update the Mermaid diagram in [README
 
 - **`pnpm dev` does not load `.env`** — the app has no dotenv dependency. Use `node --env-file=.env --import tsx src/index.ts` (with `ROLE=web` or `ROLE=worker` set in `.env` or the shell) instead of `pnpm dev` when you need `.env` values.
 - **`GITHUB_APP_PRIVATE_KEY` must be a valid PEM key** — `loadConfig()` calls `crypto.createPrivateKey()` and throws on placeholders. For local-only dev, generate a throwaway key: `openssl genrsa 2048 > key.pem` and set the `.env` value to the escaped content.
-- **Docker in cloud VMs** — needs `fuse-overlayfs` storage driver and `iptables-legacy`. The update script handles Docker installation; start `dockerd` manually if needed: `sudo dockerd &>/tmp/dockerd.log &`.
+- **Docker in cloud VMs** — needs `fuse-overlayfs` storage driver and `iptables-legacy`. The update script handles Docker installation; start `dockerd` manually if needed: `sudo dockerd &>/tmp/dockerd.log &`. Use `sudo docker …` for container commands when `/var/run/docker.sock` is root-owned.
+- **Node engine** — `package.json` requires Node `>=22.19.0`; cloud VMs may ship `22.14.x` (pnpm warns but tests and runtime work).
 - **Tests (`pnpm test`)** are pure unit/integration tests and do not need Postgres or any running service.
 - **Lint/fmt commands**: `pnpm lint` (oxlint, type-aware), `pnpm typecheck` (tsc), `pnpm fmt:check` (oxfmt). Combined: `pnpm check:code`.
 - **Ignored build scripts warning** from pnpm is expected for some transitive deps (`esbuild`, `protobufjs`). **`sqlite3` is approved** in `package.json` (`pnpm.onlyBuiltDependencies`) because `@cursor/sdk` needs its native binding when `PI_PROVIDER=cursor`. The Docker image compiles `sqlite3` in the `deps` stage (with `python3`/`make`/`g++`) and copies `node_modules` into runtime — do not run a fresh `pnpm install --prod` in the final stage without build tools.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds two small notes to `AGENTS.md` Cursor Cloud instructions discovered during environment setup:

- Use `sudo docker` when the Docker socket is root-owned (common on cloud VMs after starting `dockerd`).
- Document that Node `22.14.x` triggers an engines warning but tests and runtime still work.

No application code changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff503343-ed1d-4c99-900d-385da52e0ea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff503343-ed1d-4c99-900d-385da52e0ea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

___

## PR Agent Description

### PR Type

Documentation

### Description

- Add sudo docker guidance for root-owned Docker socket
- Document Node >=22.19.0 requirement vs cloud VM versions
- Expand Cursor Cloud gotchas for agent onboarding

### File Walkthrough

<details>
<summary>Documentation (1 file)</summary>

<details>
<summary>Expand Cursor Cloud gotchas section</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/63/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9"><code>AGENTS.md</code></a>

- Note using `sudo docker` when docker.sock is root-owned
- Clarify Node engine mismatch on cloud VMs (22.14.x vs >=22.19.0)

</details>

</details>