### PR TITLE
Add agent work integration harness

### DIFF
--- a/plans/005-INVESTIGATION.md
+++ b/plans/005-INVESTIGATION.md
@@ -1,0 +1,31 @@
+# Plan 005 investigation
+
+Question: Can pg-boss redeliver an agent-work job while the original handler is still executing, and does `claimWorkForExecution` admit a second executor?
+
+Evidence:
+
+- `src/settings/defaults.ts:26-27` sets `DEFAULT_QUEUE_EXPIRE_IN_SECONDS = 3600` and `DEFAULT_QUEUE_HEARTBEAT_SECONDS = 60`.
+- `src/agentWork/boss.ts:18-28` applies those values to every queue through `queueDefaults`.
+- `node_modules/pg-boss/dist/types.d.ts:127-131` documents heartbeat as a liveness check. Missing heartbeat fails or retries the job.
+- `node_modules/pg-boss/dist/types.d.ts:307-311` documents worker heartbeat refresh timing as `heartbeatSeconds / 2` by default.
+- `node_modules/pg-boss/dist/manager.js:187-208` starts a timer that calls `touch()` for active jobs while the handler promise is pending.
+- `node_modules/pg-boss/dist/manager.js:210-217` races the handler against `expireInSeconds` and fails the pg-boss job on timeout.
+- `node_modules/pg-boss/dist/tools.js:33-43` implements that timeout with `Promise.race`; it aborts the signal after the race but does not cancel a handler that ignores the signal.
+- `node_modules/pg-boss/dist/plans.js:1001-1006` still has a hard active-job timeout based on `started_on + expire_seconds`.
+- `node_modules/pg-boss/dist/plans.js:1008-1024` separately fails jobs whose heartbeat is stale and updates only `heartbeat_on` during `touch()`.
+- `node_modules/pg-boss/dist/plans.js:1029-1104` re-inserts failed active jobs as `retry` until `retry_count` reaches `retry_limit`, preserving the job id.
+- `node_modules/pg-boss/dist/plans.js:748-857` fetches retry jobs again and marks them `active`.
+- `src/agentWork/repository.ts:98-120` returns `true` for an already-`running` work item with no cancellation request.
+- `src/agentWork/durableJob.ts:232-237` claims the app-level row before loading the payload, but the pg-boss abort signal is not part of the durable execution context.
+
+Verdict: BUG
+
+Heartbeat protects against stale workers, but it does not extend `expireInSeconds`. A handler that runs past 3600 seconds is timed out by pg-boss and retried. Because this repo does not thread pg-boss's abort signal through durable execution, the original handler can keep running if the provider or publish path ignores cancellation. The retry then reaches `claimWorkForExecution`, sees the app row still `running`, and returns `true` through the resume path. That admits two concurrent executors for one work item.
+
+Reachability:
+
+Review work can plausibly exceed one hour on large PRs, slow providers, or long publish retries. The queue retry delay defaults to 30 seconds, so overlap can start shortly after the timeout if the original handler remains alive.
+
+Recommended follow-up:
+
+Keep the new concurrent double-claim test as the current-contract pin. A follow-up fix should add an app-level lease, for example `locked_until`, or reject resume while `started_at` is fresh. After the fix, change the double-claim test to assert exclusive ownership.

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,5 @@
+# Plans
+
+| Plan | Status | Notes                                    |
+| ---- | ------ | ---------------------------------------- |
+| 005  | Done   | Integration harness added. Verdict: BUG. |

--- a/test/integration/agentWorkRepository.integration.test.ts
+++ b/test/integration/agentWorkRepository.integration.test.ts
@@ -1,0 +1,177 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { Pool } from "pg";
+import { runMigrations } from "../../src/db/migrations.js";
+import {
+  claimWorkForExecution,
+  forceMarkRescheduledParentCompleted,
+  markWorkCancelled,
+  markWorkCompleted,
+  markWorkRetrying,
+} from "../../src/agentWork/repository.js";
+import type { WorkStatus } from "../../src/agentWork/types.js";
+import { hasDatabase, integrationPool } from "./db.js";
+
+const OWNER = "repo-it";
+
+type InsertWorkItemInput = {
+  readonly status?: WorkStatus;
+  readonly attemptCount?: number;
+  readonly cancelRequestedAt?: string | null;
+  readonly payload?: Record<string, unknown>;
+};
+
+type WorkRow = {
+  readonly status: WorkStatus;
+  readonly attempt_count: number;
+  readonly started_at: Date | null;
+  readonly completed_at: Date | null;
+  readonly cancel_requested_at: Date | null;
+  readonly last_error: string | null;
+};
+
+describe.skipIf(!hasDatabase)("agent work repository (integration)", () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = integrationPool();
+    await runMigrations(pool);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  afterEach(async () => {
+    await pool.query("DELETE FROM agent_work_items WHERE owner = $1", [OWNER]);
+  });
+
+  async function insertWorkItem(input: InsertWorkItemInput = {}): Promise<string> {
+    const id = randomUUID();
+    await pool.query(
+      `INSERT INTO agent_work_items (
+         id, type, source, status, owner, repo, pr_number, installation_id,
+         head_sha, review_lens, resource_key, attempt_count, cancel_requested_at, payload
+       )
+       VALUES ($1, 'review', 'auto', $2, $3, 'r', 1, 1, 'h', 'review', $4, $5, $6, $7::jsonb)`,
+      [
+        id,
+        input.status ?? "queued",
+        OWNER,
+        `repo-it-${id}`,
+        input.attemptCount ?? 0,
+        input.cancelRequestedAt ?? null,
+        JSON.stringify(input.payload ?? {}),
+      ],
+    );
+    return id;
+  }
+
+  async function getWorkRow(id: string): Promise<WorkRow> {
+    const { rows } = await pool.query<WorkRow>(
+      `SELECT status, attempt_count, started_at, completed_at, cancel_requested_at, last_error
+         FROM agent_work_items
+        WHERE id = $1`,
+      [id],
+    );
+    const row = rows[0];
+    if (!row) throw new Error(`missing work item ${id}`);
+    return row;
+  }
+
+  it("claims queued work and increments attempt count", async () => {
+    const id = await insertWorkItem();
+
+    await expect(claimWorkForExecution(pool, id)).resolves.toBe(true);
+
+    const row = await getWorkRow(id);
+    expect(row.status).toBe("running");
+    expect(row.attempt_count).toBe(1);
+    expect(row.started_at).toBeInstanceOf(Date);
+  });
+
+  it("claims running work through the resume path", async () => {
+    const id = await insertWorkItem();
+
+    await claimWorkForExecution(pool, id);
+    await expect(claimWorkForExecution(pool, id)).resolves.toBe(true);
+
+    const row = await getWorkRow(id);
+    expect(row.status).toBe("running");
+    expect(row.attempt_count).toBe(1);
+  });
+
+  it("does not claim work after cancellation is requested", async () => {
+    const id = await insertWorkItem({ cancelRequestedAt: new Date().toISOString() });
+
+    await expect(claimWorkForExecution(pool, id)).resolves.toBe(false);
+
+    const row = await getWorkRow(id);
+    expect(row.status).toBe("queued");
+    expect(row.attempt_count).toBe(0);
+  });
+
+  it("completes running work once only", async () => {
+    const id = await insertWorkItem({ status: "running", attemptCount: 1 });
+
+    await expect(markWorkCompleted(pool, id)).resolves.toBe(true);
+    await expect(markWorkCompleted(pool, id)).resolves.toBe(false);
+
+    const row = await getWorkRow(id);
+    expect(row.status).toBe("completed");
+    expect(row.completed_at).toBeInstanceOf(Date);
+  });
+
+  it("prevents completion after cancellation wins", async () => {
+    const id = await insertWorkItem({ status: "running", attemptCount: 1 });
+
+    await markWorkCancelled(pool, id);
+
+    await expect(markWorkCompleted(pool, id)).resolves.toBe(false);
+    await expect(getWorkRow(id)).resolves.toMatchObject({ status: "cancelled" });
+  });
+
+  it("requeues retrying work and increments attempt on the next claim", async () => {
+    const id = await insertWorkItem({ status: "running", attemptCount: 1 });
+
+    await expect(markWorkRetrying(pool, id, new Error("retry me"))).resolves.toBe(true);
+
+    const retrying = await getWorkRow(id);
+    expect(retrying.status).toBe("queued");
+    expect(retrying.attempt_count).toBe(1);
+    expect(retrying.last_error).toBe("retry me");
+
+    await expect(claimWorkForExecution(pool, id)).resolves.toBe(true);
+    await expect(getWorkRow(id)).resolves.toMatchObject({
+      status: "running",
+      attempt_count: 2,
+    });
+  });
+
+  it("only force-completes rescheduled parents with a replacement marker", async () => {
+    const ordinary = await insertWorkItem({ status: "running", attemptCount: 1 });
+    const rescheduled = await insertWorkItem({
+      status: "queued",
+      payload: { staleHeadReplacementWorkItemId: "replacement-wi" },
+    });
+
+    await expect(forceMarkRescheduledParentCompleted(pool, ordinary)).resolves.toBe(false);
+    await expect(forceMarkRescheduledParentCompleted(pool, rescheduled)).resolves.toBe(true);
+
+    await expect(getWorkRow(ordinary)).resolves.toMatchObject({ status: "running" });
+    await expect(getWorkRow(rescheduled)).resolves.toMatchObject({ status: "completed" });
+  });
+
+  it("allows concurrent double-claim through one running resume", async () => {
+    const id = await insertWorkItem();
+
+    await expect(
+      Promise.all([claimWorkForExecution(pool, id), claimWorkForExecution(pool, id)]),
+    ).resolves.toEqual([true, true]);
+
+    await expect(getWorkRow(id)).resolves.toMatchObject({
+      status: "running",
+      attempt_count: 1,
+    });
+  });
+});

--- a/test/integration/webhookDedupe.integration.test.ts
+++ b/test/integration/webhookDedupe.integration.test.ts
@@ -1,0 +1,89 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { Pool } from "pg";
+import { insertWebhookEvent } from "../../src/agentWork/intake/webhookEvents.js";
+import type { WebhookHeaders } from "../../src/agentWork/types.js";
+import { runMigrations } from "../../src/db/migrations.js";
+import { hasDatabase, integrationPool } from "./db.js";
+
+const EVENT = "webhook-dedupe-it";
+
+describe.skipIf(!hasDatabase)("webhook dedupe (integration)", () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = integrationPool();
+    await runMigrations(pool);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  afterEach(async () => {
+    await pool.query("DELETE FROM webhook_events WHERE event_name = $1", [EVENT]);
+  });
+
+  function headers(body: string, delivery?: string): WebhookHeaders {
+    const base = { event: EVENT, rawBody: Buffer.from(body) };
+    return delivery ? { ...base, delivery } : base;
+  }
+
+  async function countRows(): Promise<number> {
+    const { rows } = await pool.query<{ count: string }>(
+      "SELECT COUNT(*)::text AS count FROM webhook_events WHERE event_name = $1",
+      [EVENT],
+    );
+    return Number(rows[0]?.count ?? "0");
+  }
+
+  it("stores the first delivery id insert", async () => {
+    const result = await insertWebhookEvent(pool, headers("{}", "delivery-first"), "processed");
+
+    if (result.duplicate) throw new Error("delivery-first insert was treated as duplicate");
+    const { rows } = await pool.query<{ delivery_id: string | null }>(
+      "SELECT delivery_id FROM webhook_events WHERE id = $1",
+      [result.id],
+    );
+    expect(rows[0]?.delivery_id).toBe("delivery-first");
+  });
+
+  it("dedupes repeated delivery ids", async () => {
+    const first = await insertWebhookEvent(pool, headers("{}", "delivery-1"), "processed");
+    const second = await insertWebhookEvent(pool, headers("{}", "delivery-1"), "processed");
+
+    expect(first.duplicate).toBe(false);
+    expect(second.duplicate).toBe(true);
+    await expect(countRows()).resolves.toBe(1);
+  });
+
+  it("dedupes identical bodies without delivery ids", async () => {
+    const first = await insertWebhookEvent(pool, headers('{"same":true}'), "processed");
+    const second = await insertWebhookEvent(pool, headers('{"same":true}'), "processed");
+
+    expect(first.duplicate).toBe(false);
+    expect(second.duplicate).toBe(true);
+    expect(first.dedupeKey).toBe(second.dedupeKey);
+    await expect(countRows()).resolves.toBe(1);
+  });
+
+  it("keeps different bodies without delivery ids", async () => {
+    const first = await insertWebhookEvent(pool, headers('{"n":1}'), "processed");
+    const second = await insertWebhookEvent(pool, headers('{"n":2}'), "processed");
+
+    expect(first.duplicate).toBe(false);
+    expect(second.duplicate).toBe(false);
+    expect(first.dedupeKey).not.toBe(second.dedupeKey);
+    await expect(countRows()).resolves.toBe(2);
+  });
+
+  it("lets only one concurrent same-key insert win", async () => {
+    const results = await Promise.all([
+      insertWebhookEvent(pool, headers("{}", "delivery-race"), "processed"),
+      insertWebhookEvent(pool, headers("{}", "delivery-race"), "processed"),
+    ]);
+
+    expect(results.filter((result) => !result.duplicate)).toHaveLength(1);
+    expect(results.filter((result) => result.duplicate)).toHaveLength(1);
+    await expect(countRows()).resolves.toBe(1);
+  });
+});


### PR DESCRIPTION
Adds real-Postgres coverage for agent-work claim, retry, cancel, completion, rescheduled-parent completion, and webhook dedupe behavior. Includes the current concurrent double-claim behavior so the retry semantics are pinned before any fix.

Writes the Plan 005 verdict as BUG. pg-boss heartbeat keeps active jobs fresh, but it does not extend expireInSeconds, so timeout retry can overlap with original durable work if cancellation is ignored.

Verification:
- pnpm test
- DATABASE_URL=postgres://pr_agent:pr_agent@localhost:5432/pr_agent pnpm test:integration
- pnpm typecheck
- pnpm lint
- pnpm fmt:check

Closes #93.

___

## PR Agent Description

### PR Type

Tests, Documentation

### Description

- Document Plan 005: pg-boss retry can admit concurrent executors via resume path
- Add Postgres integration tests for agent work claim, complete, cancel, and retry flows
- Add webhook dedupe tests for delivery IDs, body hashes, and concurrent inserts
- Pin concurrent double-claim behavior as current contract until lease fix lands

### Changes Diagram

```mermaid
flowchart LR
  A["Plan 005 investigation"] --> B["pg-boss timeout retry"]
  B --> C["Resume path double claim"]
  C --> D["Agent work integration tests"]
  D --> E["Webhook dedupe integration tests"]
  E --> F["Future app-level lease fix"]
```

### File Walkthrough

<details>
<summary>Documentation (2 files)</summary>

<details>
<summary>Document pg-boss concurrent execution bug</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/111/files#diff-5ee83fbd108db5268ee78b310fe8a7dfdfa5d6e814ebcacec67e3b1b07625fce"><code>plans/005-INVESTIGATION.md</code></a>

- Traces pg-boss heartbeat, expire, and retry behavior against queue defaults
- Shows claimWorkForExecution resume path allows two concurrent executors
- Recommends app-level lease or fresh-started_at guard as follow-up

</details>

<details>
<summary>Track Plan 005 status in plans index</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/111/files#diff-783ff68d8648e67461d1023e2cfe8bf5f1a1b05af93573c29fa4eeefa36b1bbd"><code>plans/README.md</code></a>

- Adds plans table with Plan 005 marked Done
- Notes integration harness added and investigation verdict BUG

</details>

</details>

<details>
<summary>Tests (2 files)</summary>

<details>
<summary>Integration tests for agent work repository</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/111/files#diff-c95967d2e1c0faf1bc82a4b0552072741a120c1636e3b4826b6585d38391d540"><code>test/integration/agentWorkRepository.integration.test.ts</code></a>

- Covers claim, resume, cancel, complete, retry, and rescheduled-parent flows
- Asserts concurrent double-claim returns true for both callers today
- Skips when DATABASE_URL unset; runs migrations and cleans up per test

</details>

<details>
<summary>Integration tests for webhook event deduplication</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/111/files#diff-ea8d803545de9c1eae1e5ced714bce042d4f7938413f16d5ff6e02369a588c0b"><code>test/integration/webhookDedupe.integration.test.ts</code></a>

- Verifies first delivery ID insert and duplicate rejection
- Dedupes identical bodies without delivery IDs via shared dedupe key
- Ensures only one concurrent same-key insert wins under race

</details>

</details>