### PR TITLE
Remove redundant PEM toString in config tests

### DIFF
--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -6,7 +6,7 @@ function testPrivateKeyPem(): string {
   const { privateKey } = crypto.generateKeyPairSync("rsa", {
     modulusLength: 2048,
   });
-  return privateKey.export({ type: "pkcs1", format: "pem" }).toString();
+  return privateKey.export({ type: "pkcs1", format: "pem" });
 }
 
 describe("normalizeGithubAppPrivateKey", () => {

--- a/test/configCursor.test.ts
+++ b/test/configCursor.test.ts
@@ -5,7 +5,7 @@ function testPrivateKeyPem(): string {
   const { privateKey } = crypto.generateKeyPairSync("rsa", {
     modulusLength: 2048,
   });
-  return privateKey.export({ type: "pkcs1", format: "pem" }).toString();
+  return privateKey.export({ type: "pkcs1", format: "pem" });
 }
 
 const BASE_ENV = {

--- a/test/configValidation.test.ts
+++ b/test/configValidation.test.ts
@@ -5,7 +5,7 @@ function testPrivateKeyPem(): string {
   const { privateKey } = crypto.generateKeyPairSync("rsa", {
     modulusLength: 2048,
   });
-  return privateKey.export({ type: "pkcs1", format: "pem" }).toString();
+  return privateKey.export({ type: "pkcs1", format: "pem" });
 }
 
 const BASE_ENV = {


### PR DESCRIPTION
## Summary
- Remove redundant `.toString()` on `KeyObject.export()` PEM output in config test helpers
- Clears `typescript/no-unnecessary-type-conversion` oxlint warnings in three test files

## Test plan
- [x] `pnpm run check:code`
- [x] `pnpm test`