### PR TITLE
Gate ask answer publishing

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,6 +120,7 @@ These are related but not wired together on INSERT today.
 | `AUTOMATED_PR_ACTIONS`                     | opened, synchronize, reopened       |
 | `AUTOMATED_DESCRIPTION_PR_ACTIONS`         | opened only (use `/describe` after) |
 | `AUTOMATED_REVIEW_LENS`                    | `review`                            |
+| `ASK_PUBLISH_LENS`                         | `ask`                               |
 | `MAX_STORED_COMMENT_TEXT_LEN`              | 16384                               |
 
 ### Review output

--- a/migrations/007_ask_publish_records.sql
+++ b/migrations/007_ask_publish_records.sql
@@ -5,3 +5,13 @@ ALTER TABLE publish_records ADD CONSTRAINT publish_records_review_lens_check
 ALTER TABLE publish_records DROP CONSTRAINT IF EXISTS publish_records_step_check;
 ALTER TABLE publish_records ADD CONSTRAINT publish_records_step_check
   CHECK (step IN ('progress_comment', 'inline_review', 'summary_comment', 'labels', 'pr_body', 'ask_reply'));
+
+ALTER TABLE publish_records DROP CONSTRAINT IF EXISTS publish_records_resource_key_review_lens_step_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS publish_records_unique_shared_step_idx
+  ON publish_records (resource_key, review_lens, step)
+  WHERE review_lens <> 'ask';
+
+CREATE UNIQUE INDEX IF NOT EXISTS publish_records_unique_ask_work_item_step_idx
+  ON publish_records (work_item_id, review_lens, step)
+  WHERE review_lens = 'ask';

--- a/migrations/007_ask_publish_records.sql
+++ b/migrations/007_ask_publish_records.sql
@@ -1,0 +1,7 @@
+ALTER TABLE publish_records DROP CONSTRAINT IF EXISTS publish_records_review_lens_check;
+ALTER TABLE publish_records ADD CONSTRAINT publish_records_review_lens_check
+  CHECK (review_lens IN ('review', 'review-security', 'review-quality', 'description', 'ask'));
+
+ALTER TABLE publish_records DROP CONSTRAINT IF EXISTS publish_records_step_check;
+ALTER TABLE publish_records ADD CONSTRAINT publish_records_step_check
+  CHECK (step IN ('progress_comment', 'inline_review', 'summary_comment', 'labels', 'pr_body', 'ask_reply'));

--- a/plans/README.md
+++ b/plans/README.md
@@ -2,6 +2,7 @@
 
 | Plan | Status | Notes                                    |
 | ---- | ------ | ---------------------------------------- |
+| 003  | Done   | Issue #91 implemented.                   |
 | 005  | Done   | Integration harness added. Verdict: BUG. |
 | 016  | Done   | Review spam reduction implemented.       |
 | 018  | Done   | Issue #77 implemented.                   |

--- a/src/agentWork/executors/askExecutor.ts
+++ b/src/agentWork/executors/askExecutor.ts
@@ -115,12 +115,23 @@ export async function executeAskJob(
               true,
             );
             answerDelivered = true;
-            await recordAskPublishStep(pool, {
-              workItemId: item.id,
-              resourceKey: item.resourceKey,
-              step: "ask_reply",
-              detail: { replyTargetKind: payload.replyTarget.kind },
-            });
+            try {
+              await recordAskPublishStep(pool, {
+                workItemId: item.id,
+                resourceKey: item.resourceKey,
+                step: "ask_reply",
+                detail: { replyTargetKind: payload.replyTarget.kind },
+              });
+            } catch (e) {
+              logWarn("ask_publish_record_failed", {
+                owner: item.owner,
+                repo: item.repo,
+                pr: item.prNumber,
+                workItemId: item.id,
+                message: e instanceof Error ? e.message : String(e),
+              });
+              return { degraded: true };
+            }
           } else {
             answerDelivered = true;
           }

--- a/src/agentWork/executors/askExecutor.ts
+++ b/src/agentWork/executors/askExecutor.ts
@@ -9,7 +9,7 @@ import { ASK_PUBLISH_LENS } from "../../settings/index.js";
 import { withPrRepositoryView } from "../../prWorkspace/index.js";
 import { makeInstallationTokenRefresher, runDurableWorkItem } from "../durableJob.js";
 import { getPullRequestHead, postSlashReply } from "../githubPrSurface.js";
-import { hasCompletedPublishStep, recordPublishStep } from "../repository.js";
+import { hasCompletedPublishStep, recordAskPublishStep } from "../repository.js";
 import type { AgentWorkItem, AskJobData, AskWorkPayload } from "../types.js";
 
 async function publishAskAnswer(
@@ -115,10 +115,9 @@ export async function executeAskJob(
               true,
             );
             answerDelivered = true;
-            await recordPublishStep(pool, {
+            await recordAskPublishStep(pool, {
               workItemId: item.id,
               resourceKey: item.resourceKey,
-              reviewLens: ASK_PUBLISH_LENS,
               step: "ask_reply",
               detail: { replyTargetKind: payload.replyTarget.kind },
             });

--- a/src/agentWork/executors/askExecutor.ts
+++ b/src/agentWork/executors/askExecutor.ts
@@ -5,9 +5,11 @@ import { runAskRun } from "../../agent/askRun.js";
 import { formatAskFailureReply, sanitizeAskAnswerText } from "../../agent/formatAskReply.js";
 import { installationOctokit } from "../../github/appAuth.js";
 import { logWarn } from "../../evlog.js";
+import { ASK_PUBLISH_LENS } from "../../settings/index.js";
 import { withPrRepositoryView } from "../../prWorkspace/index.js";
 import { makeInstallationTokenRefresher, runDurableWorkItem } from "../durableJob.js";
 import { getPullRequestHead, postSlashReply } from "../githubPrSurface.js";
+import { hasCompletedPublishStep, recordPublishStep } from "../repository.js";
 import type { AgentWorkItem, AskJobData, AskWorkPayload } from "../types.js";
 
 async function publishAskAnswer(
@@ -63,6 +65,10 @@ export async function executeAskJob(
       const tokenState = { installation: env.installation };
       const headSha = env.headSha;
       const payload = item.payload as AskWorkPayload;
+      const askReplyPublished = () =>
+        hasCompletedPublishStep(pool, item.id, item.resourceKey, ASK_PUBLISH_LENS, "ask_reply");
+      if (await askReplyPublished()) return {};
+
       return withPrRepositoryView(
         {
           cfg,
@@ -96,13 +102,22 @@ export async function executeAskJob(
               tokenState,
             ),
           });
-          await publishAskAnswer(
-            tokenState.installation.token,
-            tokenState.installation.expiresAtTs,
-            item,
-            result.answer,
-            true,
-          );
+          if (!(await askReplyPublished())) {
+            await publishAskAnswer(
+              tokenState.installation.token,
+              tokenState.installation.expiresAtTs,
+              item,
+              result.answer,
+              true,
+            );
+            await recordPublishStep(pool, {
+              workItemId: item.id,
+              resourceKey: item.resourceKey,
+              reviewLens: ASK_PUBLISH_LENS,
+              step: "ask_reply",
+              detail: { replyTargetKind: payload.replyTarget.kind },
+            });
+          }
           return {};
         },
       );

--- a/src/agentWork/executors/askExecutor.ts
+++ b/src/agentWork/executors/askExecutor.ts
@@ -53,6 +53,7 @@ export async function executeAskJob(
   boss: PgBoss,
   job: JobWithMetadata<AskJobData>,
 ): Promise<void> {
+  let answerDelivered = false;
   await runDurableWorkItem({
     cfg,
     pool,
@@ -67,7 +68,10 @@ export async function executeAskJob(
       const payload = item.payload as AskWorkPayload;
       const askReplyPublished = () =>
         hasCompletedPublishStep(pool, item.id, item.resourceKey, ASK_PUBLISH_LENS, "ask_reply");
-      if (await askReplyPublished()) return {};
+      if (await askReplyPublished()) {
+        answerDelivered = true;
+        return {};
+      }
 
       return withPrRepositoryView(
         {
@@ -110,6 +114,7 @@ export async function executeAskJob(
               result.answer,
               true,
             );
+            answerDelivered = true;
             await recordPublishStep(pool, {
               workItemId: item.id,
               resourceKey: item.resourceKey,
@@ -117,13 +122,15 @@ export async function executeAskJob(
               step: "ask_reply",
               detail: { replyTargetKind: payload.replyTarget.kind },
             });
+          } else {
+            answerDelivered = true;
           }
           return {};
         },
       );
     },
     onTerminalFailure: async (item, installation) => {
-      if (!installation) return;
+      if (!installation || answerDelivered) return;
       const payload = item.payload as AskWorkPayload;
       await publishAskAnswer(
         installation.token,

--- a/src/agentWork/intake/workItemRepository.ts
+++ b/src/agentWork/intake/workItemRepository.ts
@@ -100,11 +100,11 @@ export async function createReviewWorkItem(
   });
   await client.query(
     `INSERT INTO publish_records (id, work_item_id, resource_key, review_lens, step, status)
-		 VALUES ($1, $2, $3, $4, 'progress_comment', 'pending')
-		 ON CONFLICT (resource_key, review_lens, step)
-		 DO UPDATE SET work_item_id = EXCLUDED.work_item_id,
-		               status = 'pending',
-		               updated_at = now()`,
+			 VALUES ($1, $2, $3, $4, 'progress_comment', 'pending')
+			 ON CONFLICT (resource_key, review_lens, step) WHERE review_lens <> 'ask'
+			 DO UPDATE SET work_item_id = EXCLUDED.work_item_id,
+			               status = 'pending',
+			               updated_at = now()`,
     [crypto.randomUUID(), id, resourceKey, params.lens],
   );
   return id;

--- a/src/agentWork/repository.ts
+++ b/src/agentWork/repository.ts
@@ -10,6 +10,7 @@ export type PublishLens =
   | ReviewWorkPayload["mode"]
   | typeof DESCRIPTION_PUBLISH_LENS
   | typeof ASK_PUBLISH_LENS;
+type SharedPublishLens = Exclude<PublishLens, typeof ASK_PUBLISH_LENS>;
 export type PublishStep =
   | "progress_comment"
   | "inline_review"
@@ -17,6 +18,8 @@ export type PublishStep =
   | "labels"
   | "pr_body"
   | "ask_reply";
+type SharedPublishStep = Exclude<PublishStep, "ask_reply">;
+type AskPublishStep = Extract<PublishStep, "ask_reply">;
 
 type AgentWorkRow = {
   id: string;
@@ -481,26 +484,57 @@ export async function recordPublishStep(
   params: {
     workItemId: string;
     resourceKey: string;
-    reviewLens: PublishLens;
-    step: PublishStep;
+    reviewLens: SharedPublishLens;
+    step: SharedPublishStep;
     githubId?: string | number;
     detail?: Record<string, unknown>;
   },
 ): Promise<void> {
   await pool.query(
     `INSERT INTO publish_records (id, work_item_id, resource_key, review_lens, step, github_id, status, detail)
-		 VALUES ($1, $2, $3, $4, $5, $6, 'completed', $7::jsonb)
-		 ON CONFLICT (resource_key, review_lens, step)
-		 DO UPDATE SET work_item_id = EXCLUDED.work_item_id,
-		               github_id = EXCLUDED.github_id,
-		               status = 'completed',
-		               detail = EXCLUDED.detail,
-		               updated_at = now()`,
+			 VALUES ($1, $2, $3, $4, $5, $6, 'completed', $7::jsonb)
+			 ON CONFLICT (resource_key, review_lens, step) WHERE review_lens <> 'ask'
+			 DO UPDATE SET work_item_id = EXCLUDED.work_item_id,
+			               github_id = EXCLUDED.github_id,
+			               status = 'completed',
+			               detail = EXCLUDED.detail,
+			               updated_at = now()`,
     [
       crypto.randomUUID(),
       params.workItemId,
       params.resourceKey,
       params.reviewLens,
+      params.step,
+      params.githubId == null ? null : String(params.githubId),
+      JSON.stringify(params.detail ?? {}),
+    ],
+  );
+}
+
+export async function recordAskPublishStep(
+  pool: Pool,
+  params: {
+    workItemId: string;
+    resourceKey: string;
+    step: AskPublishStep;
+    githubId?: string | number;
+    detail?: Record<string, unknown>;
+  },
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO publish_records (id, work_item_id, resource_key, review_lens, step, github_id, status, detail)
+			 VALUES ($1, $2, $3, $4, $5, $6, 'completed', $7::jsonb)
+			 ON CONFLICT (work_item_id, review_lens, step) WHERE review_lens = 'ask'
+			 DO UPDATE SET resource_key = EXCLUDED.resource_key,
+			               github_id = EXCLUDED.github_id,
+			               status = 'completed',
+			               detail = EXCLUDED.detail,
+			               updated_at = now()`,
+    [
+      crypto.randomUUID(),
+      params.workItemId,
+      params.resourceKey,
+      ASK_PUBLISH_LENS,
       params.step,
       params.githubId == null ? null : String(params.githubId),
       JSON.stringify(params.detail ?? {}),

--- a/src/agentWork/repository.ts
+++ b/src/agentWork/repository.ts
@@ -3,16 +3,20 @@ import type { Pool } from "pg";
 import { queryOne } from "../db/postgres.js";
 import { sanitizeLogMessage } from "../security/sanitizeLogMessage.js";
 import { parseStoredInlineFingerprints } from "../review/reviewFindingFingerprint.js";
-import { DESCRIPTION_PUBLISH_LENS } from "../settings/index.js";
+import { ASK_PUBLISH_LENS, DESCRIPTION_PUBLISH_LENS } from "../settings/index.js";
 import type { AgentWorkItem, AgentWorkItemCore, ReviewWorkPayload, WorkStatus } from "./types.js";
 
-export type PublishLens = ReviewWorkPayload["mode"] | typeof DESCRIPTION_PUBLISH_LENS;
+export type PublishLens =
+  | ReviewWorkPayload["mode"]
+  | typeof DESCRIPTION_PUBLISH_LENS
+  | typeof ASK_PUBLISH_LENS;
 export type PublishStep =
   | "progress_comment"
   | "inline_review"
   | "summary_comment"
   | "labels"
-  | "pr_body";
+  | "pr_body"
+  | "ask_reply";
 
 type AgentWorkRow = {
   id: string;
@@ -256,6 +260,28 @@ export async function hasPriorCompletedSummaryPublish(
 		    AND work_item_id <> $3
 		  LIMIT 1`,
     [resourceKey, reviewLens, excludeWorkItemId],
+  );
+  return row != null;
+}
+
+export async function hasCompletedPublishStep(
+  pool: Pool,
+  workItemId: string,
+  resourceKey: string,
+  reviewLens: PublishLens,
+  step: PublishStep,
+): Promise<boolean> {
+  const row = await queryOne<{ exists: number }>(
+    pool,
+    `SELECT 1 AS exists
+		   FROM publish_records
+		  WHERE work_item_id = $1
+		    AND resource_key = $2
+		    AND review_lens = $3
+		    AND step = $4
+		    AND status = 'completed'
+		  LIMIT 1`,
+    [workItemId, resourceKey, reviewLens, step],
   );
   return row != null;
 }

--- a/src/settings/constants.ts
+++ b/src/settings/constants.ts
@@ -16,6 +16,7 @@ export const AUTOMATED_PR_ACTIONS = new Set(["opened", "synchronize", "reopened"
 export const AUTOMATED_DESCRIPTION_PR_ACTIONS = new Set(["opened"]);
 export const AUTOMATED_REVIEW_LENS = "review" as const;
 export const DESCRIPTION_PUBLISH_LENS = "description" as const;
+export const ASK_PUBLISH_LENS = "ask" as const;
 export const MAX_STORED_COMMENT_TEXT_LEN = 16_384;
 
 /** pi-ai metadata when mapping Cursor.models.list() items. */

--- a/test/askExecutor.test.ts
+++ b/test/askExecutor.test.ts
@@ -7,7 +7,7 @@ import { makeTestConfig } from "./helpers/config.js";
 
 const mocks = vi.hoisted(() => ({
   hasCompletedPublishStep: vi.fn(),
-  recordPublishStep: vi.fn(),
+  recordAskPublishStep: vi.fn(),
   runAskRun: vi.fn(),
   runDurableWorkItem: vi.fn(),
   withPrRepositoryView: vi.fn(),
@@ -16,7 +16,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("../src/agentWork/repository.js", () => ({
   hasCompletedPublishStep: mocks.hasCompletedPublishStep,
-  recordPublishStep: mocks.recordPublishStep,
+  recordAskPublishStep: mocks.recordAskPublishStep,
 }));
 
 vi.mock("../src/agent/askRun.js", () => ({
@@ -139,7 +139,7 @@ describe("executeAskJob", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.hasCompletedPublishStep.mockResolvedValue(false);
-    mocks.recordPublishStep.mockResolvedValue(undefined);
+    mocks.recordAskPublishStep.mockResolvedValue(undefined);
     mocks.runAskRun.mockResolvedValue({ answer: "answer" });
     mocks.postSlashReply.mockResolvedValue(undefined);
     mockDurableExecution();
@@ -159,11 +159,10 @@ describe("executeAskJob", () => {
       "answer",
       1_000_000,
     );
-    expect(mocks.recordPublishStep).toHaveBeenCalledTimes(1);
-    expect(mocks.recordPublishStep).toHaveBeenCalledWith(pool, {
+    expect(mocks.recordAskPublishStep).toHaveBeenCalledTimes(1);
+    expect(mocks.recordAskPublishStep).toHaveBeenCalledWith(pool, {
       workItemId: "wi-1",
       resourceKey: "o/r#1",
-      reviewLens: "ask",
       step: "ask_reply",
       detail: { replyTargetKind: "prConversation" },
     });
@@ -177,11 +176,11 @@ describe("executeAskJob", () => {
     expect(mocks.withPrRepositoryView).not.toHaveBeenCalled();
     expect(mocks.runAskRun).not.toHaveBeenCalled();
     expect(mocks.postSlashReply).not.toHaveBeenCalled();
-    expect(mocks.recordPublishStep).not.toHaveBeenCalled();
+    expect(mocks.recordAskPublishStep).not.toHaveBeenCalled();
   });
 
   it("attempts answer publish again when the publish record is missing after a crash", async () => {
-    mocks.recordPublishStep
+    mocks.recordAskPublishStep
       .mockRejectedValueOnce(new Error("record failed"))
       .mockResolvedValueOnce(undefined);
 
@@ -190,11 +189,11 @@ describe("executeAskJob", () => {
 
     expect(mocks.runAskRun).toHaveBeenCalledTimes(2);
     expect(mocks.postSlashReply).toHaveBeenCalledTimes(2);
-    expect(mocks.recordPublishStep).toHaveBeenCalledTimes(2);
+    expect(mocks.recordAskPublishStep).toHaveBeenCalledTimes(2);
   });
 
   it("skips terminal failure reply after the answer was delivered", async () => {
-    mocks.recordPublishStep.mockRejectedValue(new Error("record failed"));
+    mocks.recordAskPublishStep.mockRejectedValue(new Error("record failed"));
     mocks.runDurableWorkItem.mockImplementation(async (spec: DurableJobSpec) => {
       const item = askItem();
       const installation = {

--- a/test/askExecutor.test.ts
+++ b/test/askExecutor.test.ts
@@ -179,17 +179,26 @@ describe("executeAskJob", () => {
     expect(mocks.recordAskPublishStep).not.toHaveBeenCalled();
   });
 
-  it("attempts answer publish again when the publish record is missing after a crash", async () => {
-    mocks.recordAskPublishStep
-      .mockRejectedValueOnce(new Error("record failed"))
-      .mockResolvedValueOnce(undefined);
+  it("returns degraded when the publish record fails after answer delivery", async () => {
+    let result: unknown;
+    mocks.recordAskPublishStep.mockRejectedValue(new Error("record failed"));
+    mocks.runDurableWorkItem.mockImplementation(async (spec: DurableJobSpec) => {
+      result = await spec.execute(askItem(), {
+        installation: {
+          token: "tok",
+          expiresAtTs: 1_000_000,
+          ttlMs: 60_000,
+        },
+        headSha: "head",
+      });
+    });
 
-    await expect(executeAskJob(cfg, pool, boss, askJob())).rejects.toThrow("record failed");
     await executeAskJob(cfg, pool, boss, askJob());
 
-    expect(mocks.runAskRun).toHaveBeenCalledTimes(2);
-    expect(mocks.postSlashReply).toHaveBeenCalledTimes(2);
-    expect(mocks.recordAskPublishStep).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ degraded: true });
+    expect(mocks.runAskRun).toHaveBeenCalledTimes(1);
+    expect(mocks.postSlashReply).toHaveBeenCalledTimes(1);
+    expect(mocks.recordAskPublishStep).toHaveBeenCalledTimes(1);
   });
 
   it("skips terminal failure reply after the answer was delivered", async () => {
@@ -201,18 +210,14 @@ describe("executeAskJob", () => {
         expiresAtTs: 1_000_000,
         ttlMs: 60_000,
       };
-      try {
-        await spec.execute(item, {
-          installation,
-          headSha: "head",
-        });
-      } catch (error) {
-        await spec.onTerminalFailure?.(item, installation, error);
-        throw error;
-      }
+      await spec.execute(item, {
+        installation,
+        headSha: "head",
+      });
+      await spec.onTerminalFailure?.(item, installation, new Error("complete failed"));
     });
 
-    await expect(executeAskJob(cfg, pool, boss, askJob())).rejects.toThrow("record failed");
+    await executeAskJob(cfg, pool, boss, askJob());
 
     expect(mocks.postSlashReply).toHaveBeenCalledTimes(1);
     expect(mocks.postSlashReply.mock.calls[0]?.[4]).toBe("answer");

--- a/test/askExecutor.test.ts
+++ b/test/askExecutor.test.ts
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Pool } from "pg";
+import type { JobWithMetadata, PgBoss } from "pg-boss";
+import type { DurableJobSpec } from "../src/agentWork/durableJob.js";
+import type { AgentWorkItem, AskJobData } from "../src/agentWork/types.js";
+import { makeTestConfig } from "./helpers/config.js";
+
+const mocks = vi.hoisted(() => ({
+  hasCompletedPublishStep: vi.fn(),
+  recordPublishStep: vi.fn(),
+  runAskRun: vi.fn(),
+  runDurableWorkItem: vi.fn(),
+  withPrRepositoryView: vi.fn(),
+  postSlashReply: vi.fn(),
+}));
+
+vi.mock("../src/agentWork/repository.js", () => ({
+  hasCompletedPublishStep: mocks.hasCompletedPublishStep,
+  recordPublishStep: mocks.recordPublishStep,
+}));
+
+vi.mock("../src/agent/askRun.js", () => ({
+  runAskRun: mocks.runAskRun,
+}));
+
+vi.mock("../src/agentWork/durableJob.js", () => ({
+  makeInstallationTokenRefresher: vi.fn(() => async () => ({
+    token: "tok",
+    expiresAtTs: 1_000_000,
+    ttlMs: 60_000,
+  })),
+  runDurableWorkItem: mocks.runDurableWorkItem,
+}));
+
+vi.mock("../src/prWorkspace/index.js", () => ({
+  withPrRepositoryView: mocks.withPrRepositoryView,
+}));
+
+vi.mock("../src/agentWork/githubPrSurface.js", () => ({
+  getPullRequestHead: vi.fn(async () => ({ headSha: "head" })),
+  postSlashReply: mocks.postSlashReply,
+}));
+
+vi.mock("../src/github/appAuth.js", () => ({
+  installationOctokit: vi.fn(() => ({
+    rest: {
+      issues: { createComment: vi.fn() },
+    },
+  })),
+}));
+
+vi.mock("../src/evlog.js", () => ({
+  logWarn: vi.fn(),
+}));
+
+import { executeAskJob } from "../src/agentWork/executors/askExecutor.js";
+
+const cfg = makeTestConfig({ piModel: "test" });
+const pool = {} as Pool;
+const boss = {} as PgBoss;
+
+function askItem(): AgentWorkItem {
+  return {
+    id: "wi-1",
+    webhookEventId: "ev-1",
+    type: "ask",
+    source: "slash",
+    status: "running",
+    owner: "o",
+    repo: "r",
+    prNumber: 1,
+    installationId: 42,
+    headSha: "head",
+    reviewLens: null,
+    resourceKey: "o/r#1",
+    attemptCount: 0,
+    payload: {
+      question: "what changed?",
+      replyTarget: { kind: "prConversation", prNumber: 1 },
+      commentId: 99,
+    },
+    cancelRequestedAt: null,
+  };
+}
+
+function askJob(): JobWithMetadata<AskJobData> {
+  const now = new Date();
+  return {
+    id: "job-1",
+    name: "agent-work-ask",
+    data: { kind: "ask", workItemId: "wi-1" },
+    expireInSeconds: 3600,
+    heartbeatSeconds: null,
+    signal: new AbortController().signal,
+    priority: 0,
+    state: "active",
+    retryLimit: 3,
+    retryCount: 0,
+    retryDelay: 0,
+    retryBackoff: false,
+    startAfter: now,
+    startedOn: now,
+    singletonKey: null,
+    singletonOn: null,
+    deleteAfterSeconds: 0,
+    createdOn: now,
+    completedOn: null,
+    keepUntil: now,
+    policy: "standard",
+    heartbeatOn: null,
+    deadLetter: "",
+    output: {},
+  };
+}
+
+function mockDurableExecution(): void {
+  mocks.runDurableWorkItem.mockImplementation(async (spec: DurableJobSpec) => {
+    await spec.execute(askItem(), {
+      installation: {
+        token: "tok",
+        expiresAtTs: 1_000_000,
+        ttlMs: 60_000,
+      },
+      headSha: "head",
+    });
+  });
+}
+
+function mockRepositoryView(): void {
+  mocks.withPrRepositoryView.mockImplementation(async (_params, run) =>
+    run({
+      agentCwd: "/tmp/pr-agent",
+      workspace: undefined,
+    }),
+  );
+}
+
+describe("executeAskJob", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.hasCompletedPublishStep.mockResolvedValue(false);
+    mocks.recordPublishStep.mockResolvedValue(undefined);
+    mocks.runAskRun.mockResolvedValue({ answer: "answer" });
+    mocks.postSlashReply.mockResolvedValue(undefined);
+    mockDurableExecution();
+    mockRepositoryView();
+  });
+
+  it("runs the agent and records first answer publish", async () => {
+    await executeAskJob(cfg, pool, boss, askJob());
+
+    expect(mocks.runAskRun).toHaveBeenCalledTimes(1);
+    expect(mocks.postSlashReply).toHaveBeenCalledTimes(1);
+    expect(mocks.postSlashReply).toHaveBeenCalledWith(
+      "tok",
+      "o",
+      "r",
+      { kind: "prConversation", prNumber: 1 },
+      "answer",
+      1_000_000,
+    );
+    expect(mocks.recordPublishStep).toHaveBeenCalledTimes(1);
+    expect(mocks.recordPublishStep).toHaveBeenCalledWith(pool, {
+      workItemId: "wi-1",
+      resourceKey: "o/r#1",
+      reviewLens: "ask",
+      step: "ask_reply",
+      detail: { replyTargetKind: "prConversation" },
+    });
+  });
+
+  it("skips agent and answer publish when the ask reply was already recorded", async () => {
+    mocks.hasCompletedPublishStep.mockResolvedValue(true);
+
+    await executeAskJob(cfg, pool, boss, askJob());
+
+    expect(mocks.withPrRepositoryView).not.toHaveBeenCalled();
+    expect(mocks.runAskRun).not.toHaveBeenCalled();
+    expect(mocks.postSlashReply).not.toHaveBeenCalled();
+    expect(mocks.recordPublishStep).not.toHaveBeenCalled();
+  });
+
+  it("attempts answer publish again when the publish record is missing after a crash", async () => {
+    mocks.recordPublishStep
+      .mockRejectedValueOnce(new Error("record failed"))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(executeAskJob(cfg, pool, boss, askJob())).rejects.toThrow("record failed");
+    await executeAskJob(cfg, pool, boss, askJob());
+
+    expect(mocks.runAskRun).toHaveBeenCalledTimes(2);
+    expect(mocks.postSlashReply).toHaveBeenCalledTimes(2);
+    expect(mocks.recordPublishStep).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test/askExecutor.test.ts
+++ b/test/askExecutor.test.ts
@@ -192,4 +192,30 @@ describe("executeAskJob", () => {
     expect(mocks.postSlashReply).toHaveBeenCalledTimes(2);
     expect(mocks.recordPublishStep).toHaveBeenCalledTimes(2);
   });
+
+  it("skips terminal failure reply after the answer was delivered", async () => {
+    mocks.recordPublishStep.mockRejectedValue(new Error("record failed"));
+    mocks.runDurableWorkItem.mockImplementation(async (spec: DurableJobSpec) => {
+      const item = askItem();
+      const installation = {
+        token: "tok",
+        expiresAtTs: 1_000_000,
+        ttlMs: 60_000,
+      };
+      try {
+        await spec.execute(item, {
+          installation,
+          headSha: "head",
+        });
+      } catch (error) {
+        await spec.onTerminalFailure?.(item, installation, error);
+        throw error;
+      }
+    });
+
+    await expect(executeAskJob(cfg, pool, boss, askJob())).rejects.toThrow("record failed");
+
+    expect(mocks.postSlashReply).toHaveBeenCalledTimes(1);
+    expect(mocks.postSlashReply.mock.calls[0]?.[4]).toBe("answer");
+  });
 });

--- a/test/integration/agentWorkRepository.integration.test.ts
+++ b/test/integration/agentWorkRepository.integration.test.ts
@@ -5,9 +5,11 @@ import { runMigrations } from "../../src/db/migrations.js";
 import {
   claimWorkForExecution,
   forceMarkRescheduledParentCompleted,
+  hasCompletedPublishStep,
   markWorkCancelled,
   markWorkCompleted,
   markWorkRetrying,
+  recordAskPublishStep,
 } from "../../src/agentWork/repository.js";
 import type { WorkStatus } from "../../src/agentWork/types.js";
 import { hasDatabase, integrationPool } from "./db.js";
@@ -62,6 +64,29 @@ describe.skipIf(!hasDatabase)("agent work repository (integration)", () => {
         input.attemptCount ?? 0,
         input.cancelRequestedAt ?? null,
         JSON.stringify(input.payload ?? {}),
+      ],
+    );
+    return id;
+  }
+
+  async function insertAskWorkItem(resourceKey: string): Promise<string> {
+    const id = randomUUID();
+    await pool.query(
+      `INSERT INTO agent_work_items (
+         id, type, source, status, owner, repo, pr_number, installation_id,
+         head_sha, resource_key, payload
+       )
+       VALUES ($1, 'ask', 'slash', 'queued', $2, 'r', 1, 1, 'h', $3, $4::jsonb)`,
+      [
+        id,
+        OWNER,
+        resourceKey,
+        JSON.stringify({
+          question: "what changed?",
+          replyTarget: { kind: "prConversation", prNumber: 1 },
+          commentId: 99,
+          commenterId: 123,
+        }),
       ],
     );
     return id;
@@ -173,5 +198,42 @@ describe.skipIf(!hasDatabase)("agent work repository (integration)", () => {
       status: "running",
       attempt_count: 1,
     });
+  });
+
+  it("keeps ask publish records separate per work item", async () => {
+    const resourceKey = "repo-it-shared-ask";
+    const first = await insertAskWorkItem(resourceKey);
+    const second = await insertAskWorkItem(resourceKey);
+
+    await recordAskPublishStep(pool, {
+      workItemId: first,
+      resourceKey,
+      step: "ask_reply",
+      detail: { replyTargetKind: "prConversation" },
+    });
+    await recordAskPublishStep(pool, {
+      workItemId: second,
+      resourceKey,
+      step: "ask_reply",
+      detail: { replyTargetKind: "prConversation" },
+    });
+
+    await expect(
+      hasCompletedPublishStep(pool, first, resourceKey, "ask", "ask_reply"),
+    ).resolves.toBe(true);
+    await expect(
+      hasCompletedPublishStep(pool, second, resourceKey, "ask", "ask_reply"),
+    ).resolves.toBe(true);
+
+    const { rows } = await pool.query<{ work_item_id: string }>(
+      `SELECT work_item_id
+         FROM publish_records
+        WHERE resource_key = $1
+          AND review_lens = 'ask'
+          AND step = 'ask_reply'
+          AND status = 'completed'`,
+      [resourceKey],
+    );
+    expect(rows.map((row) => row.work_item_id).toSorted()).toEqual([first, second].toSorted());
   });
 });

--- a/test/integration/migrations.integration.test.ts
+++ b/test/integration/migrations.integration.test.ts
@@ -50,9 +50,10 @@ describe.skipIf(!hasDatabase)("migrations (integration)", () => {
     const publishIndexes = await pool.query<{ indexname: string }>(
       "SELECT indexname FROM pg_indexes WHERE tablename = 'publish_records'",
     );
-    expect(publishIndexes.rows.map((r) => r.indexname)).toContain(
-      "publish_records_work_item_id_idx",
-    );
+    const publishIndexNames = publishIndexes.rows.map((r) => r.indexname);
+    expect(publishIndexNames).toContain("publish_records_work_item_id_idx");
+    expect(publishIndexNames).toContain("publish_records_unique_shared_step_idx");
+    expect(publishIndexNames).toContain("publish_records_unique_ask_work_item_step_idx");
   });
 
   it("is idempotent under concurrent runs (advisory lock)", async () => {

--- a/test/integration/migrations.integration.test.ts
+++ b/test/integration/migrations.integration.test.ts
@@ -10,6 +10,7 @@ const EXPECTED_MIGRATIONS = [
   "004_indexes.sql",
   "005_retention_indexes.sql",
   "006_retention_fk_indexes.sql",
+  "007_ask_publish_records.sql",
 ];
 
 describe.skipIf(!hasDatabase)("migrations (integration)", () => {


### PR DESCRIPTION
Makes `/ask` reply publishing durable and per-work-item so pg-boss retries do not duplicate answers.

- Adds an `ask` publish lens and `ask_reply` publish step.
- Stores ask publish records per `work_item_id`, while preserving shared uniqueness for review publish steps.
- Skips re-running the ask agent when the ask reply was already recorded.
- Re-checks before publishing, suppresses failure replies after delivery, and degrades if bookkeeping fails after a GitHub reply.

Verified with `pnpm typecheck`, `pnpm lint`, `pnpm test -- askExecutor`, `pnpm test`, and `pnpm fmt:check`.

Closes #91.
