### PR TITLE
Pass token expiry to Octokit cache

### DIFF
--- a/src/agent/askRunSetup.ts
+++ b/src/agent/askRunSetup.ts
@@ -25,13 +25,14 @@ export function buildAskRunSetup(params: AskRunParams) {
         initialToken: token,
         tokenExpiresAtTs,
         refreshInstallationToken: params.refreshInstallationToken,
-        build: (activeToken) => {
+        build: (activeToken, activeExpiresAtTs) => {
           const gh = buildAskGithubTools(
             activeToken,
             { owner, repo, prNumber, headSha: params.headSha },
             {
               maxPrFilesListed: cfg.maxPrFilesListed,
               maxPrFilesPatchBytes: cfg.maxPrFilesPatchBytes,
+              tokenExpiresAtTs: activeExpiresAtTs,
             },
             pathGate,
           );

--- a/src/agent/askSafety.ts
+++ b/src/agent/askSafety.ts
@@ -193,7 +193,11 @@ export function buildScopedAskExecutors(
 export function buildAskGithubTools(
   token: string,
   scope: AskToolScope,
-  limits: { maxPrFilesListed: number; maxPrFilesPatchBytes: number },
+  limits: {
+    maxPrFilesListed: number;
+    maxPrFilesPatchBytes: number;
+    tokenExpiresAtTs?: number;
+  },
   gate: AskPathGate,
 ): {
   piTools: PiTool[];

--- a/src/agent/descriptionRunSetup.ts
+++ b/src/agent/descriptionRunSetup.ts
@@ -68,7 +68,7 @@ export function buildDescriptionRunSetup(params: {
     tokenExpiresAtTs,
     refreshInstallationToken: params.refreshInstallationToken,
     githubToolNames: new Set([TOKEN_REFRESH_TOOL]),
-    build: (activeToken) => {
+    build: (activeToken, activeExpiresAtTs) => {
       if (workspace) {
         return buildLocalWorkspaceTools(workspace, workspaceToolLimitsFromConfig(cfg), {
           pathGate,
@@ -77,6 +77,7 @@ export function buildDescriptionRunSetup(params: {
       return buildGithubTools(activeToken, {
         maxPrFilesListed: cfg.maxPrFilesListed,
         maxPrFilesPatchBytes: cfg.maxPrFilesPatchBytes,
+        tokenExpiresAtTs: activeExpiresAtTs,
       });
     },
   });
@@ -85,6 +86,8 @@ export function buildDescriptionRunSetup(params: {
     buildSubmitDescriptionTool({
       cfg,
       token: refreshableGh.getToken(),
+      tokenExpiresAtTs: refreshableGh.getTokenExpiresAtTs(),
+      getTokenExpiresAtTs: () => refreshableGh.getTokenExpiresAtTs(),
       owner,
       repo,
       prNumber,

--- a/src/agent/githubTools.ts
+++ b/src/agent/githubTools.ts
@@ -118,7 +118,11 @@ type BlameResponse = {
 
 export function buildGithubTools(
   token: string,
-  limits: { maxPrFilesListed: number; maxPrFilesPatchBytes: number } = {
+  limits: {
+    maxPrFilesListed: number;
+    maxPrFilesPatchBytes: number;
+    tokenExpiresAtTs?: number;
+  } = {
     maxPrFilesListed: DEFAULT_MAX_PR_FILES_LISTED,
     maxPrFilesPatchBytes: DEFAULT_MAX_PR_FILES_PATCH_BYTES,
   },
@@ -126,7 +130,7 @@ export function buildGithubTools(
   piTools: PiTool[];
   executors: Record<string, (args: Record<string, unknown>) => Promise<unknown>>;
 } {
-  const octokit = installationOctokit(token);
+  const octokit = installationOctokit(token, limits.tokenExpiresAtTs);
   const fileLimits = limits;
   type PullRequestData = Awaited<ReturnType<typeof octokit.rest.pulls.get>>["data"];
   const pullRequestByKey = new Map<string, Promise<PullRequestData>>();

--- a/src/agent/providers/cursor/refreshableGithubTools.ts
+++ b/src/agent/providers/cursor/refreshableGithubTools.ts
@@ -12,12 +12,13 @@ export type RefreshableToolExecutors = {
   readonly githubExecutorNames: ReadonlySet<string>;
   readonly refreshBeforeTool: (toolName: string) => Promise<void>;
   readonly getToken: () => string;
+  readonly getTokenExpiresAtTs: () => number;
 };
 
 export function createRefreshableToolExecutors(params: {
   initialToken: string;
   tokenExpiresAtTs: number;
-  build: (token: string) => ToolExecutorBundle;
+  build: (token: string, expiresAtTs: number) => ToolExecutorBundle;
   refreshInstallationToken?: () => Promise<{
     token: string;
     expiresAtTs: number;
@@ -26,7 +27,7 @@ export function createRefreshableToolExecutors(params: {
 }): RefreshableToolExecutors {
   let activeToken = params.initialToken;
   let activeExpiresAtTs = params.tokenExpiresAtTs;
-  let built = params.build(activeToken);
+  let built = params.build(activeToken, activeExpiresAtTs);
   const executorStore: Record<string, CursorExecutor> = { ...built.executors };
   let bundle: ToolExecutorBundle = {
     piTools: built.piTools,
@@ -41,7 +42,7 @@ export function createRefreshableToolExecutors(params: {
     const fresh = await params.refreshInstallationToken();
     activeToken = fresh.token;
     activeExpiresAtTs = fresh.expiresAtTs;
-    built = params.build(activeToken);
+    built = params.build(activeToken, activeExpiresAtTs);
     Object.assign(executorStore, built.executors);
     bundle = { piTools: built.piTools, executors: executorStore };
   };
@@ -53,5 +54,6 @@ export function createRefreshableToolExecutors(params: {
     githubExecutorNames,
     refreshBeforeTool,
     getToken: () => activeToken,
+    getTokenExpiresAtTs: () => activeExpiresAtTs,
   };
 }

--- a/src/agent/publishDescription.ts
+++ b/src/agent/publishDescription.ts
@@ -13,13 +13,14 @@ export type PublishDescriptionResult = {
 export async function publishDescriptionToPullRequest(params: {
   cfg: Config;
   token: string;
+  tokenExpiresAtTs?: number;
   owner: string;
   repo: string;
   prNumber: number;
   payload: DescriptionPayload;
 }): Promise<PublishDescriptionResult> {
-  const { cfg, token, owner, repo, prNumber, payload } = params;
-  const octokit = installationOctokit(token);
+  const { cfg, token, tokenExpiresAtTs, owner, repo, prNumber, payload } = params;
+  const octokit = installationOctokit(token, tokenExpiresAtTs);
   const { data: pr } = await octokit.rest.pulls.get({
     owner,
     repo,

--- a/src/agent/submitDescriptionTool.ts
+++ b/src/agent/submitDescriptionTool.ts
@@ -43,6 +43,8 @@ const SUBMIT_DESCRIPTION_PARAMETERS = z.toJSONSchema(descriptionPayloadSchema, {
 export function buildSubmitDescriptionTool(params: {
   cfg: Config;
   token: string;
+  tokenExpiresAtTs?: number;
+  getTokenExpiresAtTs?: () => number;
   owner: string;
   repo: string;
   prNumber: number;
@@ -99,6 +101,7 @@ export function buildSubmitDescriptionTool(params: {
     const result = await publishDescriptionToPullRequest({
       cfg: params.cfg,
       token: params.token,
+      tokenExpiresAtTs: params.getTokenExpiresAtTs?.() ?? params.tokenExpiresAtTs,
       owner: params.owner,
       repo: params.repo,
       prNumber: params.prNumber,

--- a/src/agentWork/durableJob.ts
+++ b/src/agentWork/durableJob.ts
@@ -78,7 +78,11 @@ export type DurableJobSpec = {
   readonly job: JobWithMetadata<{ workItemId: string }>;
   readonly type: "review" | "ask" | "description";
   readonly acceptItem?: (item: AgentWorkItemCore) => boolean;
-  readonly resolveHeadSha: (token: string, item: AgentWorkItem) => Promise<DurableHeadResolution>;
+  readonly resolveHeadSha: (
+    token: string,
+    expiresAtTs: number,
+    item: AgentWorkItem,
+  ) => Promise<DurableHeadResolution>;
   readonly execute: (
     item: AgentWorkItem,
     env: DurableExecutionContext,
@@ -136,10 +140,11 @@ export function makeInstallationTokenRefresher(
 
 export async function resolveWorkItemHead(
   token: string,
+  expiresAtTs: number,
   item: AgentWorkItemCore,
 ): Promise<DurableHeadResolution> {
   return item.headSha === DEFERRED_HEAD_SHA
-    ? getPullRequestHead(token, item.owner, item.repo, item.prNumber)
+    ? getPullRequestHead(token, item.owner, item.repo, item.prNumber, expiresAtTs)
     : { headSha: item.headSha };
 }
 
@@ -242,7 +247,11 @@ export async function runDurableWorkItem(spec: DurableJobSpec): Promise<void> {
       return undefined;
     }
 
-    const resolvedHead = await spec.resolveHeadSha(installationToken.token, item);
+    const resolvedHead = await spec.resolveHeadSha(
+      installationToken.token,
+      installationToken.expiresAtTs,
+      item,
+    );
     const headSha = resolvedHead.headSha;
     if (await updateRunningWorkHeadSha(spec.pool, item.id, headSha)) {
       return {

--- a/src/agentWork/executors/ackExecutor.ts
+++ b/src/agentWork/executors/ackExecutor.ts
@@ -32,7 +32,13 @@ export async function executeAckJob(cfg: Config, pool: Pool, data: AckJobData): 
   await Promise.all(
     data.targets.map(async (target) => {
       try {
-        await safeReaction(installation.token, data.owner, data.repo, target);
+        await safeReaction(
+          installation.token,
+          data.owner,
+          data.repo,
+          target,
+          installation.expiresAtTs,
+        );
       } catch (e) {
         logDebug("ack_reaction_failed", {
           owner: data.owner,
@@ -47,7 +53,13 @@ export async function executeAckJob(cfg: Config, pool: Pool, data: AckJobData): 
   if (data.progress) {
     const headSha =
       data.progress.headSha === DEFERRED_HEAD_SHA
-        ? await getPullRequestHeadSha(installation.token, data.owner, data.repo, data.prNumber)
+        ? await getPullRequestHeadSha(
+            installation.token,
+            data.owner,
+            data.repo,
+            data.prNumber,
+            installation.expiresAtTs,
+          )
         : data.progress.headSha;
     const body = renderReviewProgressComment({
       mode: data.progress.lens,
@@ -61,6 +73,8 @@ export async function executeAckJob(cfg: Config, pool: Pool, data: AckJobData): 
       data.prNumber,
       body,
       reviewSummarySentinelForMode(data.progress.lens),
+      undefined,
+      installation.expiresAtTs,
     );
     if (data.workItemId) {
       await recordPublishStep(pool, {
@@ -75,6 +89,6 @@ export async function executeAckJob(cfg: Config, pool: Pool, data: AckJobData): 
   }
 
   if (data.reply) {
-    await postAckReply(installation.token, data, data.reply.body);
+    await postAckReply(installation.token, data, data.reply.body, installation.expiresAtTs);
   }
 }

--- a/src/agentWork/executors/askExecutor.ts
+++ b/src/agentWork/executors/askExecutor.ts
@@ -12,6 +12,7 @@ import type { AgentWorkItem, AskJobData, AskWorkPayload } from "../types.js";
 
 async function publishAskAnswer(
   token: string,
+  tokenExpiresAtTs: number,
   item: AgentWorkItem,
   answer: string,
   alreadySanitized = false,
@@ -20,7 +21,7 @@ async function publishAskAnswer(
   const replyTarget = (item.payload as AskWorkPayload).replyTarget;
   if (replyTarget.kind === "inlineReviewThread") {
     try {
-      await postSlashReply(token, item.owner, item.repo, replyTarget, body);
+      await postSlashReply(token, item.owner, item.repo, replyTarget, body, tokenExpiresAtTs);
       return;
     } catch (e) {
       logWarn("ask_inline_reply_failed", {
@@ -30,7 +31,7 @@ async function publishAskAnswer(
         inReplyToCommentId: replyTarget.inReplyToCommentId,
         message: e instanceof Error ? e.message : String(e),
       });
-      const octokit = installationOctokit(token);
+      const octokit = installationOctokit(token, tokenExpiresAtTs);
       await octokit.rest.issues.createComment({
         owner: item.owner,
         repo: item.repo,
@@ -42,7 +43,7 @@ async function publishAskAnswer(
       return;
     }
   }
-  await postSlashReply(token, item.owner, item.repo, replyTarget, body);
+  await postSlashReply(token, item.owner, item.repo, replyTarget, body, tokenExpiresAtTs);
 }
 export async function executeAskJob(
   cfg: Config,
@@ -56,8 +57,8 @@ export async function executeAskJob(
     boss,
     job,
     type: "ask",
-    resolveHeadSha: (token, item) =>
-      getPullRequestHead(token, item.owner, item.repo, item.prNumber),
+    resolveHeadSha: (token, expiresAtTs, item) =>
+      getPullRequestHead(token, item.owner, item.repo, item.prNumber, expiresAtTs),
     execute: async (item, env) => {
       const tokenState = { installation: env.installation };
       const headSha = env.headSha;
@@ -70,6 +71,7 @@ export async function executeAskJob(
           prNumber: item.prNumber,
           headSha,
           installationToken: tokenState.installation.token,
+          installationExpiresAtTs: tokenState.installation.expiresAtTs,
           pullRequest: env.pullRequest,
           repositorySizeKb: payload.repositorySizeKb,
         },
@@ -94,7 +96,13 @@ export async function executeAskJob(
               tokenState,
             ),
           });
-          await publishAskAnswer(tokenState.installation.token, item, result.answer, true);
+          await publishAskAnswer(
+            tokenState.installation.token,
+            tokenState.installation.expiresAtTs,
+            item,
+            result.answer,
+            true,
+          );
           return {};
         },
       );
@@ -104,6 +112,7 @@ export async function executeAskJob(
       const payload = item.payload as AskWorkPayload;
       await publishAskAnswer(
         installation.token,
+        installation.expiresAtTs,
         item,
         formatAskFailureReply({
           question: payload.question,

--- a/src/agentWork/executors/descriptionExecutor.ts
+++ b/src/agentWork/executors/descriptionExecutor.ts
@@ -38,6 +38,7 @@ export async function executeDescriptionJob(
           prNumber: item.prNumber,
           headSha,
           installationToken: tokenState.installation.token,
+          installationExpiresAtTs: tokenState.installation.expiresAtTs,
           pullRequest: env.pullRequest,
           repositorySizeKb: payload.repositorySizeKb,
         },
@@ -85,7 +86,7 @@ export async function executeDescriptionJob(
       if (!installation) return;
       const payload = item.payload as DescriptionWorkPayload;
       if (payload.source !== "slash") return;
-      const octokit = installationOctokit(installation.token);
+      const octokit = installationOctokit(installation.token, installation.expiresAtTs);
       await octokit.rest.issues.createComment({
         owner: item.owner,
         repo: item.repo,

--- a/src/agentWork/executors/reviewExecutor.ts
+++ b/src/agentWork/executors/reviewExecutor.ts
@@ -72,7 +72,12 @@ export async function executeReviewJob(
         !payload.staleHeadRescheduled &&
         payload.staleHeadReplacementWorkItemId
       ) {
-        return buildStaleSlashReviewRescheduleResult(pool, item, env.installation.token);
+        return buildStaleSlashReviewRescheduleResult(
+          pool,
+          item,
+          env.installation.token,
+          env.installation.expiresAtTs,
+        );
       }
       const {
         publishState,
@@ -99,6 +104,8 @@ export async function executeReviewJob(
               maxPrFilesListed: cfg.maxPrFilesListed,
               maxPrFilesPatchBytes: cfg.maxPrFilesPatchBytes,
             },
+            undefined,
+            tokenState.installation.expiresAtTs,
           ),
         );
         assertPullRequestFilesHeadSha(prefetchedPrFiles, headSha);
@@ -107,6 +114,7 @@ export async function executeReviewJob(
           item,
           reviewLens,
           token: tokenState.installation.token,
+          tokenExpiresAtTs: tokenState.installation.expiresAtTs,
           preflight,
         });
         if (lightweightResult.handled) {
@@ -164,6 +172,7 @@ export async function executeReviewJob(
           prNumber: item.prNumber,
           headSha,
           installationToken: tokenState.installation.token,
+          installationExpiresAtTs: tokenState.installation.expiresAtTs,
           prFiles: prefetchedPrFiles,
           pullRequest: env.pullRequest,
           repositorySizeKb: payload.repositorySizeKb,
@@ -217,6 +226,7 @@ export async function executeReviewJob(
                 item.owner,
                 item.repo,
                 item.prNumber,
+                tokenState.installation.expiresAtTs,
               );
               if (latestHeadSha !== headSha) {
                 staleHeadAtPublish = true;
@@ -232,7 +242,12 @@ export async function executeReviewJob(
             ),
           });
           if (staleHeadAtPublish && payload.source === "slash" && !payload.staleHeadRescheduled) {
-            return buildStaleSlashReviewRescheduleResult(pool, item, tokenState.installation.token);
+            return buildStaleSlashReviewRescheduleResult(
+              pool,
+              item,
+              tokenState.installation.token,
+              tokenState.installation.expiresAtTs,
+            );
           }
           if (!result.published) {
             if (result.publishSuperseded) {
@@ -269,6 +284,8 @@ export async function executeReviewJob(
           retryCommand: reviewRetrySlashCommandForMode(reviewLens),
         }),
         reviewSummarySentinelForMode(reviewLens),
+        undefined,
+        installation.expiresAtTs,
       );
     },
   });

--- a/src/agentWork/githubPrSurface.ts
+++ b/src/agentWork/githubPrSurface.ts
@@ -15,8 +15,9 @@ export async function getPullRequestHead(
   owner: string,
   repo: string,
   prNumber: number,
+  expiresAtTs?: number,
 ): Promise<PullRequestHeadResolution> {
-  const octokit = installationOctokit(token);
+  const octokit = installationOctokit(token, expiresAtTs);
   const { data } = await octokit.rest.pulls.get({
     owner,
     repo,
@@ -30,8 +31,9 @@ export async function getPullRequestHeadSha(
   owner: string,
   repo: string,
   prNumber: number,
+  expiresAtTs?: number,
 ): Promise<string> {
-  return (await getPullRequestHead(token, owner, repo, prNumber)).headSha;
+  return (await getPullRequestHead(token, owner, repo, prNumber, expiresAtTs)).headSha;
 }
 
 export async function safeReaction(
@@ -39,8 +41,9 @@ export async function safeReaction(
   owner: string,
   repo: string,
   target: AckTarget,
+  expiresAtTs?: number,
 ): Promise<void> {
-  const octokit = installationOctokit(token);
+  const octokit = installationOctokit(token, expiresAtTs);
   try {
     if (target.kind === "pr") {
       await octokit.rest.reactions.createForIssue({
@@ -77,8 +80,9 @@ export async function postSlashReply(
   repo: string,
   target: ReplyTarget,
   body: string,
+  expiresAtTs?: number,
 ): Promise<void> {
-  const octokit = installationOctokit(token);
+  const octokit = installationOctokit(token, expiresAtTs);
   if (target.kind === "inlineReviewThread") {
     await octokit.rest.pulls.createReplyForReviewComment({
       owner,
@@ -97,10 +101,15 @@ export async function postSlashReply(
   });
 }
 
-export async function postAckReply(token: string, data: AckJobData, body: string): Promise<void> {
+export async function postAckReply(
+  token: string,
+  data: AckJobData,
+  body: string,
+  expiresAtTs?: number,
+): Promise<void> {
   const target = data.reply?.target;
   if (!target) return;
-  await postSlashReply(token, data.owner, data.repo, target, body);
+  await postSlashReply(token, data.owner, data.repo, target, body, expiresAtTs);
 }
 
 export { getAppBotIdentity };

--- a/src/agentWork/reviewLightweightCompletion.ts
+++ b/src/agentWork/reviewLightweightCompletion.ts
@@ -27,6 +27,7 @@ export async function tryLightweightAutoReviewCompletion(
     item: AgentWorkItem;
     reviewLens: ReviewMode;
     token: string;
+    tokenExpiresAtTs?: number;
     preflight: ReviewPreflightMetadata;
   },
 ): Promise<LightweightAutoReviewResult> {
@@ -43,14 +44,28 @@ export async function tryLightweightAutoReviewCompletion(
   }
 
   const body = renderLightweightReviewCompletion(params.reviewLens);
-  const summary = await upsertReviewSummaryComment(
-    params.token,
-    params.item.owner,
-    params.item.repo,
-    params.item.prNumber,
-    body,
-    reviewSummarySentinelForMode(params.reviewLens),
-  );
+  let summary;
+  if (params.tokenExpiresAtTs == null) {
+    summary = await upsertReviewSummaryComment(
+      params.token,
+      params.item.owner,
+      params.item.repo,
+      params.item.prNumber,
+      body,
+      reviewSummarySentinelForMode(params.reviewLens),
+    );
+  } else {
+    summary = await upsertReviewSummaryComment(
+      params.token,
+      params.item.owner,
+      params.item.repo,
+      params.item.prNumber,
+      body,
+      reviewSummarySentinelForMode(params.reviewLens),
+      undefined,
+      params.tokenExpiresAtTs,
+    );
+  }
   await recordPublishStep(pool, {
     workItemId: params.item.id,
     resourceKey: params.item.resourceKey,

--- a/src/agentWork/reviewReschedule.ts
+++ b/src/agentWork/reviewReschedule.ts
@@ -30,8 +30,15 @@ export async function buildStaleSlashReviewRescheduleResult(
   pool: Pool,
   item: AgentWorkItem,
   token: string,
+  expiresAtTs?: number,
 ): Promise<StaleSlashReviewRescheduleResult> {
-  const latestHeadSha = await getPullRequestHeadSha(token, item.owner, item.repo, item.prNumber);
+  const latestHeadSha = await getPullRequestHeadSha(
+    token,
+    item.owner,
+    item.repo,
+    item.prNumber,
+    expiresAtTs,
+  );
   const replacement = await createSlashReviewRescheduleWorkItem(pool, item, latestHeadSha);
   return {
     rescheduled: true,

--- a/src/github/listPullRequestFiles.ts
+++ b/src/github/listPullRequestFiles.ts
@@ -223,7 +223,8 @@ export async function fetchPullRequestFiles(
   pullNumber: number,
   limits: ListPullRequestFilesLimits,
   pullRequest?: PullRequestForFileList,
+  expiresAtTs?: number,
 ): Promise<ListPullRequestFilesResult> {
-  const octokit = installationOctokit(token);
+  const octokit = installationOctokit(token, expiresAtTs);
   return listPullRequestFilesPaginated(octokit, owner, repo, pullNumber, limits, pullRequest);
 }

--- a/src/github/reviewPublish.ts
+++ b/src/github/reviewPublish.ts
@@ -50,8 +50,9 @@ export async function listPullRequestReviewCommentsForReview(
   repo: string,
   pullNumber: number,
   reviewId: number,
+  expiresAtTs?: number,
 ): Promise<PublishedReviewComment[]> {
-  const octokit = installationOctokit(token);
+  const octokit = installationOctokit(token, expiresAtTs);
   const comments = await paginateOctokitPages({
     perPage: COMMENTS_PAGE_SIZE,
     maxPages: COMMENT_PAGINATION_MAX_PAGES,
@@ -92,8 +93,9 @@ async function getIssueCommentIfSentinel(
   repo: string,
   commentId: number,
   sentinel: string,
+  expiresAtTs?: number,
 ): Promise<IssueCommentRef | null> {
-  const octokit = installationOctokit(token);
+  const octokit = installationOctokit(token, expiresAtTs);
   try {
     const { data } = await octokit.rest.issues.getComment({
       owner,
@@ -115,8 +117,9 @@ export async function findIssueCommentBySentinel(
   repo: string,
   issueNumber: number,
   sentinel: string,
+  expiresAtTs?: number,
 ): Promise<IssueCommentRef | null> {
-  const octokit = installationOctokit(token);
+  const octokit = installationOctokit(token, expiresAtTs);
   let lastMatch: IssueCommentRef | null = null;
 
   const pages = await paginateOctokitPages({
@@ -150,12 +153,27 @@ export async function resolveVerifiedSummaryCommentRef(
   prNumber: number,
   sentinel: string,
   hintCommentId?: number | null,
+  expiresAtTs?: number,
 ): Promise<ResolvedSummaryCommentRef | null> {
   if (hintCommentId != null) {
-    const verified = await getIssueCommentIfSentinel(token, owner, repo, hintCommentId, sentinel);
+    const verified = await getIssueCommentIfSentinel(
+      token,
+      owner,
+      repo,
+      hintCommentId,
+      sentinel,
+      expiresAtTs,
+    );
     if (verified) return { ...verified, source: "hint" };
   }
-  const found = await findIssueCommentBySentinel(token, owner, repo, prNumber, sentinel);
+  const found = await findIssueCommentBySentinel(
+    token,
+    owner,
+    repo,
+    prNumber,
+    sentinel,
+    expiresAtTs,
+  );
   return found ? { ...found, source: "scan" } : null;
 }
 
@@ -179,8 +197,9 @@ async function createIssueComment(
   repo: string,
   issueNumber: number,
   body: string,
+  expiresAtTs?: number,
 ): Promise<{ id: number; url: string }> {
-  const octokit = installationOctokit(token);
+  const octokit = installationOctokit(token, expiresAtTs);
   const { data } = await octokit.rest.issues.createComment({
     owner,
     repo,
@@ -196,8 +215,9 @@ async function updateIssueComment(
   repo: string,
   commentId: number,
   body: string,
+  expiresAtTs?: number,
 ): Promise<void> {
-  const octokit = installationOctokit(token);
+  const octokit = installationOctokit(token, expiresAtTs);
   await octokit.rest.issues.updateComment({
     owner,
     repo,
@@ -214,14 +234,16 @@ export async function upsertReviewSummaryComment(
   body: string,
   sentinel: string = REVIEW_SUMMARY_SENTINEL,
   knownExisting?: IssueCommentRef | null,
+  expiresAtTs?: number,
 ): Promise<{ id: number; updated: boolean }> {
   const existing =
-    knownExisting ?? (await findIssueCommentBySentinel(token, owner, repo, prNumber, sentinel));
+    knownExisting ??
+    (await findIssueCommentBySentinel(token, owner, repo, prNumber, sentinel, expiresAtTs));
   if (existing) {
-    await updateIssueComment(token, owner, repo, existing.id, body);
+    await updateIssueComment(token, owner, repo, existing.id, body, expiresAtTs);
     return { id: existing.id, updated: true };
   }
-  const created = await createIssueComment(token, owner, repo, prNumber, body);
+  const created = await createIssueComment(token, owner, repo, prNumber, body, expiresAtTs);
   return { id: created.id, updated: false };
 }
 
@@ -230,8 +252,9 @@ export async function listPullRequestLabels(
   owner: string,
   repo: string,
   pullNumber: number,
+  expiresAtTs?: number,
 ): Promise<string[]> {
-  const octokit = installationOctokit(token);
+  const octokit = installationOctokit(token, expiresAtTs);
   const { data } = await octokit.rest.issues.listLabelsOnIssue({
     owner,
     repo,
@@ -246,8 +269,9 @@ export async function setPullRequestLabels(
   repo: string,
   pullNumber: number,
   labels: string[],
+  expiresAtTs?: number,
 ): Promise<void> {
-  const octokit = installationOctokit(token);
+  const octokit = installationOctokit(token, expiresAtTs);
   await octokit.rest.issues.setLabels({
     owner,
     repo,

--- a/src/prWorkspace/prRepositoryView.ts
+++ b/src/prWorkspace/prRepositoryView.ts
@@ -30,6 +30,7 @@ export type PreparePrRepositoryViewParams = {
   readonly prNumber: number;
   readonly headSha: string;
   readonly installationToken: string;
+  readonly installationExpiresAtTs?: number;
   readonly prFiles?: ListPullRequestFilesResult;
   readonly pullRequest?: PullRequestForFileList;
   readonly repositorySizeKb?: number;
@@ -85,6 +86,7 @@ async function prepareUncached(
         maxPrFilesPatchBytes: params.cfg.maxPrFilesPatchBytes,
       },
       params.pullRequest,
+      params.installationExpiresAtTs,
     ));
   assertPullRequestFilesHeadSha(prFiles, params.headSha);
   const workspace = await prepareLocalPrWorkspace({

--- a/src/review/publish/publishReview.ts
+++ b/src/review/publish/publishReview.ts
@@ -40,6 +40,7 @@ export async function publishReview(
     mode?: ReviewMode;
     cfg: Pick<Config, "enableReviewLabelsEffort" | "enableReviewLabelsSecurity">;
     payload: ReviewPayload;
+    tokenExpiresAtTs?: number;
     /** Set when payload was already normalized, deduped, and validated by submitReview. */
     dedupedFindingCount?: number;
     publishState: SubmitReviewState;
@@ -57,6 +58,7 @@ export async function publishReview(
   },
 ): Promise<void> {
   const { token, owner, repo, prNumber, headSha, cfg, payload, publishState } = params;
+  const tokenExpiresAtTs = params.tokenExpiresAtTs;
   const mode = params.mode ?? "review";
   const summarySentinel = reviewSummarySentinelForMode(mode);
   const storedInlineFingerprints = params.storedInlineFingerprints ?? [];
@@ -98,14 +100,27 @@ export async function publishReview(
   let summaryCommentUrl: string | undefined;
   let knownSummaryCommentRef: { id: number; url: string } | null = null;
   if (params.shouldLinkToSummary) {
-    const resolvedSummary = await resolveVerifiedSummaryCommentRef(
-      token,
-      owner,
-      repo,
-      prNumber,
-      summarySentinel,
-      params.summaryCommentIdHint,
-    );
+    let resolvedSummary;
+    if (tokenExpiresAtTs == null) {
+      resolvedSummary = await resolveVerifiedSummaryCommentRef(
+        token,
+        owner,
+        repo,
+        prNumber,
+        summarySentinel,
+        params.summaryCommentIdHint,
+      );
+    } else {
+      resolvedSummary = await resolveVerifiedSummaryCommentRef(
+        token,
+        owner,
+        repo,
+        prNumber,
+        summarySentinel,
+        params.summaryCommentIdHint,
+        tokenExpiresAtTs,
+      );
+    }
     summaryCommentUrl = resolvedSummary?.url;
     knownSummaryCommentRef = resolvedSummary
       ? { id: resolvedSummary.id, url: resolvedSummary.url }
@@ -147,13 +162,25 @@ export async function publishReview(
 
   if (inlineReviewId != null) {
     try {
-      const reviewComments = await listPullRequestReviewCommentsForReview(
-        token,
-        owner,
-        repo,
-        prNumber,
-        inlineReviewId,
-      );
+      let reviewComments;
+      if (tokenExpiresAtTs == null) {
+        reviewComments = await listPullRequestReviewCommentsForReview(
+          token,
+          owner,
+          repo,
+          prNumber,
+          inlineReviewId,
+        );
+      } else {
+        reviewComments = await listPullRequestReviewCommentsForReview(
+          token,
+          owner,
+          repo,
+          prNumber,
+          inlineReviewId,
+          tokenExpiresAtTs,
+        );
+      }
       summaryPlacements = enrichPlacementsWithInlineCommentUrls(summaryPlacements, reviewComments);
     } catch (e) {
       logWarn("review_inline_comment_urls_failed", {
@@ -176,21 +203,59 @@ export async function publishReview(
   });
 
   const shouldSyncLabels = cfg.enableReviewLabelsEffort || cfg.enableReviewLabelsSecurity;
-  const labelsPromise = shouldSyncLabels
-    ? listPullRequestLabels(token, owner, repo, prNumber).catch((e: unknown) => e)
-    : Promise.resolve<string[] | null>(null);
-  const summaryUpsert =
-    knownSummaryCommentRef != null
-      ? upsertReviewSummaryComment(
-          token,
-          owner,
-          repo,
-          prNumber,
-          summaryBody,
-          summarySentinel,
-          knownSummaryCommentRef,
-        )
-      : upsertReviewSummaryComment(token, owner, repo, prNumber, summaryBody, summarySentinel);
+  let labelsPromise: Promise<unknown> = Promise.resolve(null);
+  if (shouldSyncLabels) {
+    const pending =
+      tokenExpiresAtTs == null
+        ? listPullRequestLabels(token, owner, repo, prNumber)
+        : listPullRequestLabels(token, owner, repo, prNumber, tokenExpiresAtTs);
+    labelsPromise = pending.catch((e: unknown) => e);
+  }
+
+  let summaryUpsert: Promise<{ id: number; updated: boolean }>;
+  if (knownSummaryCommentRef != null) {
+    summaryUpsert =
+      tokenExpiresAtTs == null
+        ? upsertReviewSummaryComment(
+            token,
+            owner,
+            repo,
+            prNumber,
+            summaryBody,
+            summarySentinel,
+            knownSummaryCommentRef,
+          )
+        : upsertReviewSummaryComment(
+            token,
+            owner,
+            repo,
+            prNumber,
+            summaryBody,
+            summarySentinel,
+            knownSummaryCommentRef,
+            tokenExpiresAtTs,
+          );
+  } else if (tokenExpiresAtTs == null) {
+    summaryUpsert = upsertReviewSummaryComment(
+      token,
+      owner,
+      repo,
+      prNumber,
+      summaryBody,
+      summarySentinel,
+    );
+  } else {
+    summaryUpsert = upsertReviewSummaryComment(
+      token,
+      owner,
+      repo,
+      prNumber,
+      summaryBody,
+      summarySentinel,
+      undefined,
+      tokenExpiresAtTs,
+    );
+  }
   const [summary, currentLabels] = await Promise.all([summaryUpsert, labelsPromise]);
   await params.recordPublishStep?.("summary_comment", {
     githubId: summary.id,
@@ -227,7 +292,11 @@ export async function publishReview(
         security: cfg.enableReviewLabelsSecurity,
       });
       const next = syncReviewLabels(currentLabels, managed);
-      await setPullRequestLabels(token, owner, repo, prNumber, next);
+      if (tokenExpiresAtTs == null) {
+        await setPullRequestLabels(token, owner, repo, prNumber, next);
+      } else {
+        await setPullRequestLabels(token, owner, repo, prNumber, next, tokenExpiresAtTs);
+      }
       await params.recordPublishStep?.("labels", { meta: { labels: next } });
       logDebug("review_labels_synced", {
         owner,

--- a/src/review/publish/submitReviewTool.ts
+++ b/src/review/publish/submitReviewTool.ts
@@ -54,7 +54,9 @@ export function createSubmitReviewState(
 export function buildSubmitReviewTool(params: {
   cfg: Config;
   token: string;
+  tokenExpiresAtTs?: number;
   getToken?: () => string;
+  getTokenExpiresAtTs?: () => number;
   ctx: ReviewPublishContext;
   mode?: ReviewMode;
   state: SubmitReviewState;
@@ -212,6 +214,7 @@ export function buildSubmitReviewTool(params: {
     try {
       await publishReview({
         token: params.getToken?.() ?? params.token,
+        tokenExpiresAtTs: params.getTokenExpiresAtTs?.() ?? params.tokenExpiresAtTs,
         mode,
         cfg: params.cfg,
         ...params.ctx,

--- a/src/review/reviewRunHarness.ts
+++ b/src/review/reviewRunHarness.ts
@@ -211,6 +211,8 @@ export async function runReviewHarness(params: {
         prNumber,
         renderReviewFailureNotice({ mode: reviewMode, retryCommand }),
         reviewSummarySentinelForMode(reviewMode),
+        undefined,
+        setup.getTokenExpiresAtTs(),
       );
     } catch (e) {
       logWarn("review_publish_fallback_comment_failed", {

--- a/src/review/reviewRunSetup.ts
+++ b/src/review/reviewRunSetup.ts
@@ -46,6 +46,7 @@ export type ReviewRunSetup = {
   readonly cachedDiffIndex: CachedPrDiffIndex;
   readonly submitState: SubmitReviewState;
   readonly getToken: () => string;
+  readonly getTokenExpiresAtTs: () => number;
   readonly refreshBeforeTool: (toolName: string) => Promise<void>;
 };
 
@@ -114,7 +115,7 @@ export function buildReviewRunSetup(params: {
     tokenExpiresAtTs,
     refreshInstallationToken: params.refreshInstallationToken,
     githubToolNames: new Set([TOKEN_REFRESH_TOOL]),
-    build: (activeToken) => {
+    build: (activeToken, activeExpiresAtTs) => {
       if (params.workspace) {
         return buildLocalWorkspaceTools(params.workspace, workspaceToolLimitsFromConfig(cfg), {
           pathGate,
@@ -123,6 +124,7 @@ export function buildReviewRunSetup(params: {
       const gh = buildGithubTools(activeToken, {
         maxPrFilesListed: cfg.maxPrFilesListed,
         maxPrFilesPatchBytes: cfg.maxPrFilesPatchBytes,
+        tokenExpiresAtTs: activeExpiresAtTs,
       });
       const executors = { ...gh.executors };
       wrapListPullRequestFilesDiffIngestion(executors, cachedDiffIndex);
@@ -136,6 +138,8 @@ export function buildReviewRunSetup(params: {
       cfg,
       token: refreshableGh.getToken(),
       getToken: () => refreshableGh.getToken(),
+      tokenExpiresAtTs: refreshableGh.getTokenExpiresAtTs(),
+      getTokenExpiresAtTs: () => refreshableGh.getTokenExpiresAtTs(),
       ctx: { owner, repo, prNumber, headSha },
       mode: reviewMode,
       state: submitState,
@@ -186,6 +190,7 @@ export function buildReviewRunSetup(params: {
     cachedDiffIndex,
     submitState,
     getToken: refreshableGh.getToken,
+    getTokenExpiresAtTs: refreshableGh.getTokenExpiresAtTs,
     refreshBeforeTool,
   };
 }

--- a/test/appAuth.test.ts
+++ b/test/appAuth.test.ts
@@ -3,6 +3,7 @@ import {
   clearInstallationOctokitCacheForTest,
   installationOctokit,
 } from "../src/github/appAuth.js";
+import { INSTALLATION_TOKEN_FALLBACK_TTL_MS } from "../src/github/githubRequestError.js";
 
 describe("installationOctokit", () => {
   beforeEach(() => {
@@ -22,7 +23,7 @@ describe("installationOctokit", () => {
     expect(other).not.toBe(first);
   });
 
-  it("evicts expired token clients", async () => {
+  it("evicts clients at the provided token expiry", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
 
@@ -33,5 +34,31 @@ describe("installationOctokit", () => {
 
     expect(installationOctokit("token-a", Date.now() + 1_000)).not.toBe(first);
     expect(installationOctokit("token-b")).toBe(other);
+  });
+
+  it("uses the fallback ttl when expiry is omitted", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+
+    const first = installationOctokit("token-a");
+
+    await vi.advanceTimersByTimeAsync(INSTALLATION_TOKEN_FALLBACK_TTL_MS - 1);
+    expect(installationOctokit("token-a")).toBe(first);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(installationOctokit("token-a")).not.toBe(first);
+  });
+
+  it("tightens fallback entries when a later call provides expiry", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+
+    const first = installationOctokit("token-a");
+    const second = installationOctokit("token-a", Date.now() + 1_000);
+
+    expect(second).toBe(first);
+
+    await vi.advanceTimersByTimeAsync(1_001);
+    expect(installationOctokit("token-a")).not.toBe(first);
   });
 });

--- a/test/refreshableGithubTools.test.ts
+++ b/test/refreshableGithubTools.test.ts
@@ -5,14 +5,15 @@ import { createRefreshableToolExecutors } from "../src/agent/providers/cursor/re
 
 describe("createRefreshableToolExecutors", () => {
   it("refreshes token and rebuilds executors when near expiry", async () => {
+    const freshExpiresAtTs = Date.now() + 3_600_000;
     const refresh = vi.fn(async () => ({
       token: "fresh-token",
-      expiresAtTs: Date.now() + 3_600_000,
+      expiresAtTs: freshExpiresAtTs,
     }));
-    const build = vi.fn((token: string) => ({
+    const build = vi.fn((token: string, expiresAtTs: number) => ({
       piTools: [],
       executors: {
-        getPullRequest: vi.fn(async () => ({ tokenUsed: token })),
+        getPullRequest: vi.fn(async () => ({ tokenUsed: token, expiresAtTs })),
       },
     }));
 
@@ -28,8 +29,9 @@ describe("createRefreshableToolExecutors", () => {
 
     expect(refresh).toHaveBeenCalledTimes(1);
     expect(refreshable.getToken()).toBe("fresh-token");
+    expect(refreshable.getTokenExpiresAtTs()).toBe(freshExpiresAtTs);
     expect(build).toHaveBeenCalledTimes(2);
-    expect(build).toHaveBeenLastCalledWith("fresh-token");
+    expect(build).toHaveBeenLastCalledWith("fresh-token", freshExpiresAtTs);
   });
 
   it("keeps static GitHub tool parameter schemas identical across token rebuilds", () => {


### PR DESCRIPTION
Passes installation token expiry through refreshable GitHub tools, durable worker GitHub helpers, PR file fetching, description publish, and direct review summary and label publish paths. Cached installation Octokit clients now evict on the real token lifetime when that expiry is in scope.

Leaves deeper fallback paths on the legacy TTL where threading expiry would cross the plan limit: appAuth bot identity lookup, inline review creation, and prior inline feedback fetch. The appAuth tests now pin provided-expiry eviction, fallback TTL behavior, and the self-heal case where a later real-expiry call tightens an existing fallback entry.

Verified with `pnpm install`, `pnpm typecheck`, `pnpm test -- appAuth`, and `pnpm test && pnpm lint && pnpm fmt:check`. Lint exits 0 with the existing config-test warnings. `plans/README.md` is absent in this repo, so there was no status row to update.

Closes #99

___

## PR Agent Description

### PR Type

Enhancement, Tests

### Description

- Pass token expiry into Octokit construction across agent, worker, and publish paths
- Refreshable GitHub tool bundles rebuild with updated expiry after token refresh
- Durable jobs, ack replies, and publish tools forward expiry to GitHub helpers
- Add tests for Octokit cache eviction and refreshable executor expiry plumbing

### Changes Diagram

```mermaid
flowchart LR
  A["Mint installation token"] --> B["Refreshable tool executors"]
  B --> C["buildGithubTools with expiry"]
  C --> D["installationOctokit cache"]
  B --> E["Submit and publish tools"]
  E --> F["Review and description publish"]
  F --> D
  G["Durable job head resolve"] --> H["getPullRequestHead"]
  H --> D
```

### File Walkthrough

<details>
<summary>Enhancement (13 files)</summary>

<details>
<summary>Pass expiry through refreshable executors</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/110/files#diff-6340e1cccdf8a03289c4ffa24a77ae1c37a44124e5ded8a79fc2c26bdb882fff"><code>src/agent/providers/cursor/refreshableGithubTools.ts</code></a>

- Build callback now receives token and expiresAtTs
- Exposes getTokenExpiresAtTs for downstream publish paths

</details>

<details>
<summary>Forward expiry into GitHub tool Octokit</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/110/files#diff-2d43c9a7c5ab557ff1be7be46a37bd96136e4e8c8ee6e374d3cdc430c873e06f"><code>src/agent/githubTools.ts</code></a>

- buildGithubTools accepts optional tokenExpiresAtTs
- installationOctokit uses expiry for client cache eviction

</details>

<details>
<summary>Wire expiry into ask GitHub tools</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/110/files#diff-b76365992f89cd82ceb351b9820d0795d8be75faf7b34ddca19a02f4446c684b"><code>src/agent/askRunSetup.ts</code></a>

- Passes activeExpiresAtTs when rebuilding ask GitHub tools

</details>

<details>
<summary>Wire expiry into description run setup</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/110/files#diff-127a8797f28a3a761e62394e53babf5ec8769dc5398543de832d89fc26251309"><code>src/agent/descriptionRunSetup.ts</code></a>

- Rebuilds GitHub tools with active token expiry
- Submit description tool reads fresh expiry at publish time

</details>

<details>
<summary>Wire expiry into review run setup</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/110/files#diff-0001ce81a1fda1e81d62facae1ade82c60d24927aaa54622563faded6fed8f08"><code>src/review/reviewRunSetup.ts</code></a>

- Rebuilds GitHub tools with active token expiry
- Submit review tool and setup expose getTokenExpiresAtTs

</details>

<details>
<summary>Include expiry in durable head resolution</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/110/files#diff-2a8065030fb6774303b2e7c6b7ff1e655439800bab56c38eb2bddbc58ed7300f"><code>src/agentWork/durableJob.ts</code></a>

- resolveHeadSha callback receives expiresAtTs
- Deferred head lookups pass expiry to getPullRequestHead

</details>

<details>
<summary>Add expiry to PR surface helpers</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/110/files#diff-f2abcb1b96cfa329761c6987116e9a4cabf3ad388a1cdb9b6e9c16ba44812a6c"><code>src/agentWork/githubPrSurface.ts</code></a>

- Head resolution, reactions, and slash replies accept expiresAtTs
- postAckReply forwards expiry through reply chain

</details>

<details>
<summary>Thread expiry through review publish APIs</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/110/files#diff-f9013fe886e2bb90805777d02a4c5fda045ba7e417e3eb1652239e0c9a4514c5"><code>src/github/reviewPublish.ts</code></a>

- Comment, label, and summary helpers accept expiresAtTs
- All publish paths use installationOctokit with expiry

</details>

<details>
<summary>Use expiry when publishing descriptions</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/110/files#diff-cec77731b87b02214001c2fab881350ece314ea074bc78ce0e57105c2c767cc5"><code>src/agent/publishDescription.ts</code></a>

- publishDescriptionToPullRequest accepts tokenExpiresAtTs
- Octokit client built with matching cache lifetime

</details>

<details>
<summary>Resolve fresh expiry at description publish</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/110/files#diff-dd70a84d43027794f22d1cdf7012c5490cf9294cea0addca23c1e4fc4fc5c1c8"><code>src/agent/submitDescriptionTool.ts</code></a>

- Accepts tokenExpiresAtTs and getTokenExpiresAtTs
- Publish uses current expiry after token refresh

</details>

<details>
<summary>Resolve fresh expiry at review publish</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/110/files#diff-b7f6000f024af4098289401282412f483599c30d7dd91f33a2d4fb948e2b85ef"><code>src/review/publish/submitReviewTool.ts</code></a>

- Accepts tokenExpiresAtTs and getTokenExpiresAtTs
- Publish uses current expiry after token refresh

</details>

<details>
<summary>Forward expiry in ack executor</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/110/files#diff-e6d6e214faadfaeb3ff1ee70099c91c9425a27b07c7c1a20561e70fe513ac648"><code>src/agentWork/executors/ackExecutor.ts</code></a>

- Reactions, replies, and progress comments pass installation.expiresAtTs

</details>

<details>
<summary>Pass expiry in PR file listing</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/110/files#diff-0b4f93d2d31665ec5221396471df8bd6ee9fc823b29086ec8f344ea37c30fe9e"><code>src/github/listPullRequestFiles.ts</code></a>

- fetchPullRequestFiles accepts optional expiresAtTs
- Forwards expiry when constructing Octokit client

</details>

</details>

<details>
<summary>Tests (2 files)</summary>

<details>
<summary>Expand Octokit cache expiry tests</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/110/files#diff-61c85fd3b4cde91ea188a8be03d419bd58d58235025de7511f57646a60ef4cb2"><code>test/appAuth.test.ts</code></a>

- Covers fallback TTL when expiry omitted
- Verifies later explicit expiry tightens cached entries

</details>

<details>
<summary>Assert expiry through token refresh</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/110/files#diff-905597641f64b15e967b788a9541c3e8ffe5581cf9fad44cfdce8e9394e9b76b"><code>test/refreshableGithubTools.test.ts</code></a>

- Build receives refreshed expiresAtTs
- getTokenExpiresAtTs returns updated value after refresh

</details>

</details>