### PR TITLE
Reduce review spam

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -123,41 +123,42 @@ These are related but not wired together on INSERT today.
 
 ### Review output
 
-| Symbol                                                                                 | Role                                                   |
-| -------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| `REVIEW_SUMMARY_SENTINEL`                                                              | PR conversation summary marker                         |
-| `SECURITY_REVIEW_SUMMARY_SENTINEL`                                                     | Security summary marker                                |
-| `QUALITY_REVIEW_SUMMARY_SENTINEL`                                                      | Code-quality summary marker                            |
-| `REVIEW_POINTER_BODY` / `SECURITY_REVIEW_POINTER_BODY` / `QUALITY_REVIEW_POINTER_BODY` | Files-tab pointer text (repeat no-bugs fallback)       |
-| `REVIEW_POINTER_NOTE_LEAD`                                                             | First-publish pointer NOTE body                        |
-| `REVIEW_POINTER_BODY_MAX_CHARS`                                                        | 60000                                                  |
-| `REVIEW_EFFORT_WORDS`                                                                  | Light → Heavy labels for effort row                    |
-| `REVIEW_OVERVIEW_ALERT` / `REVIEW_FAILURE_ALERT`                                       | GitHub alert types (`NOTE`, `CAUTION`)                 |
-| `REVIEW_PROGRESS_NOTE`                                                                 | In-progress NOTE body                                  |
-| `REVIEW_PROGRESS_SOURCE_AUTO` / `REVIEW_PROGRESS_SOURCE_SLASH`                         | Progress table source labels                           |
-| `LIGHTWEIGHT_REVIEW_COMPLETION_*`                                                      | Docs-only auto-review skip copy                        |
-| `REVIEW_SIZE_TIER_*`                                                                   | Advisory small/medium/large tier thresholds            |
-| `REVIEW_RISK_PATH_PATTERNS`                                                            | Path categories for trusted review context             |
-| `REVIEW_FINDING_FOOTNOTE_INLINE` / `REVIEW_FINDING_FOOTNOTE_SUMMARY`                   | Finding row footnotes                                  |
-| `REVIEW_FINDINGS_NONE`                                                                 | Empty findings table cell                              |
-| `REVIEW_SECURITY_DEFAULT`                                                              | Default security row when null                         |
-| `AGENT_FIX_PROMPT_ACCORDION_SUMMARY`                                                   | Pointer accordion title                                |
-| `MAX_REVIEW_FOLLOW_UPS`                                                                | 5                                                      |
-| `REVIEW_FINDING_TITLE_MAX_CHARS`                                                       | 80                                                     |
-| `REVIEW_FINDING_DETAIL_MAX_CHARS`                                                      | 4000                                                   |
-| `REVIEW_FINDING_FIX_PROMPT_MAX_CHARS`                                                  | 2000                                                   |
-| `REVIEW_OVERVIEW_MAX_CHARS`                                                            | 8000                                                   |
-| `REVIEW_OVERVIEW_COMPACT_MAX_CHARS`                                                    | 500                                                    |
-| `REVIEW_SECURITY_CONCERNS_MAX_CHARS`                                                   | 4000                                                   |
-| `REVIEW_FOLLOW_UP_MAX_CHARS`                                                           | 2000                                                   |
-| `REVIEW_SUMMARY_BODY_MAX_CHARS`                                                        | 60000                                                  |
-| `REVIEW_SUMMARY_COMPACTION_NOTE`                                                       | Public note when summary is compacted                  |
-| `REVIEW_SUMMARY_FINDINGS_OMITTED_SUFFIX`                                               | Public note when finding rows are omitted              |
-| `MAX_REVIEW_PAYLOAD_FINDINGS`                                                          | 128                                                    |
-| `MAX_INLINE_REVIEW_COMMENTS`                                                           | 50                                                     |
-| `REVIEW_EFFORT_MIN` / `REVIEW_EFFORT_MAX`                                              | 1–5                                                    |
-| `REVIEW_SEVERITY_RANK`                                                                 | P0–P3 ordering                                         |
-| Label prefixes                                                                         | `LABEL_REVIEW_EFFORT_PREFIX`, `LABEL_SECURITY_CONCERN` |
+| Symbol                                                                                 | Role                                                                                                                  |
+| -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `REVIEW_SUMMARY_SENTINEL`                                                              | PR conversation summary marker                                                                                        |
+| `SECURITY_REVIEW_SUMMARY_SENTINEL`                                                     | Security summary marker                                                                                               |
+| `QUALITY_REVIEW_SUMMARY_SENTINEL`                                                      | Code-quality summary marker                                                                                           |
+| `REVIEW_POINTER_BODY` / `SECURITY_REVIEW_POINTER_BODY` / `QUALITY_REVIEW_POINTER_BODY` | Files-tab pointer text (repeat no-bugs fallback)                                                                      |
+| `REVIEW_POINTER_NOTE_LEAD`                                                             | First-publish pointer NOTE body                                                                                       |
+| `REVIEW_POINTER_BODY_MAX_CHARS`                                                        | 60000                                                                                                                 |
+| `REVIEW_EFFORT_WORDS`                                                                  | Light → Heavy labels for effort row                                                                                   |
+| `REVIEW_OVERVIEW_ALERT` / `REVIEW_FAILURE_ALERT`                                       | GitHub alert types (`NOTE`, `CAUTION`)                                                                                |
+| `REVIEW_PROGRESS_NOTE`                                                                 | In-progress NOTE body                                                                                                 |
+| `REVIEW_PROGRESS_SOURCE_AUTO` / `REVIEW_PROGRESS_SOURCE_SLASH`                         | Progress table source labels                                                                                          |
+| `LIGHTWEIGHT_REVIEW_COMPLETION_*`                                                      | Docs-only auto-review skip copy                                                                                       |
+| `REVIEW_SIZE_TIER_*`                                                                   | Advisory small/medium/large tier thresholds                                                                           |
+| `REVIEW_RISK_PATH_PATTERNS`                                                            | Path categories for trusted review context                                                                            |
+| `REVIEW_FINDING_FOOTNOTE_INLINE` / `REVIEW_FINDING_FOOTNOTE_SUMMARY`                   | Finding row footnotes                                                                                                 |
+| `REVIEW_FINDINGS_NONE`                                                                 | Empty findings table cell                                                                                             |
+| `REVIEW_SECURITY_DEFAULT`                                                              | Default security row when null                                                                                        |
+| `AGENT_FIX_PROMPT_ACCORDION_SUMMARY`                                                   | Pointer accordion title                                                                                               |
+| `MAX_REVIEW_FOLLOW_UPS`                                                                | 5                                                                                                                     |
+| `REVIEW_FINDING_TITLE_MAX_CHARS`                                                       | 80                                                                                                                    |
+| `REVIEW_FINDING_DETAIL_MAX_CHARS`                                                      | 4000                                                                                                                  |
+| `REVIEW_FINDING_FIX_PROMPT_MAX_CHARS`                                                  | 2000                                                                                                                  |
+| `REVIEW_OVERVIEW_MAX_CHARS`                                                            | 8000                                                                                                                  |
+| `REVIEW_OVERVIEW_COMPACT_MAX_CHARS`                                                    | 500                                                                                                                   |
+| `REVIEW_SECURITY_CONCERNS_MAX_CHARS`                                                   | 4000                                                                                                                  |
+| `REVIEW_FOLLOW_UP_MAX_CHARS`                                                           | 2000                                                                                                                  |
+| `REVIEW_SUMMARY_BODY_MAX_CHARS`                                                        | 60000                                                                                                                 |
+| `REVIEW_SUMMARY_COMPACTION_NOTE`                                                       | Public note when summary is compacted                                                                                 |
+| `REVIEW_SUMMARY_FINDINGS_OMITTED_SUFFIX`                                               | Public note when finding rows are omitted                                                                             |
+| `MAX_REVIEW_PAYLOAD_FINDINGS`                                                          | 128                                                                                                                   |
+| `MAX_INLINE_REVIEW_COMMENTS`                                                           | 50                                                                                                                    |
+| `REVIEW_EFFORT_MIN` / `REVIEW_EFFORT_MAX`                                              | 1–5                                                                                                                   |
+| `REVIEW_SEVERITY_RANK`                                                                 | P0–P3 ordering                                                                                                        |
+| Label prefixes                                                                         | `LABEL_REVIEW_EFFORT_PREFIX`, `LABEL_SECURITY_EFFORT_PREFIX`, `LABEL_QUALITY_EFFORT_PREFIX`, `LABEL_SECURITY_CONCERN` |
+| `REVIEW_FINDING_FINGERPRINT_LINE_BUCKET_SIZE`                                          | 50                                                                                                                    |
 
 ### Review / ask agent loops
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -3,3 +3,4 @@
 | Plan | Status | Notes                                    |
 | ---- | ------ | ---------------------------------------- |
 | 005  | Done   | Integration harness added. Verdict: BUG. |
+| 016  | Done   | Review spam reduction implemented.       |

--- a/src/agentWork/intake/slashIntake.ts
+++ b/src/agentWork/intake/slashIntake.ts
@@ -198,11 +198,8 @@ async function handleSlashReview(ctx: SlashIntakeContext, command: ReviewMode): 
 }
 
 async function handleSlashUnknown(ctx: SlashIntakeContext, command: string): Promise<void> {
-  await enqueueSlashAck(ctx, {
-    reply: {
-      target: ctx.input.replyTarget,
-      body: `Unknown command \`/${command}\`. Try \`/help\`.`,
-    },
+  recordEvent(ctx.intakeLog, "ignored_unknown_slash_command", {
+    command,
   });
 }
 

--- a/src/review/publish/publishReview.ts
+++ b/src/review/publish/publishReview.ts
@@ -277,21 +277,30 @@ export async function publishReview(
         throw new Error(`listPullRequestLabels returned non-array: ${String(currentLabels)}`);
       }
       if (
-        labelsAlreadySynced(currentLabels, payload, {
-          effort: cfg.enableReviewLabelsEffort,
-          security: cfg.enableReviewLabelsSecurity,
-        })
+        labelsAlreadySynced(
+          currentLabels,
+          payload,
+          {
+            effort: cfg.enableReviewLabelsEffort,
+            security: cfg.enableReviewLabelsSecurity,
+          },
+          mode,
+        )
       ) {
         await params.recordPublishStep?.("labels", {
           meta: { labels: currentLabels, alreadySynced: true },
         });
         return;
       }
-      const managed = reviewLabelsFromPayload(payload, {
-        effort: cfg.enableReviewLabelsEffort,
-        security: cfg.enableReviewLabelsSecurity,
-      });
-      const next = syncReviewLabels(currentLabels, managed);
+      const managed = reviewLabelsFromPayload(
+        payload,
+        {
+          effort: cfg.enableReviewLabelsEffort,
+          security: cfg.enableReviewLabelsSecurity,
+        },
+        mode,
+      );
+      const next = syncReviewLabels(currentLabels, managed, mode);
       if (tokenExpiresAtTs == null) {
         await setPullRequestLabels(token, owner, repo, prNumber, next);
       } else {

--- a/src/review/reviewFindingFingerprint.ts
+++ b/src/review/reviewFindingFingerprint.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import { REVIEW_FINDING_FINGERPRINT_LINE_BUCKET_SIZE } from "../settings/index.js";
 import type { FingerprintedInlinePlacement, InlinePlacement } from "./reviewDiffPlacement.js";
 import type { ReviewFinding, ReviewMode } from "./reviewSchema.js";
 
@@ -11,13 +12,13 @@ export function normalizeFindingSubstance(text: string): string {
 }
 
 export function fingerprintFinding(finding: ReviewFinding, mode: ReviewMode): string {
+  const lineBucket = Math.floor(finding.startLine / REVIEW_FINDING_FINGERPRINT_LINE_BUCKET_SIZE);
   const material = [
     mode,
     finding.file,
-    String(finding.startLine),
-    String(finding.endLine),
     normalizeFindingSubstance(finding.title),
     normalizeFindingSubstance(finding.detail),
+    String(lineBucket),
   ].join("|");
   return crypto.createHash("sha256").update(material).digest("hex").slice(0, 16);
 }

--- a/src/review/reviewLabels.ts
+++ b/src/review/reviewLabels.ts
@@ -1,14 +1,35 @@
-import { LABEL_REVIEW_EFFORT_PREFIX, LABEL_SECURITY_CONCERN } from "../settings/index.js";
-import type { ReviewPayload } from "./reviewSchema.js";
+import {
+  LABEL_QUALITY_EFFORT_PREFIX,
+  LABEL_REVIEW_EFFORT_PREFIX,
+  LABEL_SECURITY_CONCERN,
+  LABEL_SECURITY_EFFORT_PREFIX,
+} from "../settings/index.js";
+import type { ReviewMode, ReviewPayload } from "./reviewSchema.js";
+
+function reviewEffortLabelPrefix(mode: ReviewMode): string {
+  switch (mode) {
+    case "review-security":
+      return LABEL_SECURITY_EFFORT_PREFIX;
+    case "review-quality":
+      return LABEL_QUALITY_EFFORT_PREFIX;
+    case "review":
+      return LABEL_REVIEW_EFFORT_PREFIX;
+  }
+  const exhaustive: never = mode;
+  return exhaustive;
+}
 
 export function labelsAlreadySynced(
   currentLabels: string[],
   payload: ReviewPayload,
   opts: { effort: boolean; security: boolean },
+  mode: ReviewMode = "review",
 ): boolean {
   if (opts.effort) {
-    const effortLabel = `${LABEL_REVIEW_EFFORT_PREFIX}${payload.estimatedEffort}/5`;
-    if (!currentLabels.includes(effortLabel)) return false;
+    const effortPrefix = reviewEffortLabelPrefix(mode);
+    const effortLabel = `${effortPrefix}${payload.estimatedEffort}/5`;
+    const currentEffortLabels = currentLabels.filter((label) => label.startsWith(effortPrefix));
+    if (currentEffortLabels.length !== 1 || currentEffortLabels[0] !== effortLabel) return false;
   }
   if (opts.security) {
     const wantsSecurity = payload.securityConcerns != null;
@@ -20,10 +41,11 @@ export function labelsAlreadySynced(
 export function reviewLabelsFromPayload(
   payload: ReviewPayload,
   opts: { effort: boolean; security: boolean },
+  mode: ReviewMode = "review",
 ): string[] {
   const labels: string[] = [];
   if (opts.effort) {
-    labels.push(`${LABEL_REVIEW_EFFORT_PREFIX}${payload.estimatedEffort}/5`);
+    labels.push(`${reviewEffortLabelPrefix(mode)}${payload.estimatedEffort}/5`);
   }
   if (opts.security && payload.securityConcerns != null) {
     labels.push(LABEL_SECURITY_CONCERN);
@@ -31,9 +53,14 @@ export function reviewLabelsFromPayload(
   return labels;
 }
 
-export function syncReviewLabels(currentLabels: string[], nextManaged: string[]): string[] {
+export function syncReviewLabels(
+  currentLabels: string[],
+  nextManaged: string[],
+  mode: ReviewMode = "review",
+): string[] {
+  const effortPrefix = reviewEffortLabelPrefix(mode);
   const preserved = currentLabels.filter(
-    (name) => !name.startsWith(LABEL_REVIEW_EFFORT_PREFIX) && name !== LABEL_SECURITY_CONCERN,
+    (name) => !name.startsWith(effortPrefix) && name !== LABEL_SECURITY_CONCERN,
   );
   return [...preserved, ...nextManaged];
 }

--- a/src/settings/constants.ts
+++ b/src/settings/constants.ts
@@ -43,7 +43,10 @@ export const REVIEW_SUMMARY_SENTINEL = "## PR Agent Review";
 export const SECURITY_REVIEW_SUMMARY_SENTINEL = "## PR Agent Security Review";
 export const QUALITY_REVIEW_SUMMARY_SENTINEL = "## PR Agent Quality Review";
 export const LABEL_REVIEW_EFFORT_PREFIX = "Review effort ";
+export const LABEL_SECURITY_EFFORT_PREFIX = "Security effort ";
+export const LABEL_QUALITY_EFFORT_PREFIX = "Quality effort ";
 export const LABEL_SECURITY_CONCERN = "Possible security concern";
+export const REVIEW_FINDING_FINGERPRINT_LINE_BUCKET_SIZE = 50;
 
 export const REVIEW_POINTER_BODY = "See the structured review summary in the PR conversation.";
 export const SECURITY_REVIEW_POINTER_BODY =

--- a/test/publishReview.test.ts
+++ b/test/publishReview.test.ts
@@ -406,6 +406,31 @@ describe("publishReview", () => {
     ]);
   });
 
+  it("syncs quality effort without removing review effort", async () => {
+    vi.mocked(listPullRequestLabels).mockResolvedValueOnce([
+      "Review effort 3/5",
+      "Quality effort 1/5",
+      "bug",
+    ]);
+
+    await publishReviewForTest({
+      ...baseParams,
+      mode: "review-quality",
+      publishState: testPublishState(),
+      cfg: {
+        enableReviewLabelsEffort: true,
+        enableReviewLabelsSecurity: false,
+      },
+      payload: { ...payload, estimatedEffort: 4 },
+    });
+
+    expect(setPullRequestLabels).toHaveBeenCalledWith("t", "o", "r", 1, [
+      "Review effort 3/5",
+      "bug",
+      "Quality effort 4/5",
+    ]);
+  });
+
   it("links pointer when shouldLinkToSummary and comment verifies", async () => {
     vi.mocked(resolveVerifiedSummaryCommentRef).mockResolvedValueOnce({
       id: 99,

--- a/test/reviewFindingFingerprint.test.ts
+++ b/test/reviewFindingFingerprint.test.ts
@@ -35,6 +35,21 @@ describe("fingerprintFinding", () => {
     const other = { ...finding, detail: "different substance" };
     expect(fingerprintFinding(finding, "review")).not.toBe(fingerprintFinding(other, "review"));
   });
+
+  it("matches when a finding shifts within the same line bucket", () => {
+    const shifted = { ...finding, startLine: 13, endLine: 15 };
+    expect(fingerprintFinding(finding, "review")).toBe(fingerprintFinding(shifted, "review"));
+  });
+
+  it("differs when title changes", () => {
+    const other = { ...finding, title: "Leaked token" };
+    expect(fingerprintFinding(finding, "review")).not.toBe(fingerprintFinding(other, "review"));
+  });
+
+  it("differs for identical findings in distant line buckets", () => {
+    const distant = { ...finding, startLine: 400, endLine: 402 };
+    expect(fingerprintFinding(finding, "review")).not.toBe(fingerprintFinding(distant, "review"));
+  });
 });
 
 describe("parseStoredInlineFingerprints", () => {

--- a/test/reviewLabels.test.ts
+++ b/test/reviewLabels.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { ReviewPayload } from "../src/review/reviewSchema.js";
-import { labelsAlreadySynced, syncReviewLabels } from "../src/review/reviewLabels.js";
+import {
+  labelsAlreadySynced,
+  reviewLabelsFromPayload,
+  syncReviewLabels,
+} from "../src/review/reviewLabels.js";
 
 const basePayload: ReviewPayload = {
   prCharacter: "Test.",
@@ -36,6 +40,59 @@ describe("labelsAlreadySynced", () => {
       ),
     ).toBe(true);
   });
+
+  it("checks effort labels inside the current lens prefix", () => {
+    expect(
+      labelsAlreadySynced(
+        ["Review effort 4/5", "Quality effort 2/5"],
+        basePayload,
+        {
+          effort: true,
+          security: false,
+        },
+        "review-quality",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false when the current lens effort label is stale", () => {
+    expect(
+      labelsAlreadySynced(
+        ["Quality effort 1/5"],
+        basePayload,
+        {
+          effort: true,
+          security: false,
+        },
+        "review-quality",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("reviewLabelsFromPayload", () => {
+  it("uses lens-specific effort prefixes", () => {
+    expect(
+      reviewLabelsFromPayload(
+        basePayload,
+        {
+          effort: true,
+          security: false,
+        },
+        "review-security",
+      ),
+    ).toEqual(["Security effort 2/5"]);
+    expect(
+      reviewLabelsFromPayload(
+        basePayload,
+        {
+          effort: true,
+          security: false,
+        },
+        "review-quality",
+      ),
+    ).toEqual(["Quality effort 2/5"]);
+  });
 });
 
 describe("syncReviewLabels", () => {
@@ -49,5 +106,11 @@ describe("syncReviewLabels", () => {
     const current = ["Possible security concern", "docs"];
     const next = syncReviewLabels(current, ["Review effort 2/5"]);
     expect(next).toEqual(["docs", "Review effort 2/5"]);
+  });
+
+  it("replaces only the current lens effort label family", () => {
+    const current = ["Review effort 3/5", "Quality effort 1/5", "bug"];
+    const next = syncReviewLabels(current, ["Quality effort 2/5"], "review-quality");
+    expect(next).toEqual(["Review effort 3/5", "bug", "Quality effort 2/5"]);
   });
 });

--- a/test/slashIntake.test.ts
+++ b/test/slashIntake.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Effect } from "effect";
+import type { Pool, PoolClient } from "pg";
+import type { PgBoss } from "pg-boss";
+import { makeAgentWorkScheduler } from "../src/agentWork/scheduler.js";
+import { createOperationLogger, initEvlog } from "../src/evlog.js";
+import { ACK_QUEUE, SLASH_HELP_BODY } from "../src/settings/index.js";
+import * as postgres from "../src/db/postgres.js";
+
+function makeSlashInput(body: string) {
+  const command = body.slice(1).split(/\s+/, 1)[0] ?? "";
+  return {
+    headers: {
+      event: "issue_comment",
+      delivery: `d-${command}`,
+      rawBody: Buffer.from("{}"),
+    },
+    installationId: 42,
+    owner: "acme",
+    repo: "app",
+    prNumber: 7,
+    commentId: 99,
+    commenterId: 1,
+    body,
+    command,
+    replyTarget: { kind: "prConversation" as const, prNumber: 7 },
+  };
+}
+
+function makeClient() {
+  return {
+    query: vi.fn(async (sql: string) => {
+      if (sql.includes("INSERT INTO webhook_events")) {
+        return { rows: [{ id: "event-1" }] };
+      }
+      throw new Error(`unexpected query: ${sql.slice(0, 80)}`);
+    }),
+  } as unknown as PoolClient;
+}
+
+describe("applySlashCommandIntake", () => {
+  beforeEach(() => {
+    initEvlog("info", { silent: true, suppressDrainWarning: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    initEvlog("error", { silent: true, suppressDrainWarning: true });
+  });
+
+  it("records unknown slash commands without acking", async () => {
+    const boss = { send: vi.fn() } as unknown as PgBoss;
+    const client = makeClient();
+    vi.spyOn(postgres, "inTransaction").mockImplementation(async (_pool, fn) => fn(client));
+
+    const scheduler = makeAgentWorkScheduler({} as Pool, boss);
+    const intakeLog = createOperationLogger({
+      method: "POST",
+      path: "/webhooks",
+    });
+
+    await Effect.runPromise(
+      scheduler.submitSlashCommand(makeSlashInput("/cc looks good"), intakeLog),
+    );
+
+    expect(boss.send).not.toHaveBeenCalled();
+    expect(intakeLog.getContext().events).toEqual([
+      expect.objectContaining({
+        event: "ignored_unknown_slash_command",
+        command: "cc",
+      }),
+    ]);
+  });
+
+  it("still replies to help", async () => {
+    const sentJobs: { queue: string; data: Record<string, unknown> }[] = [];
+    const boss = {
+      send: vi.fn(async (queue: string, data: Record<string, unknown>) => {
+        sentJobs.push({ queue, data });
+        return "job-1";
+      }),
+    } as unknown as PgBoss;
+    const client = makeClient();
+    vi.spyOn(postgres, "inTransaction").mockImplementation(async (_pool, fn) => fn(client));
+
+    const scheduler = makeAgentWorkScheduler({} as Pool, boss);
+    const intakeLog = createOperationLogger({
+      method: "POST",
+      path: "/webhooks",
+    });
+
+    await Effect.runPromise(scheduler.submitSlashCommand(makeSlashInput("/help"), intakeLog));
+
+    expect(sentJobs).toHaveLength(1);
+    expect(sentJobs[0]?.queue).toBe(ACK_QUEUE);
+    expect(sentJobs[0]?.data.reply).toEqual({
+      target: { kind: "prConversation", prNumber: 7 },
+      body: SLASH_HELP_BODY,
+    });
+    expect(intakeLog.getContext().events ?? []).not.toContainEqual(
+      expect.objectContaining({ event: "ignored_unknown_slash_command" }),
+    );
+  });
+});


### PR DESCRIPTION
Reduce review noise from three paths.

- Unknown slash commands now record an intake event without sending an ack reply.
- Review, security, and quality runs manage separate effort label prefixes.
- Inline finding fingerprints ignore exact line shifts and keep a coarse 50-line bucket for repeated findings.

Compatibility note: existing stored fingerprints use the old material, so open PRs can re-post an existing finding once after deploy. A finding that crosses a 50-line bucket can also re-fire once.

Verified with:

- pnpm install
- pnpm test -- slashIntake schedulerIgnoredIntake
- pnpm test -- reviewLabels publishReview
- pnpm test -- reviewFindingFingerprint reviewFindingDedup
- pnpm test && pnpm typecheck && pnpm lint && pnpm fmt:check

Closes #75.

___

## PR Agent Description

### PR Type

Enhancement, Tests

### Description

- Bucket finding fingerprints by 50-line ranges to tolerate small line shifts
- Scope effort labels per review lens so modes no longer overwrite each other
- Stop replying to unknown slash commands; log ignored events instead
- Add tests and document new label prefixes and fingerprint bucket constant

### Changes Diagram

```mermaid
flowchart LR
  A["Line-bucket fingerprints"] --> D["Less duplicate review noise"]
  B["Lens-specific effort labels"] --> D
  C["Silent unknown slash intake"] --> D
```

### File Walkthrough

<details>
<summary>Enhancement (5 files)</summary>

<details>
<summary>Bucket finding fingerprints by line range</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/112/files#diff-d81dd16fc971586ed597ba94c630eeab236ceda65a1446555a21bd735c392ffb"><code>src/review/reviewFindingFingerprint.ts</code></a>

- Hash findings using 50-line buckets instead of exact start/end lines
- Keeps fingerprints stable when findings shift slightly within a region

</details>

<details>
<summary>Scope effort labels to review lens</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/112/files#diff-74544e585cb8da9ad12eec406fd3aeab9ad9a2c168f986765037b89319b576b2"><code>src/review/reviewLabels.ts</code></a>

- Add mode-specific effort prefixes for security and quality reviews
- Sync and compare only the current lens effort label family
- Preserve other lens effort labels when updating

</details>

<details>
<summary>Pass review mode into label sync</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/112/files#diff-e02701f5218dd6ca7ddbc891f403f4c6310a2e047806dd9057bdc13fedf9b2ea"><code>src/review/publish/publishReview.ts</code></a>

- Thread review mode through label sync and payload label helpers
- Ensures publish uses lens-aware label comparison and replacement

</details>

<details>
<summary>Silence unknown slash command replies</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/112/files#diff-fd02b6445593a4dd48d473f870fa98790b8c8260de189fc0a43f99adc1e30fc1"><code>src/agentWork/intake/slashIntake.ts</code></a>

- Remove PR conversation ack for unrecognized slash commands
- Record ignored_unknown_slash_command intake event instead

</details>

<details>
<summary>Add lens effort and bucket constants</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/112/files#diff-0ff20bf86329037153bc6b9dc8593498e91c9eed21750c634f60fe1f5a7e2ea3"><code>src/settings/constants.ts</code></a>

- Define Security effort and Quality effort label prefixes
- Export REVIEW_FINDING_FINGERPRINT_LINE_BUCKET_SIZE as 50

</details>

</details>

<details>
<summary>Tests (4 files)</summary>

<details>
<summary>Cover unknown slash intake behavior</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/112/files#diff-bd93c7c427c5bb8d7e1ad2ed1cd5d6d37534db1518969a882ad6a6f802f44bb5"><code>test/slashIntake.test.ts</code></a>

- Assert unknown commands log events without enqueueing ack jobs
- Verify /help still posts the expected help reply

</details>

<details>
<summary>Expand review label sync coverage</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/112/files#diff-6ee915f7b1f148d76c68de0c895fdb24dd90808d3384a0ae88b27a67b193cbea"><code>test/reviewLabels.test.ts</code></a>

- Test lens-specific prefixes and stale label detection
- Verify sync replaces only the active lens effort family

</details>

<details>
<summary>Test line-bucket fingerprint stability</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/112/files#diff-a402e2d1a420360eddef74b657cb714872a86649557b1b8995e4ee45db587552"><code>test/reviewFindingFingerprint.test.ts</code></a>

- Match fingerprints within the same bucket after line shifts
- Differ across distant buckets or title changes

</details>

<details>
<summary>Test quality publish label isolation</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/112/files#diff-d957d6504cf9376e66ab7a55a1431355cc8e4a75f1007f53866e58e27fb8ecda"><code>test/publishReview.test.ts</code></a>

- Confirm quality effort sync updates without removing review effort

</details>

</details>

<details>
<summary>Documentation (1 file)</summary>

<details>
<summary>Document new review output constants</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/112/files#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180"><code>docs/configuration.md</code></a>

- List security and quality effort label prefixes
- Document fingerprint line bucket size setting

</details>

</details>