### PR TITLE
Log non-array label list failures

### DIFF
--- a/src/review/publish/publishReview.ts
+++ b/src/review/publish/publishReview.ts
@@ -208,7 +208,9 @@ export async function publishReview(
   if (shouldSyncLabels) {
     try {
       if (currentLabels instanceof Error) throw currentLabels;
-      if (!Array.isArray(currentLabels)) return;
+      if (!Array.isArray(currentLabels)) {
+        throw new Error(`listPullRequestLabels returned non-array: ${String(currentLabels)}`);
+      }
       if (
         labelsAlreadySynced(currentLabels, payload, {
           effort: cfg.enableReviewLabelsEffort,

--- a/test/publishReview.test.ts
+++ b/test/publishReview.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import * as evlog from "../src/evlog.js";
 import { publishReviewForTest } from "./helpers/reviewPublishTestHelpers.js";
 import * as reviewSchema from "../src/review/reviewSchema.js";
 import type { ReviewPayload } from "../src/review/reviewSchema.js";
@@ -543,6 +544,46 @@ describe("publishReview", () => {
 
     expect(upsertReviewSummaryComment).toHaveBeenCalled();
   });
+
+  it.each([
+    {
+      name: "string",
+      rejection: "labels exploded",
+      message: "listPullRequestLabels returned non-array: labels exploded",
+    },
+    {
+      name: "Error",
+      rejection: new Error("labels forbidden"),
+      message: "labels forbidden",
+    },
+  ])(
+    "does not fail publish when label listing rejects with $name",
+    async ({ rejection, message }) => {
+      const warnSpy = vi.spyOn(evlog, "logWarn").mockImplementation(() => {});
+      vi.mocked(listPullRequestLabels).mockRejectedValueOnce(rejection);
+
+      await expect(
+        publishReviewForTest({
+          ...baseParams,
+          publishState: testPublishState(),
+          cfg: {
+            enableReviewLabelsEffort: true,
+            enableReviewLabelsSecurity: false,
+          },
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(upsertReviewSummaryComment).toHaveBeenCalled();
+      expect(setPullRequestLabels).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith("review_labels_sync_failed", {
+        owner: "o",
+        repo: "r",
+        pr: 1,
+        message,
+      });
+      warnSpy.mockRestore();
+    },
+  );
 
   it("publishes summary when inline anchors are invalid", async () => {
     const publishState = testPublishState();


### PR DESCRIPTION
Closes #97

This routes non-array `currentLabels` values through the existing `review_labels_sync_failed` catch. Summary publishing still succeeds, and label sync failures remain non-fatal.

Added regression coverage for string and `Error` rejections from `listPullRequestLabels`.

Verification:
- `pnpm install`
- `pnpm typecheck`
- `pnpm test -- publishReview`
- `pnpm test && pnpm lint && pnpm fmt:check`

Note: `plans/README.md` is not present in this checkout, so there was no status row to update.

___

## PR Agent Description

### PR Type

Bug fix, Tests

### Description

- Non-array label list responses now throw into existing catch handler
- Label sync failures log `review_labels_sync_failed` instead of silent return
- Review summary publish still completes when label listing or sync fails
- Parametrized tests cover string and Error rejections from label listing

### Changes Diagram

```mermaid
flowchart LR
  A["Publish summary comment"] --> B["List PR labels"]
  B --> C{"Valid label array?"}
  C -->|"no"| D["Throw into catch"]
  D --> E["Log review_labels_sync_failed"]
  C -->|"yes"| F["Sync managed labels"]
```

### File Walkthrough

<details>
<summary>Bug fix (1 file)</summary>

<details>
<summary>Route non-array label responses through catch</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/108/files#diff-e02701f5218dd6ca7ddbc891f403f4c6310a2e047806dd9057bdc13fedf9b2ea"><code>src/review/publish/publishReview.ts</code></a>

- Replace silent early return with descriptive Error throw
- Existing catch block logs warning without failing publish

</details>

</details>

<details>
<summary>Tests (1 file)</summary>

<details>
<summary>Test label listing rejection handling</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/108/files#diff-d957d6504cf9376e66ab7a55a1431355cc8e4a75f1007f53866e58e27fb8ecda"><code>test/publishReview.test.ts</code></a>

- Add parametrized cases for string and Error rejections
- Assert summary still publishes and warn is logged

</details>

</details>