### PR TITLE
Prevent duplicate summary comments when ack and review publish concurrently

### DIFF
--- a/migrations/009_summary_comment_claim.sql
+++ b/migrations/009_summary_comment_claim.sql
@@ -1,0 +1,11 @@
+ALTER TABLE publish_records DROP CONSTRAINT IF EXISTS publish_records_step_check;
+ALTER TABLE publish_records ADD CONSTRAINT publish_records_step_check
+  CHECK (step IN (
+    'progress_comment',
+    'inline_review',
+    'summary_comment',
+    'summary_comment_claim',
+    'labels',
+    'pr_body',
+    'ask_reply'
+  ));

--- a/src/agentWork/executors/ackExecutor.ts
+++ b/src/agentWork/executors/ackExecutor.ts
@@ -3,6 +3,7 @@ import type { Config } from "../../config.js";
 import { upsertReviewSummaryComment } from "../../github/reviewPublish.js";
 import { logDebug, logWarn } from "../../evlog.js";
 import { reviewSummarySentinelForMode } from "../../review/reviewSchema.js";
+import { upsertSummaryCommentWithCreationClaim } from "../../review/publish/publishReview.js";
 import { DEFERRED_HEAD_SHA } from "../../settings/index.js";
 import { mintInstallationToken } from "../durableJob.js";
 import { recordPublishStep } from "../repository.js";
@@ -66,16 +67,32 @@ export async function executeAckJob(cfg: Config, pool: Pool, data: AckJobData): 
       headSha,
       source: data.progress.source,
     });
-    const summary = await upsertReviewSummaryComment(
-      installation.token,
-      data.owner,
-      data.repo,
-      data.prNumber,
-      body,
-      reviewSummarySentinelForMode(data.progress.lens),
-      undefined,
-      installation.expiresAtTs,
-    );
+    const resourceKey = `${data.owner}/${data.repo}#${data.prNumber}`;
+    const sentinel = reviewSummarySentinelForMode(data.progress.lens);
+    const summary = data.workItemId
+      ? await upsertSummaryCommentWithCreationClaim({
+          pool,
+          workItemId: data.workItemId,
+          resourceKey,
+          reviewLens: data.progress.lens,
+          token: installation.token,
+          owner: data.owner,
+          repo: data.repo,
+          prNumber: data.prNumber,
+          body,
+          sentinel,
+          expiresAtTs: installation.expiresAtTs,
+        })
+      : await upsertReviewSummaryComment(
+          installation.token,
+          data.owner,
+          data.repo,
+          data.prNumber,
+          body,
+          sentinel,
+          undefined,
+          installation.expiresAtTs,
+        );
     if (data.workItemId) {
       await recordPublishStep(pool, {
         workItemId: data.workItemId,

--- a/src/agentWork/executors/reviewExecutor.ts
+++ b/src/agentWork/executors/reviewExecutor.ts
@@ -24,6 +24,7 @@ import {
 } from "../../review/reviewRunMetrics.js";
 import { upsertReviewSummaryComment } from "../../github/reviewPublish.js";
 import { logInfo, logWarn } from "../../evlog.js";
+import { attachSummaryCommentCoordination } from "../../review/publish/publishReview.js";
 import { withPrRepositoryView } from "../../prWorkspace/index.js";
 import { tryLightweightAutoReviewCompletion } from "../reviewLightweightCompletion.js";
 import {
@@ -207,15 +208,18 @@ export async function executeReviewJob(
               published: publishState.summaryPublished,
               inlineReviewId: publishState.inlineReviewId,
             },
-            recordPublishStep: (step, detail) =>
-              recordPublishStep(pool, {
-                workItemId: item.id,
-                resourceKey: item.resourceKey,
-                reviewLens,
-                step,
-                githubId: detail?.githubId,
-                detail: detail?.meta,
-              }),
+            recordPublishStep: attachSummaryCommentCoordination(
+              (step, detail) =>
+                recordPublishStep(pool, {
+                  workItemId: item.id,
+                  resourceKey: item.resourceKey,
+                  reviewLens,
+                  step,
+                  githubId: detail?.githubId,
+                  detail: detail?.meta,
+                }),
+              { pool, workItemId: item.id, resourceKey: item.resourceKey },
+            ),
             reviewSource: payload.source,
             staleHeadRescheduled: payload.staleHeadRescheduled,
             publishAbortState,

--- a/src/agentWork/repository.ts
+++ b/src/agentWork/repository.ts
@@ -15,6 +15,7 @@ export type PublishStep =
   | "progress_comment"
   | "inline_review"
   | "summary_comment"
+  | "summary_comment_claim"
   | "labels"
   | "pr_body"
   | "ask_reply";
@@ -287,6 +288,23 @@ export async function hasCompletedPublishStep(
     [workItemId, resourceKey, reviewLens, step],
   );
   return row != null;
+}
+
+/** Returns true exactly once per (resourceKey, lens) until the claim row is deleted. */
+export async function claimSummaryCommentCreation(
+  pool: Pool,
+  workItemId: string,
+  resourceKey: string,
+  reviewLens: ReviewWorkPayload["mode"],
+): Promise<boolean> {
+  const result = await pool.query(
+    `INSERT INTO publish_records (id, work_item_id, resource_key, review_lens, step, status, detail)
+     VALUES ($1, $2, $3, $4, 'summary_comment_claim', 'completed', '{}'::jsonb)
+     ON CONFLICT (resource_key, review_lens, step) WHERE review_lens <> 'ask'
+     DO NOTHING`,
+    [crypto.randomUUID(), workItemId, resourceKey, reviewLens],
+  );
+  return (result.rowCount ?? 0) > 0;
 }
 
 export async function getSummaryCommentGithubId(

--- a/src/review/publish/publishReview.ts
+++ b/src/review/publish/publishReview.ts
@@ -1,15 +1,24 @@
 import type { Config } from "../../config.js";
+import type { Pool } from "pg";
 import { enrichPlacementsWithInlineCommentUrls } from "./placementEnrichment.js";
 import {
+  findIssueCommentBySentinel,
   listPullRequestLabels,
   listPullRequestReviewCommentsForReview,
   resolveVerifiedSummaryCommentRef,
   setPullRequestLabels,
   upsertReviewSummaryComment,
 } from "../../github/reviewPublish.js";
+import {
+  claimSummaryCommentCreation,
+  getSummaryCommentGithubId,
+} from "../../agentWork/repository.js";
 import { labelsAlreadySynced, reviewLabelsFromPayload, syncReviewLabels } from "../reviewLabels.js";
 import { logWarn, logDebug } from "../../evlog.js";
-import { MAX_INLINE_REVIEW_COMMENTS } from "../../settings/index.js";
+import {
+  MAX_INLINE_REVIEW_COMMENTS,
+  REVIEW_PUBLISH_TRANSIENT_RETRY_DELAYS_MS,
+} from "../../settings/index.js";
 import { renderReviewSummaryComment } from "../reviewRender.js";
 import {
   applyInlineCommentCap,
@@ -34,6 +43,191 @@ import {
 } from "../reviewSchema.js";
 import type { SubmitReviewState } from "./submitReviewTool.js";
 
+export type SummaryCommentCoordination = {
+  pool: Pool;
+  workItemId: string;
+  resourceKey: string;
+};
+
+export type RecordPublishStepFn = (
+  step: "inline_review" | "summary_comment" | "labels",
+  detail?: { githubId?: string | number; meta?: Record<string, unknown> },
+) => Promise<void>;
+
+export type RecordPublishStepWithCoordination = RecordPublishStepFn & {
+  summaryCommentCoordination?: SummaryCommentCoordination;
+};
+
+export function attachSummaryCommentCoordination(
+  recordPublishStep: RecordPublishStepFn,
+  coordination: SummaryCommentCoordination,
+): RecordPublishStepWithCoordination {
+  const wrapped = recordPublishStep as RecordPublishStepWithCoordination;
+  wrapped.summaryCommentCoordination = coordination;
+  return wrapped;
+}
+
+function sleepMs(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function resolveKnownSummaryCommentRef(
+  token: string,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  sentinel: string,
+  hintCommentId: number | null | undefined,
+  expiresAtTs?: number,
+): Promise<{ id: number; url: string } | null> {
+  const resolved =
+    expiresAtTs == null
+      ? await resolveVerifiedSummaryCommentRef(
+          token,
+          owner,
+          repo,
+          prNumber,
+          sentinel,
+          hintCommentId,
+        )
+      : await resolveVerifiedSummaryCommentRef(
+          token,
+          owner,
+          repo,
+          prNumber,
+          sentinel,
+          hintCommentId,
+          expiresAtTs,
+        );
+  return resolved ? { id: resolved.id, url: resolved.url } : null;
+}
+
+export async function upsertSummaryCommentWithCreationClaim(params: {
+  pool: Pool;
+  workItemId: string;
+  resourceKey: string;
+  reviewLens: ReviewMode;
+  token: string;
+  owner: string;
+  repo: string;
+  prNumber: number;
+  body: string;
+  sentinel: string;
+  expiresAtTs?: number;
+  hintCommentId?: number | null;
+}): Promise<{ id: number; updated: boolean }> {
+  const {
+    pool,
+    workItemId,
+    resourceKey,
+    reviewLens,
+    token,
+    owner,
+    repo,
+    prNumber,
+    body,
+    sentinel,
+    expiresAtTs,
+  } = params;
+
+  const storedId = await getSummaryCommentGithubId(pool, resourceKey, reviewLens);
+  const hintId = params.hintCommentId ?? storedId ?? null;
+  const knownFromStored = await resolveKnownSummaryCommentRef(
+    token,
+    owner,
+    repo,
+    prNumber,
+    sentinel,
+    hintId,
+    expiresAtTs,
+  );
+  if (knownFromStored) {
+    return upsertReviewSummaryComment(
+      token,
+      owner,
+      repo,
+      prNumber,
+      body,
+      sentinel,
+      knownFromStored,
+      expiresAtTs,
+    );
+  }
+
+  const claimWon = await claimSummaryCommentCreation(pool, workItemId, resourceKey, reviewLens);
+  if (claimWon) {
+    const scanned = await findIssueCommentBySentinel(
+      token,
+      owner,
+      repo,
+      prNumber,
+      sentinel,
+      expiresAtTs,
+    );
+    return upsertReviewSummaryComment(
+      token,
+      owner,
+      repo,
+      prNumber,
+      body,
+      sentinel,
+      scanned,
+      expiresAtTs,
+    );
+  }
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    if (attempt > 0) {
+      const delay =
+        REVIEW_PUBLISH_TRANSIENT_RETRY_DELAYS_MS[attempt - 1] ??
+        REVIEW_PUBLISH_TRANSIENT_RETRY_DELAYS_MS.at(-1)!;
+      await sleepMs(delay);
+    }
+    const polledId = await getSummaryCommentGithubId(pool, resourceKey, reviewLens);
+    if (polledId == null) continue;
+    const knownFromPoll = await resolveKnownSummaryCommentRef(
+      token,
+      owner,
+      repo,
+      prNumber,
+      sentinel,
+      polledId,
+      expiresAtTs,
+    );
+    if (knownFromPoll) {
+      return upsertReviewSummaryComment(
+        token,
+        owner,
+        repo,
+        prNumber,
+        body,
+        sentinel,
+        knownFromPoll,
+        expiresAtTs,
+      );
+    }
+  }
+
+  const scanned = await findIssueCommentBySentinel(
+    token,
+    owner,
+    repo,
+    prNumber,
+    sentinel,
+    expiresAtTs,
+  );
+  return upsertReviewSummaryComment(
+    token,
+    owner,
+    repo,
+    prNumber,
+    body,
+    sentinel,
+    scanned,
+    expiresAtTs,
+  );
+}
+
 export async function publishReview(
   params: ReviewPublishContext & {
     token: string;
@@ -48,10 +242,7 @@ export async function publishReview(
     shouldLinkToSummary?: boolean;
     summaryCommentIdHint?: number | null;
     staleReview?: boolean;
-    recordPublishStep?: (
-      step: "inline_review" | "summary_comment" | "labels",
-      detail?: { githubId?: string | number; meta?: Record<string, unknown> },
-    ) => Promise<void>;
+    recordPublishStep?: RecordPublishStepWithCoordination;
     storedInlineFingerprints?: readonly string[];
     /** Reuse placements already computed during prepare; recomputed when omitted. */
     inlinePlacements?: readonly InlinePlacement[];
@@ -213,7 +404,21 @@ export async function publishReview(
   }
 
   let summaryUpsert: Promise<{ id: number; updated: boolean }>;
-  if (knownSummaryCommentRef != null) {
+  const summaryCoordination = params.recordPublishStep?.summaryCommentCoordination;
+  if (summaryCoordination) {
+    summaryUpsert = upsertSummaryCommentWithCreationClaim({
+      ...summaryCoordination,
+      reviewLens: mode,
+      token,
+      owner,
+      repo,
+      prNumber,
+      body: summaryBody,
+      sentinel: summarySentinel,
+      expiresAtTs: tokenExpiresAtTs,
+      hintCommentId: params.summaryCommentIdHint ?? knownSummaryCommentRef?.id,
+    });
+  } else if (knownSummaryCommentRef != null) {
     summaryUpsert =
       tokenExpiresAtTs == null
         ? upsertReviewSummaryComment(

--- a/test/ackExecutor.test.ts
+++ b/test/ackExecutor.test.ts
@@ -25,9 +25,20 @@ vi.mock("../src/github/reviewPublish.js", () => ({
 
 vi.mock("../src/agentWork/repository.js", () => ({
   recordPublishStep: vi.fn(),
+  claimSummaryCommentCreation: vi.fn(async () => true),
 }));
 
+vi.mock("../src/review/publish/publishReview.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/review/publish/publishReview.js")>();
+  return {
+    ...actual,
+    upsertSummaryCommentWithCreationClaim: vi.fn(async () => ({ id: 42, updated: false })),
+  };
+});
+
 import { safeReaction } from "../src/agentWork/githubPrSurface.js";
+import { upsertSummaryCommentWithCreationClaim } from "../src/review/publish/publishReview.js";
+import { recordPublishStep } from "../src/agentWork/repository.js";
 
 const cfg = {} as Config;
 const pool = {} as Pool;
@@ -62,5 +73,30 @@ describe("executeAckJob", () => {
 
     expect(safeReaction).toHaveBeenCalledTimes(3);
     expect(vi.mocked(safeReaction).mock.calls.map((call) => call[3])).toEqual(ackData().targets);
+  });
+
+  it("uses coordinated summary upsert for progress with work item id", async () => {
+    await executeAckJob(cfg, pool, {
+      ...ackData(),
+      workItemId: "wi-1",
+      progress: { lens: "review", headSha: "sha", source: "auto" },
+    });
+
+    expect(upsertSummaryCommentWithCreationClaim).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pool,
+        workItemId: "wi-1",
+        resourceKey: "o/r#1",
+        reviewLens: "review",
+      }),
+    );
+    expect(recordPublishStep).toHaveBeenCalledWith(
+      pool,
+      expect.objectContaining({
+        workItemId: "wi-1",
+        step: "progress_comment",
+        githubId: 42,
+      }),
+    );
   });
 });

--- a/test/publishReview.test.ts
+++ b/test/publishReview.test.ts
@@ -39,20 +39,35 @@ vi.mock("../src/github/reviewPublish.js", async (importOriginal) => {
       },
     ]),
     resolveVerifiedSummaryCommentRef: vi.fn(async () => null),
+    findIssueCommentBySentinel: vi.fn(async () => null),
     upsertReviewSummaryComment: vi.fn(async () => ({ id: 2, updated: false })),
     listPullRequestLabels: vi.fn(async () => []),
     setPullRequestLabels: vi.fn(async () => undefined),
   };
 });
 
+vi.mock("../src/agentWork/repository.js", () => ({
+  claimSummaryCommentCreation: vi.fn(async () => true),
+  getSummaryCommentGithubId: vi.fn(async () => null),
+}));
+
 import {
   createPullRequestReviewWithComments,
+  findIssueCommentBySentinel,
   listPullRequestLabels,
   listPullRequestReviewCommentsForReview,
   resolveVerifiedSummaryCommentRef,
   setPullRequestLabels,
   upsertReviewSummaryComment,
 } from "../src/github/reviewPublish.js";
+import {
+  attachSummaryCommentCoordination,
+  upsertSummaryCommentWithCreationClaim,
+} from "../src/review/publish/publishReview.js";
+import {
+  claimSummaryCommentCreation,
+  getSummaryCommentGithubId,
+} from "../src/agentWork/repository.js";
 
 const payload: ReviewPayload = {
   prCharacter: "Test PR.",
@@ -650,5 +665,164 @@ describe("publishReview", () => {
     expect(summaryBody).toContain("Summary only");
     expect(summaryBody).not.toContain("Inline thread posted");
     expect(publishState.inlinePublished).toBe(true);
+  });
+});
+
+const pool = {} as import("pg").Pool;
+const claimBase = {
+  pool,
+  workItemId: "wi-1",
+  resourceKey: "o/r#1",
+  reviewLens: "review" as const,
+  token: "t",
+  owner: "o",
+  repo: "r",
+  prNumber: 1,
+  body: "summary body",
+  sentinel: REVIEW_SUMMARY_SENTINEL,
+};
+
+describe("upsertSummaryCommentWithCreationClaim", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getSummaryCommentGithubId).mockResolvedValue(null);
+    vi.mocked(claimSummaryCommentCreation).mockResolvedValue(true);
+    vi.mocked(resolveVerifiedSummaryCommentRef).mockResolvedValue(null);
+    vi.mocked(findIssueCommentBySentinel).mockResolvedValue(null);
+    vi.mocked(upsertReviewSummaryComment).mockResolvedValue({ id: 99, updated: false });
+  });
+
+  it("creates when claim won and no stored id", async () => {
+    await upsertSummaryCommentWithCreationClaim(claimBase);
+
+    expect(claimSummaryCommentCreation).toHaveBeenCalledWith(pool, "wi-1", "o/r#1", "review");
+    expect(findIssueCommentBySentinel).toHaveBeenCalled();
+    expect(upsertReviewSummaryComment).toHaveBeenCalledWith(
+      "t",
+      "o",
+      "r",
+      1,
+      "summary body",
+      REVIEW_SUMMARY_SENTINEL,
+      null,
+      undefined,
+    );
+  });
+
+  it("uses stored id without scanning when verified", async () => {
+    vi.mocked(getSummaryCommentGithubId).mockResolvedValue(55);
+    vi.mocked(resolveVerifiedSummaryCommentRef).mockResolvedValue({
+      id: 55,
+      url: "https://example.com/55",
+      source: "hint",
+    });
+
+    await upsertSummaryCommentWithCreationClaim(claimBase);
+
+    expect(claimSummaryCommentCreation).not.toHaveBeenCalled();
+    expect(findIssueCommentBySentinel).not.toHaveBeenCalled();
+    expect(upsertReviewSummaryComment).toHaveBeenCalledWith(
+      "t",
+      "o",
+      "r",
+      1,
+      "summary body",
+      REVIEW_SUMMARY_SENTINEL,
+      { id: 55, url: "https://example.com/55" },
+      undefined,
+    );
+  });
+
+  it("updates polled id when claim lost", async () => {
+    vi.useFakeTimers();
+    vi.mocked(claimSummaryCommentCreation).mockResolvedValue(false);
+    vi.mocked(getSummaryCommentGithubId).mockResolvedValueOnce(null).mockResolvedValueOnce(77);
+    vi.mocked(resolveVerifiedSummaryCommentRef).mockResolvedValue({
+      id: 77,
+      url: "https://example.com/77",
+      source: "hint",
+    });
+
+    const pending = upsertSummaryCommentWithCreationClaim(claimBase);
+    await vi.advanceTimersByTimeAsync(1_500);
+    await pending;
+
+    expect(getSummaryCommentGithubId).toHaveBeenCalled();
+    expect(findIssueCommentBySentinel).not.toHaveBeenCalled();
+    expect(upsertReviewSummaryComment).toHaveBeenCalledWith(
+      "t",
+      "o",
+      "r",
+      1,
+      "summary body",
+      REVIEW_SUMMARY_SENTINEL,
+      { id: 77, url: "https://example.com/77" },
+      undefined,
+    );
+    vi.useRealTimers();
+  });
+
+  it("creates as last resort when claim lost and poll misses", async () => {
+    vi.useFakeTimers();
+    vi.mocked(claimSummaryCommentCreation).mockResolvedValue(false);
+    vi.mocked(findIssueCommentBySentinel).mockResolvedValue(null);
+
+    const pending = upsertSummaryCommentWithCreationClaim(claimBase);
+    await vi.advanceTimersByTimeAsync(10_000);
+    await pending;
+
+    expect(findIssueCommentBySentinel).toHaveBeenCalled();
+    expect(upsertReviewSummaryComment).toHaveBeenCalledWith(
+      "t",
+      "o",
+      "r",
+      1,
+      "summary body",
+      REVIEW_SUMMARY_SENTINEL,
+      null,
+      undefined,
+    );
+    vi.useRealTimers();
+  });
+});
+
+describe("publishReview summary coordination", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getSummaryCommentGithubId).mockResolvedValue(88);
+    vi.mocked(claimSummaryCommentCreation).mockResolvedValue(true);
+    vi.mocked(resolveVerifiedSummaryCommentRef).mockResolvedValue({
+      id: 88,
+      url: "https://example.com/88",
+      source: "hint",
+    });
+    vi.mocked(upsertReviewSummaryComment).mockResolvedValue({ id: 88, updated: true });
+  });
+
+  it("uses stored progress id without sentinel scan", async () => {
+    const recordPublishStep = attachSummaryCommentCoordination(vi.fn(), {
+      pool,
+      workItemId: "wi-1",
+      resourceKey: "o/r#1",
+    });
+
+    await publishReviewForTest({
+      ...baseParams,
+      publishState: testPublishState(),
+      cachedDiffIndex: cachedDiffForLines("src/x.ts", [4]),
+      recordPublishStep,
+    });
+
+    expect(findIssueCommentBySentinel).not.toHaveBeenCalled();
+    expect(upsertReviewSummaryComment).toHaveBeenCalledWith(
+      "t",
+      "o",
+      "r",
+      1,
+      expect.any(String),
+      REVIEW_SUMMARY_SENTINEL,
+      { id: 88, url: "https://example.com/88" },
+      undefined,
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Add a `summary_comment_claim` publish record so only one worker may create the sentinel-keyed summary comment on first publish.
- Wire ack and review publishers to prefer stored comment ids, then claim, poll, and scan before creating.
- Extend tests for claim-won, stored-id reuse, claim-lost polling, and last-resort create paths.

Closes #94 