### PR TITLE
Classify diff patch lines strictly

### DIFF
--- a/src/review/reviewDiffIndex.ts
+++ b/src/review/reviewDiffIndex.ts
@@ -43,20 +43,41 @@ export function parseCommentableRightLineRanges(patch: string): CommentableRight
     range = [line, line];
   };
 
-  for (const rawLine of patch.split("\n")) {
+  const finishRanges = () => {
+    if (range) {
+      ranges.push(range);
+    }
+    return ranges;
+  };
+
+  if (patch === "") return ranges;
+
+  const lines = patch.endsWith("\n") ? patch.slice(0, -1).split("\n") : patch.split("\n");
+  let seenHunk = false;
+
+  for (const rawLine of lines) {
     if (rawLine.startsWith("@@")) {
       const hunkMatch = rawLine.match(DIFF_HUNK_RE);
-      if (hunkMatch) {
-        rightLine = Number(hunkMatch[1]);
-        continue;
-      }
+      if (!hunkMatch) return finishRanges();
+      rightLine = Number(hunkMatch[1]);
+      seenHunk = true;
+      continue;
+    }
+    if (
+      !seenHunk &&
+      (rawLine.startsWith("diff --git ") ||
+        rawLine.startsWith("index ") ||
+        rawLine.startsWith("--- ") ||
+        rawLine.startsWith("+++ "))
+    ) {
+      continue;
     }
     if (rawLine.startsWith("+") && !rawLine.startsWith("+++")) {
       addCommentableLine(rightLine);
       rightLine++;
       continue;
     }
-    if (rawLine.startsWith(" ") && rawLine.length > 0) {
+    if (rawLine.startsWith(" ") || rawLine.length === 0) {
       addCommentableLine(rightLine);
       rightLine++;
       continue;
@@ -67,13 +88,10 @@ export function parseCommentableRightLineRanges(patch: string): CommentableRight
     if (rawLine.startsWith("\\")) {
       continue;
     }
-    if (rawLine.length > 0) {
-      rightLine++;
-    }
+    return finishRanges();
   }
 
-  if (range) ranges.push(range);
-  return ranges;
+  return finishRanges();
 }
 
 export type ListPullRequestFilesToolResult = {

--- a/src/review/reviewDiffIndex.ts
+++ b/src/review/reviewDiffIndex.ts
@@ -63,13 +63,7 @@ export function parseCommentableRightLineRanges(patch: string): CommentableRight
       seenHunk = true;
       continue;
     }
-    if (
-      !seenHunk &&
-      (rawLine.startsWith("diff --git ") ||
-        rawLine.startsWith("index ") ||
-        rawLine.startsWith("--- ") ||
-        rawLine.startsWith("+++ "))
-    ) {
+    if (!seenHunk) {
       continue;
     }
     if (rawLine.startsWith("+") && !rawLine.startsWith("+++")) {

--- a/src/review/reviewDiffIndex.ts
+++ b/src/review/reviewDiffIndex.ts
@@ -54,12 +54,14 @@ export function parseCommentableRightLineRanges(patch: string): CommentableRight
 
   const lines = patch.endsWith("\n") ? patch.slice(0, -1).split("\n") : patch.split("\n");
   let seenHunk = false;
+  let rightLinesRemaining = 0;
 
   for (const rawLine of lines) {
     if (rawLine.startsWith("@@")) {
       const hunkMatch = rawLine.match(DIFF_HUNK_RE);
       if (!hunkMatch) return finishRanges();
       rightLine = Number(hunkMatch[1]);
+      rightLinesRemaining = Number(hunkMatch[2] ?? "1");
       seenHunk = true;
       continue;
     }
@@ -69,11 +71,21 @@ export function parseCommentableRightLineRanges(patch: string): CommentableRight
     if (rawLine.startsWith("+") && !rawLine.startsWith("+++")) {
       addCommentableLine(rightLine);
       rightLine++;
+      rightLinesRemaining--;
       continue;
     }
-    if (rawLine.startsWith(" ") || rawLine.length === 0) {
+    if (rawLine.startsWith(" ")) {
       addCommentableLine(rightLine);
       rightLine++;
+      rightLinesRemaining--;
+      continue;
+    }
+    if (rawLine.length === 0) {
+      if (rightLinesRemaining > 0) {
+        addCommentableLine(rightLine);
+        rightLine++;
+        rightLinesRemaining--;
+      }
       continue;
     }
     if (rawLine.startsWith("-") && !rawLine.startsWith("---")) {

--- a/test/reviewDiffIndex.test.ts
+++ b/test/reviewDiffIndex.test.ts
@@ -139,6 +139,19 @@ describe("reviewDiffIndex", () => {
     expect(parseCommentableRightLineRanges(patch)).toEqual([[10, 10]]);
   });
 
+  it("does not treat empty split segments between hunks as context lines", () => {
+    const patch = ["@@ -5,1 +5,1 @@", "+line5", "", "@@ -7,1 +7,1 @@", "+line7"].join("\n");
+    expect(parseCommentableRightLineRanges(patch)).toEqual([
+      [5, 5],
+      [7, 7],
+    ]);
+  });
+
+  it("does not treat repeated trailing patch newlines as context lines", () => {
+    const patch = ["@@ -10,1 +10,1 @@", "+added", "", ""].join("\n");
+    expect(parseCommentableRightLineRanges(patch)).toEqual([[10, 10]]);
+  });
+
   it("returns ranges before a malformed hunk header and stops anchoring", () => {
     const patch = ["@@ -4,1 +4,2 @@", " context", "+added", "@@ garbage @@", "+after"].join("\n");
     expect(parseCommentableRightLineRanges(patch)).toEqual([[4, 5]]);

--- a/test/reviewDiffIndex.test.ts
+++ b/test/reviewDiffIndex.test.ts
@@ -162,6 +162,34 @@ describe("reviewDiffIndex", () => {
     expect(parseCommentableRightLineRanges(patch)).toEqual([[1, 2]]);
   });
 
+  it("ignores rename metadata before the first hunk", () => {
+    const patch = [
+      "diff --git a/old.txt b/new.txt",
+      "similarity index 86%",
+      "rename from old.txt",
+      "rename to new.txt",
+      "index 5626abf..f719efd 100644",
+      "--- a/old.txt",
+      "+++ b/new.txt",
+      "@@ -1,1 +1,1 @@",
+      "+renamed",
+    ].join("\n");
+    expect(parseCommentableRightLineRanges(patch)).toEqual([[1, 1]]);
+  });
+
+  it("ignores new-file metadata before the first hunk", () => {
+    const patch = [
+      "diff --git a/new.txt b/new.txt",
+      "new file mode 100644",
+      "index 0000000..f719efd",
+      "--- /dev/null",
+      "+++ b/new.txt",
+      "@@ -0,0 +1,1 @@",
+      "+added",
+    ].join("\n");
+    expect(parseCommentableRightLineRanges(patch)).toEqual([[1, 1]]);
+  });
+
   it("returns empty ranges for empty patches and deletion-only patches", () => {
     const patch = ["@@ -4,2 +4,0 @@", "-removed", "-gone"].join("\n");
     expect(parseCommentableRightLineRanges("")).toEqual([]);

--- a/test/reviewDiffIndex.test.ts
+++ b/test/reviewDiffIndex.test.ts
@@ -109,14 +109,63 @@ describe("reviewDiffIndex", () => {
     ]);
   });
 
+  it("keeps adjacent two-hunk ranges contiguous", () => {
+    const patch = ["@@ -5,1 +5,1 @@", "+code at line 5", "@@ -6,1 +6,1 @@", "+code at line 6"].join(
+      "\n",
+    );
+    expect(parseCommentableRightLineRanges(patch)).toEqual([[5, 6]]);
+  });
+
   it("keeps right-side ranges contiguous across deleted lines", () => {
     const patch = ["@@ -5,3 +5,2 @@", "+added", "-removed", " context"].join("\n");
     expect(parseCommentableRightLineRanges(patch)).toEqual([[5, 6]]);
   });
 
   it("ignores no-newline marker lines when advancing right-side line numbers", () => {
-    const patch = ["@@ -4,1 +4,2 @@", "+added", "\\ No newline at end of file"].join("\n");
+    const patch = ["@@ -4,1 +4,2 @@", " context", "+added"].join("\n");
+    const patchWithMarker = [patch, "\\ No newline at end of file"].join("\n");
+    expect(parseCommentableRightLineRanges(patchWithMarker)).toEqual(
+      parseCommentableRightLineRanges(patch),
+    );
+  });
+
+  it("treats zero-length context lines as commentable right-side lines", () => {
+    const patch = ["@@ -10,2 +10,3 @@", "+added first", "", "+added second"].join("\n");
+    expect(parseCommentableRightLineRanges(patch)).toEqual([[10, 12]]);
+  });
+
+  it("does not treat a trailing patch newline as an extra context line", () => {
+    const patch = ["@@ -10,1 +10,1 @@", "+added", ""].join("\n");
+    expect(parseCommentableRightLineRanges(patch)).toEqual([[10, 10]]);
+  });
+
+  it("returns ranges before a malformed hunk header and stops anchoring", () => {
+    const patch = ["@@ -4,1 +4,2 @@", " context", "+added", "@@ garbage @@", "+after"].join("\n");
+    expect(parseCommentableRightLineRanges(patch)).toEqual([[4, 5]]);
+  });
+
+  it("returns ranges before an unrecognized patch line and stops anchoring", () => {
+    const patch = ["@@ -4,1 +4,3 @@", " context", "*unknown", "+after"].join("\n");
     expect(parseCommentableRightLineRanges(patch)).toEqual([[4, 4]]);
+  });
+
+  it("ignores git file headers before the first hunk", () => {
+    const patch = [
+      "diff --git a/src.txt b/src.txt",
+      "index 5626abf..f719efd 100644",
+      "--- a/src.txt",
+      "+++ b/src.txt",
+      "@@ -1,1 +1,2 @@",
+      " one",
+      "+two",
+    ].join("\n");
+    expect(parseCommentableRightLineRanges(patch)).toEqual([[1, 2]]);
+  });
+
+  it("returns empty ranges for empty patches and deletion-only patches", () => {
+    const patch = ["@@ -4,2 +4,0 @@", "-removed", "-gone"].join("\n");
+    expect(parseCommentableRightLineRanges("")).toEqual([]);
+    expect(parseCommentableRightLineRanges(patch)).toEqual([]);
   });
 
   it("resolves anchors when hunks produce out-of-order commentable ranges", () => {


### PR DESCRIPTION
- Stop commentable-range parsing after malformed hunk headers or unknown patch lines instead of advancing RIGHT-side lines
- Treat stripped empty context lines as commentable and ignore pre-hunk git file headers
- Add parser regressions for adjacent hunks, markers, empty context, malformed headers, unknown lines, headers, and deletion-only patches

Closes #95

___

## PR Agent Description

### PR Type

Bug fix, Tests

### Description

- Harden parseCommentableRightLineRanges for empty, malformed, and header-heavy patches
- Treat zero-length context lines and strip trailing patch newlines correctly
- Stop anchoring on malformed hunks or unrecognized patch lines
- Add edge-case tests for contiguous hunks, headers, and deletions

### Changes Diagram

```mermaid
flowchart LR
  A["Parse patch"] --> B["Skip git headers"]
  B --> C["Walk hunk lines"]
  C --> D["Handle context and additions"]
  D --> E["Stop on malformed input"]
  E --> F["Return commentable ranges"]
```

### File Walkthrough

<details>
<summary>Bug fix (1 file)</summary>

<details>
<summary>Harden unified diff line-range parser</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/105/files#diff-2ac59907ca65f1a8985e372203fb565c3c2bd8e8122783b44c5208b10d130459"><code>src/review/reviewDiffIndex.ts</code></a>

- Skip git file headers before the first hunk
- Treat empty context lines as commentable; ignore trailing newline
- Return early on malformed hunks or unrecognized patch lines

</details>

</details>

<details>
<summary>Tests (1 file)</summary>

<details>
<summary>Add parser edge-case regression tests</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/105/files#diff-1dcc88ee075150edf66dd5351b11435fc4da76bdc51b4b2a4c36443b402f56da"><code>test/reviewDiffIndex.test.ts</code></a>

- Cover adjacent hunks, zero-length context, and trailing newlines
- Assert safe behavior for malformed hunks and git headers
- Verify empty and deletion-only patches return no ranges

</details>

</details>