### PR TITLE
Harden stale-head review rescheduling

### DIFF
--- a/src/agentWork/reviewReschedule.ts
+++ b/src/agentWork/reviewReschedule.ts
@@ -21,27 +21,28 @@ export type StaleSlashReviewRescheduleResult = {
   readonly afterComplete: (boss: PgBoss, activePgBossJobId: string) => Promise<void>;
 };
 
+type SlashReviewRescheduleWorkItem = {
+  readonly replacementWorkItemId: string;
+  readonly headSha: string;
+};
+
 export async function buildStaleSlashReviewRescheduleResult(
   pool: Pool,
   item: AgentWorkItem,
   token: string,
 ): Promise<StaleSlashReviewRescheduleResult> {
   const latestHeadSha = await getPullRequestHeadSha(token, item.owner, item.repo, item.prNumber);
-  const replacementWorkItemId = await createSlashReviewRescheduleWorkItem(
-    pool,
-    item,
-    latestHeadSha,
-  );
+  const replacement = await createSlashReviewRescheduleWorkItem(pool, item, latestHeadSha);
   return {
     rescheduled: true,
-    replacementWorkItemId,
+    replacementWorkItemId: replacement.replacementWorkItemId,
     afterComplete: async (boss, activePgBossJobId) => {
       await enqueueSlashReviewReschedule(
         pool,
         boss,
         item,
-        replacementWorkItemId,
-        latestHeadSha,
+        replacement.replacementWorkItemId,
+        replacement.headSha,
         activePgBossJobId,
       );
     },
@@ -52,7 +53,7 @@ export async function createSlashReviewRescheduleWorkItem(
   pool: Pool,
   item: AgentWorkItem,
   latestHeadSha: string,
-): Promise<string> {
+): Promise<SlashReviewRescheduleWorkItem> {
   const payload = item.payload as ReviewWorkPayload;
   const reviewLens = item.reviewLens!;
   let replacementWorkItemId = payload.staleHeadReplacementWorkItemId;
@@ -89,16 +90,16 @@ export async function createSlashReviewRescheduleWorkItem(
     staleHeadReplacementWorkItemId: replacementWorkItemId,
   };
 
-  await pool.query(
+  const insertResult = await pool.query<{ head_sha: string }>(
     `INSERT INTO agent_work_items (
        id, webhook_event_id, type, source, status, owner, repo, pr_number, installation_id,
        head_sha, review_lens, resource_key, priority, payload
      )
      VALUES ($1, $2, 'review', 'slash', 'queued', $3, $4, $5, $6, $7, $8, $9, 0, $10::jsonb)
      ON CONFLICT (id) DO UPDATE SET
-       head_sha = EXCLUDED.head_sha,
        payload = EXCLUDED.payload,
-       updated_at = now()`,
+       updated_at = now()
+     RETURNING head_sha`,
     [
       replacementWorkItemId,
       item.webhookEventId,
@@ -113,7 +114,10 @@ export async function createSlashReviewRescheduleWorkItem(
     ],
   );
 
-  return replacementWorkItemId;
+  return {
+    replacementWorkItemId,
+    headSha: insertResult.rows[0].head_sha,
+  };
 }
 
 async function claimStaleHeadReplacementEnqueue(pool: Pool, parentId: string): Promise<boolean> {
@@ -146,7 +150,7 @@ export async function enqueueSlashReviewReschedule(
   boss: PgBoss,
   item: AgentWorkItem,
   workItemId: string,
-  latestHeadSha: string,
+  replacementHeadSha: string,
   activePgBossJobId?: string,
 ): Promise<void> {
   const reviewLens = item.reviewLens!;
@@ -187,25 +191,6 @@ export async function enqueueSlashReviewReschedule(
       skipJobId: activePgBossJobId,
     });
 
-    const ackData: AckJobData = {
-      kind: "ack",
-      workItemId,
-      installationId: item.installationId,
-      owner: item.owner,
-      repo: item.repo,
-      prNumber: item.prNumber,
-      targets: [],
-      progress: { lens: reviewLens, headSha: latestHeadSha, source: "slash" },
-      ...correlation,
-    };
-    const ackJobId = await boss.send(ACK_QUEUE, ackData, {
-      priority: 100,
-      group: { id: installationGroupId(item.installationId) },
-    });
-    if (ackJobId == null) {
-      throw new Error("pg-boss did not enqueue replacement review ack job");
-    }
-
     const reviewData: ReviewJobData = {
       kind: "review",
       workItemId,
@@ -219,6 +204,25 @@ export async function enqueueSlashReviewReschedule(
       throw new Error("pg-boss did not enqueue replacement review job");
     }
 
+    const ackData: AckJobData = {
+      kind: "ack",
+      workItemId,
+      installationId: item.installationId,
+      owner: item.owner,
+      repo: item.repo,
+      prNumber: item.prNumber,
+      targets: [],
+      progress: { lens: reviewLens, headSha: replacementHeadSha, source: "slash" },
+      ...correlation,
+    };
+    const ackJobId = await boss.send(ACK_QUEUE, ackData, {
+      priority: 100,
+      group: { id: installationGroupId(item.installationId) },
+    });
+    if (ackJobId == null) {
+      throw new Error("pg-boss did not enqueue replacement review ack job");
+    }
+
     logInfo("review_stale_head_rescheduled", {
       owner: item.owner,
       repo: item.repo,
@@ -227,7 +231,7 @@ export async function enqueueSlashReviewReschedule(
       previousWorkItemId: item.id,
       replacementWorkItemId: workItemId,
       previousHeadSha: item.headSha,
-      latestHeadSha,
+      latestHeadSha: replacementHeadSha,
     });
   } catch (e) {
     await releaseStaleHeadReplacementEnqueueClaim(pool, item.id);

--- a/test/reviewReschedule.test.ts
+++ b/test/reviewReschedule.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Pool } from "pg";
 import type { PgBoss } from "pg-boss";
+import { ACK_QUEUE, REVIEW_QUEUE } from "../src/settings/index.js";
 import {
+  buildStaleSlashReviewRescheduleResult,
   createSlashReviewRescheduleWorkItem,
   enqueueSlashReviewReschedule,
 } from "../src/agentWork/reviewReschedule.js";
@@ -10,8 +12,12 @@ import type { AgentWorkItem } from "../src/agentWork/types.js";
 vi.mock("../src/agentWork/repository.js", () => ({
   getWorkItem: vi.fn(),
 }));
+vi.mock("../src/agentWork/githubPrSurface.js", () => ({
+  getPullRequestHeadSha: vi.fn(),
+}));
 
 import { getWorkItem } from "../src/agentWork/repository.js";
+import { getPullRequestHeadSha } from "../src/agentWork/githubPrSurface.js";
 
 function makeItem(overrides: Partial<AgentWorkItem> = {}): AgentWorkItem {
   return {
@@ -34,12 +40,19 @@ function makeItem(overrides: Partial<AgentWorkItem> = {}): AgentWorkItem {
   };
 }
 
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
 describe("createSlashReviewRescheduleWorkItem", () => {
-  it("upserts head_sha when replacement row already exists", async () => {
-    const query = vi.fn().mockResolvedValue({ rowCount: 1, rows: [] });
+  it("keeps the first persisted head_sha when replacement row already exists", async () => {
+    const query = vi.fn().mockResolvedValue({
+      rowCount: 1,
+      rows: [{ head_sha: "persisted-head" }],
+    });
     const pool = { query } as unknown as Pool;
 
-    await createSlashReviewRescheduleWorkItem(
+    const replacement = await createSlashReviewRescheduleWorkItem(
       pool,
       makeItem({
         payload: {
@@ -51,14 +64,23 @@ describe("createSlashReviewRescheduleWorkItem", () => {
       "newhead",
     );
 
-    expect(String(query.mock.calls[0]?.[0])).toContain("head_sha = EXCLUDED.head_sha");
+    expect(replacement).toEqual({
+      replacementWorkItemId: "existing-replacement",
+      headSha: "persisted-head",
+    });
+    const sql = String(query.mock.calls[0]?.[0]);
+    expect(sql).toContain("RETURNING head_sha");
+    expect(sql).not.toContain("head_sha = EXCLUDED.head_sha");
   });
 
   it("reuses persisted replacement id without creating a new marker", async () => {
-    const query = vi.fn().mockResolvedValue({ rowCount: 1, rows: [] });
+    const query = vi.fn().mockResolvedValue({
+      rowCount: 1,
+      rows: [{ head_sha: "newhead" }],
+    });
     const pool = { query } as unknown as Pool;
 
-    const replacementId = await createSlashReviewRescheduleWorkItem(
+    const replacement = await createSlashReviewRescheduleWorkItem(
       pool,
       makeItem({
         payload: {
@@ -70,7 +92,7 @@ describe("createSlashReviewRescheduleWorkItem", () => {
       "newhead",
     );
 
-    expect(replacementId).toBe("existing-replacement");
+    expect(replacement.replacementWorkItemId).toBe("existing-replacement");
     expect(query).toHaveBeenCalledTimes(1);
   });
 
@@ -81,12 +103,12 @@ describe("createSlashReviewRescheduleWorkItem", () => {
         rowCount: 1,
         rows: [{ replacement_id: "generated-replacement" }],
       })
-      .mockResolvedValueOnce({ rowCount: 1, rows: [] });
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ head_sha: "newhead" }] });
     const pool = { query } as unknown as Pool;
 
-    const replacementId = await createSlashReviewRescheduleWorkItem(pool, makeItem(), "newhead");
+    const replacement = await createSlashReviewRescheduleWorkItem(pool, makeItem(), "newhead");
 
-    expect(replacementId).toBe("generated-replacement");
+    expect(replacement.replacementWorkItemId).toBe("generated-replacement");
     expect(query).toHaveBeenCalledTimes(2);
     expect(String(query.mock.calls[0]?.[0])).toContain(
       "payload->>'staleHeadReplacementWorkItemId') IS NULL",
@@ -106,13 +128,44 @@ describe("createSlashReviewRescheduleWorkItem", () => {
     const query = vi
       .fn()
       .mockResolvedValueOnce({ rowCount: 0, rows: [] })
-      .mockResolvedValueOnce({ rowCount: 1, rows: [] });
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ head_sha: "newhead" }] });
     const pool = { query } as unknown as Pool;
 
-    const replacementId = await createSlashReviewRescheduleWorkItem(pool, makeItem(), "newhead");
+    const replacement = await createSlashReviewRescheduleWorkItem(pool, makeItem(), "newhead");
 
-    expect(replacementId).toBe("winner-replacement");
+    expect(replacement.replacementWorkItemId).toBe("winner-replacement");
     expect(getWorkItem).toHaveBeenCalledWith(pool, "parent-wi");
+  });
+
+  it("uses the persisted replacement head for the ack after an insert conflict", async () => {
+    vi.mocked(getPullRequestHeadSha).mockResolvedValue("latest-head");
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ head_sha: "persisted-head" }] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [] });
+    const pool = { query } as unknown as Pool;
+    const send = vi.fn().mockResolvedValue("job-id");
+    const findJobs = vi.fn().mockResolvedValue([]);
+    const cancel = vi.fn();
+    const boss = { send, findJobs, cancel } as unknown as PgBoss;
+
+    const result = await buildStaleSlashReviewRescheduleResult(
+      pool,
+      makeItem({
+        payload: {
+          mode: "review",
+          source: "slash",
+          staleHeadReplacementWorkItemId: "existing-replacement",
+        },
+      }),
+      "token",
+    );
+    await result.afterComplete(boss, "active-job");
+
+    const ackCall = send.mock.calls.find(([queue]) => queue === ACK_QUEUE);
+    expect(ackCall?.[1]).toMatchObject({
+      progress: { headSha: "persisted-head" },
+    });
   });
 });
 
@@ -143,7 +196,22 @@ describe("enqueueSlashReviewReschedule", () => {
     expect(query).not.toHaveBeenCalled();
   });
 
-  it("claims enqueue marker before boss.send and releases it on failure", async () => {
+  it("sends the replacement review job before the ack job", async () => {
+    const query = vi.fn().mockResolvedValue({ rowCount: 1, rows: [] });
+    const pool = { query } as unknown as Pool;
+    const send = vi.fn().mockResolvedValue("job-id");
+    const findJobs = vi.fn().mockResolvedValue([]);
+    const cancel = vi.fn();
+    const boss = { send, findJobs, cancel } as unknown as PgBoss;
+
+    await enqueueSlashReviewReschedule(pool, boss, makeItem(), "replacement-wi", "newhead");
+
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(send.mock.calls[0]?.[0]).toBe(REVIEW_QUEUE);
+    expect(send.mock.calls[1]?.[0]).toBe(ACK_QUEUE);
+  });
+
+  it("claims enqueue marker before boss.send and releases it on review enqueue failure", async () => {
     const query = vi
       .fn()
       .mockResolvedValueOnce({ rowCount: 1, rows: [] })
@@ -156,10 +224,31 @@ describe("enqueueSlashReviewReschedule", () => {
 
     await expect(
       enqueueSlashReviewReschedule(pool, boss, makeItem(), "replacement-wi", "newhead"),
-    ).rejects.toThrow(/did not enqueue replacement review ack job/);
+    ).rejects.toThrow(/did not enqueue replacement review job/);
 
     expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0]?.[0]).toBe(REVIEW_QUEUE);
     expect(String(query.mock.calls[0]?.[0])).toContain("staleHeadReplacementEnqueued");
+    expect(String(query.mock.calls[1]?.[0])).toContain("payload - 'staleHeadReplacementEnqueued'");
+  });
+
+  it("does not send an ack when replacement review enqueue throws", async () => {
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({ rowCount: 1, rows: [] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [] });
+    const pool = { query } as unknown as Pool;
+    const send = vi.fn().mockRejectedValueOnce(new Error("review queue unavailable"));
+    const findJobs = vi.fn().mockResolvedValue([]);
+    const cancel = vi.fn();
+    const boss = { send, findJobs, cancel } as unknown as PgBoss;
+
+    await expect(
+      enqueueSlashReviewReschedule(pool, boss, makeItem(), "replacement-wi", "newhead"),
+    ).rejects.toThrow(/review queue unavailable/);
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0]?.[0]).toBe(REVIEW_QUEUE);
     expect(String(query.mock.calls[1]?.[0])).toContain("payload - 'staleHeadReplacementEnqueued'");
   });
 });


### PR DESCRIPTION
Queues replacement review work before the progress ack, so a review enqueue failure cannot leave a user-visible orphan ack. Replacement work items now keep the first persisted head SHA on retry, with regression coverage for enqueue order, review enqueue failures, and persisted-head reuse.

___

## PR Agent Description

### PR Type

Bug fix, Tests

### Description

- Preserve replacement work item head_sha on upsert conflict instead of overwriting
- Return persisted head_sha from DB and use it for ack job progress
- Enqueue replacement review job before ack to avoid orphaned acks
- Expand tests for head preservation, job ordering, and enqueue failure paths

### Changes Diagram

```mermaid
flowchart LR
  A["Stale head detected"] --> B["Upsert replacement row"]
  B --> C["RETURNING persisted head_sha"]
  C --> D["Enqueue review job"]
  D --> E["Enqueue ack with persisted SHA"]
```

### File Walkthrough

<details>
<summary>Bug fix (1 file)</summary>

<details>
<summary>Preserve head_sha and reorder job enqueue</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/104/files#diff-c79b91f5883f00c199e4703c0646c127d2536401f6e6ef6d07f5237c030d8440"><code>src/agentWork/reviewReschedule.ts</code></a>

- Stop updating head_sha on ON CONFLICT; RETURNING head_sha from upsert
- createSlashReviewRescheduleWorkItem returns replacementWorkItemId and headSha
- Send REVIEW_QUEUE before ACK_QUEUE; ack uses persisted replacement head

</details>

</details>

<details>
<summary>Tests (1 file)</summary>

<details>
<summary>Cover head preservation and enqueue ordering</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/104/files#diff-915478ef91549b8f15dc4a3134a632e52c048fcdfffec9c245ce33164cb559f7"><code>test/reviewReschedule.test.ts</code></a>

- Assert upsert keeps first persisted head_sha on conflict
- Verify review job sent before ack; ack skipped on review enqueue failure
- Integration test: buildStaleSlashReviewRescheduleResult uses persisted head for ack

</details>

</details>