### PR TITLE
Bundle anchor menu into round 0

### DIFF
--- a/src/review/reviewRunHarness.ts
+++ b/src/review/reviewRunHarness.ts
@@ -120,19 +120,16 @@ export async function runReviewHarness(params: {
     lastText = (await session.send(setup.userContent, investigationOpts)).text;
     if (!shouldContinueReviewRun(setup)) return;
 
+    let anchorMenuBlock: string | undefined;
     if (
       cfg.reviewInjectAnchorMenu &&
       setup.cachedDiffIndex.files.size > 0 &&
       shouldContinueReviewRun(setup)
     ) {
-      const anchorMenu = renderAnchorMenuBlock(setup.cachedDiffIndex, {
+      anchorMenuBlock = renderAnchorMenuBlock(setup.cachedDiffIndex, {
         maxFiles: cfg.reviewAnchorMenuMaxFiles,
         maxRangesPerFile: cfg.reviewAnchorMenuMaxRangesPerFile,
       });
-      if (anchorMenu) {
-        lastText = (await session.send(anchorMenu, investigationOpts)).text;
-        if (!shouldContinueReviewRun(setup)) return;
-      }
     }
 
     if (shouldContinueReviewRun(setup)) {
@@ -140,7 +137,9 @@ export async function runReviewHarness(params: {
       for (let round = 0; round < 2 && shouldContinueReviewRun(setup); round++) {
         const prompt =
           round === 0
-            ? [PRE_SUBMIT_ROUND0_PROMPT, PROSE_ONLY_NUDGE].join("\n\n")
+            ? [anchorMenuBlock, PRE_SUBMIT_ROUND0_PROMPT, PROSE_ONLY_NUDGE]
+                .filter(Boolean)
+                .join("\n\n")
             : PRE_SUBMIT_REMINDER;
         lastText = await sendSubmitOnlyRepair(prompt);
         if (!shouldContinueReviewRun(setup)) break;

--- a/test/reviewRunHarness.test.ts
+++ b/test/reviewRunHarness.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { makeTestConfig } from "./helpers/config.js";
+import { PRE_SUBMIT_REMINDER, PRE_SUBMIT_ROUND0_PROMPT } from "../src/review/reviewPromptBlocks.js";
+import { PROSE_ONLY_NUDGE } from "../src/settings/index.js";
 
 const sendMock = vi.fn(async (_message: string) => ({ text: "done" }));
 const createSessionMock = vi.fn(async (_params: unknown) => ({
@@ -8,6 +10,32 @@ const createSessionMock = vi.fn(async (_params: unknown) => ({
   restoreTools: vi.fn(),
   dispose: vi.fn(async () => undefined),
 }));
+
+const nonEmptyDiffIndex = () => ({
+  files: new Map([
+    [
+      "src/a.ts",
+      {
+        patchOmitted: false,
+        commentableRightLineRanges: [[1, 5]],
+      },
+    ],
+  ]),
+  truncated: false,
+});
+
+const emptyDiffIndex = () => ({
+  files: new Map(),
+  truncated: false,
+});
+
+let cachedDiffIndex = nonEmptyDiffIndex();
+let submitState = {
+  published: false,
+  publishSuperseded: false,
+  lastValidationError: null,
+  publishCallCount: 0,
+};
 
 vi.mock("../src/github/reviewPublish.js", () => ({
   upsertReviewSummaryComment: vi.fn(async () => ({ id: 1, updated: true })),
@@ -28,24 +56,8 @@ vi.mock("../src/review/reviewRunSetup.js", async (importOriginal) => {
       userContent: "investigate",
       piTools: [],
       executors: {},
-      cachedDiffIndex: {
-        files: new Map([
-          [
-            "src/a.ts",
-            {
-              patchOmitted: false,
-              commentableRightLineRanges: [[1, 5]],
-            },
-          ],
-        ]),
-        truncated: false,
-      },
-      submitState: {
-        published: false,
-        publishSuperseded: false,
-        lastValidationError: null,
-        publishCallCount: 0,
-      },
+      cachedDiffIndex,
+      submitState,
       getToken: () => params.token,
       refreshBeforeTool: vi.fn(),
     })),
@@ -54,23 +66,33 @@ vi.mock("../src/review/reviewRunSetup.js", async (importOriginal) => {
 
 import { runReviewHarness } from "../src/review/reviewRunHarness.js";
 
-const cfg = makeTestConfig({
+const harnessConfigOverrides = {
   piModel: "test",
   maxToolRounds: 2,
   maxReviewPublishAttempts: 1,
   reviewAnchorMenuMaxFiles: 10,
   reviewAnchorMenuMaxRangesPerFile: 5,
-});
+};
 
 describe("runReviewHarness", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    cachedDiffIndex = nonEmptyDiffIndex();
+    submitState = {
+      published: false,
+      publishSuperseded: false,
+      lastValidationError: null,
+      publishCallCount: 0,
+    };
     sendMock.mockResolvedValue({ text: "done" });
   });
 
-  it("runs investigation, anchor menu, and pre-submit sends in order", async () => {
+  const runHarness = async (overrides: Parameters<typeof makeTestConfig>[0] = {}) => {
     await runReviewHarness({
-      cfg,
+      cfg: makeTestConfig({
+        ...harnessConfigOverrides,
+        ...overrides,
+      }),
       token: "tok",
       tokenExpiresAtTs: Date.now() + 60_000,
       owner: "o",
@@ -79,12 +101,52 @@ describe("runReviewHarness", () => {
       headSha: "head",
       reviewMode: "review",
     });
+  };
+
+  it("bundles the anchor menu into the first pre-submit send", async () => {
+    await runHarness();
 
     expect(createSessionMock).toHaveBeenCalledTimes(1);
-    expect(sendMock).toHaveBeenCalledTimes(4);
+    expect(sendMock).toHaveBeenCalledTimes(3);
     expect(sendMock.mock.calls[0]?.[0]).toBe("investigate");
     expect(sendMock.mock.calls[1]?.[0]).toContain("commentable RIGHT-side line ranges");
-    expect(sendMock.mock.calls[2]?.[0]).toContain("submitReview");
-    expect(sendMock.mock.calls[3]?.[0]).toContain("submitReview");
+    expect(sendMock.mock.calls[1]?.[0]).toContain("submitReview");
+    expect(sendMock.mock.calls[2]?.[0]).toBe(PRE_SUBMIT_REMINDER);
+  });
+
+  it("keeps the round-0 prompt unchanged when the anchor menu is disabled", async () => {
+    await runHarness({ reviewInjectAnchorMenu: false });
+
+    expect(sendMock).toHaveBeenCalledTimes(3);
+    expect(sendMock.mock.calls[0]?.[0]).toBe("investigate");
+    expect(sendMock.mock.calls[1]?.[0]).toBe(
+      [PRE_SUBMIT_ROUND0_PROMPT, PROSE_ONLY_NUDGE].join("\n\n"),
+    );
+    expect(sendMock.mock.calls[2]?.[0]).toBe(PRE_SUBMIT_REMINDER);
+  });
+
+  it("keeps the round-0 prompt unchanged when the diff index is empty", async () => {
+    cachedDiffIndex = emptyDiffIndex();
+
+    await runHarness();
+
+    expect(sendMock).toHaveBeenCalledTimes(3);
+    expect(sendMock.mock.calls[0]?.[0]).toBe("investigate");
+    expect(sendMock.mock.calls[1]?.[0]).toBe(
+      [PRE_SUBMIT_ROUND0_PROMPT, PROSE_ONLY_NUDGE].join("\n\n"),
+    );
+    expect(sendMock.mock.calls[2]?.[0]).toBe(PRE_SUBMIT_REMINDER);
+  });
+
+  it("skips anchor menu bundling when review stops after investigation", async () => {
+    sendMock.mockImplementationOnce(async () => {
+      submitState.publishSuperseded = true;
+      return { text: "done" };
+    });
+
+    await runHarness();
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(sendMock.mock.calls[0]?.[0]).toBe("investigate");
   });
 });


### PR DESCRIPTION
Bundles the rendered anchor menu into the first pre-submit repair prompt so reviews skip the dedicated menu send.

Covers menu-enabled, disabled, empty-index, and early-stop harness paths.

___

## PR Agent Description

### PR Type

Enhancement, Tests

### Description

- Fold the rendered anchor menu into the first pre-submit repair prompt.
- Keep the fallback reminder path unchanged when bundling is skipped.
- Add tests for enabled, disabled, empty-diff, and early-stop cases.

### File Walkthrough

<details>
<summary>Enhancement (1 file)</summary>

<details>
<summary>Delay anchor menu until pre-submit</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/106/files#diff-d1e22f3b435da729e23bdffef3d48ee5795fd03d918b8099ac5f00892944b386"><code>src/review/reviewRunHarness.ts</code></a>

- Stores the rendered anchor menu without sending it separately
- Prepends it to the round-0 submit-only repair prompt

</details>

</details>

<details>
<summary>Tests (1 file)</summary>

<details>
<summary>Cover bundled prompt behavior</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/106/files#diff-515c1ff7c44cd18f83ec9f0e4d10da1e99f4c305435c7c1a25fcf2b80515c270"><code>test/reviewRunHarness.test.ts</code></a>

- Verifies bundled and fallback pre-submit prompts
- Covers disabled, empty-diff, and early-exit paths

</details>

</details>