### PR TITLE
Pin intake transaction and singleton visibility semantics

### DIFF
--- a/test/integration/intakeTransaction.integration.test.ts
+++ b/test/integration/intakeTransaction.integration.test.ts
@@ -1,0 +1,387 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { Pool } from "pg";
+import type { PgBoss, SendOptions } from "pg-boss";
+import { applyAutomatedPullRequestIntake } from "../../src/agentWork/intake/applier.js";
+import { createStartedBoss, ensureAgentQueues, stopBoss } from "../../src/agentWork/boss.js";
+import type { PrRef, QueueConfig, WebhookHeaders } from "../../src/agentWork/types.js";
+import { prResourceKey, reviewSingletonKey } from "../../src/agentWork/types.js";
+import { runMigrations } from "../../src/db/migrations.js";
+import { createOperationLogger } from "../../src/evlog.js";
+import {
+  ACK_QUEUE,
+  AUTOMATED_REVIEW_LENS,
+  DEFAULT_INSTALLATION_GROUP_CONCURRENCY,
+  DEFAULT_QUEUE_DELETE_AFTER_SECONDS,
+  DEFAULT_QUEUE_EXPIRE_IN_SECONDS,
+  DEFAULT_QUEUE_HEARTBEAT_SECONDS,
+  DEFAULT_QUEUE_POLLING_INTERVAL_SECONDS,
+  DEFAULT_QUEUE_RETENTION_SECONDS,
+  DEFAULT_QUEUE_RETRY_DELAY_MAX_SECONDS,
+  DEFAULT_QUEUE_RETRY_DELAY_SECONDS,
+  DEFAULT_QUEUE_RETRY_LIMIT,
+  DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_SECONDS,
+  REVIEW_QUEUE,
+} from "../../src/settings/index.js";
+import { hasDatabase, integrationPool } from "./db.js";
+
+const OWNER = "intake-tx-it";
+const EVENT = "intake-tx-it";
+const DATABASE_URL = process.env.DATABASE_URL!;
+const CLEANUP_QUEUES = [ACK_QUEUE, REVIEW_QUEUE] as const;
+
+const queueConfig: QueueConfig = {
+  queueRetryLimit: DEFAULT_QUEUE_RETRY_LIMIT,
+  queueRetryDelaySeconds: DEFAULT_QUEUE_RETRY_DELAY_SECONDS,
+  queueRetryDelayMaxSeconds: DEFAULT_QUEUE_RETRY_DELAY_MAX_SECONDS,
+  queueExpireInSeconds: DEFAULT_QUEUE_EXPIRE_IN_SECONDS,
+  queueHeartbeatSeconds: DEFAULT_QUEUE_HEARTBEAT_SECONDS,
+  queuePollingIntervalSeconds: DEFAULT_QUEUE_POLLING_INTERVAL_SECONDS,
+  queueRetentionSeconds: DEFAULT_QUEUE_RETENTION_SECONDS,
+  queueDeleteAfterSeconds: DEFAULT_QUEUE_DELETE_AFTER_SECONDS,
+  installationGroupConcurrency: DEFAULT_INSTALLATION_GROUP_CONCURRENCY,
+};
+
+function headers(action: string, delivery: string): WebhookHeaders {
+  return {
+    event: EVENT,
+    delivery,
+    rawBody: Buffer.from(JSON.stringify({ action, delivery })),
+  };
+}
+
+function makePrRef(suffix = ""): PrRef {
+  const id = suffix || randomUUID().slice(0, 8);
+  return {
+    owner: OWNER,
+    repo: `repo-${id}`,
+    prNumber: 100 + id.charCodeAt(0),
+    installationId: 9001,
+    headSha: `sha-${id}`,
+  };
+}
+
+function intakeLog() {
+  return createOperationLogger({ method: "POST", path: "/webhooks" });
+}
+
+function withSendFailOnNth(
+  realBoss: PgBoss,
+  failOnSend: number,
+): { restore: () => void } {
+  let sendCount = 0;
+  const originalSend = realBoss.send.bind(realBoss);
+  realBoss.send = (async (name: string, data?: object | null, options?: SendOptions) => {
+    sendCount += 1;
+    if (sendCount >= failOnSend) {
+      throw new Error("injected send failure");
+    }
+    return originalSend(name, data, options);
+  }) as PgBoss["send"];
+  return {
+    restore: () => {
+      realBoss.send = originalSend;
+    },
+  };
+}
+
+function withFindJobsGate(
+  realBoss: PgBoss,
+  shouldGate: (queue: string, options?: Parameters<PgBoss["findJobs"]>[1]) => boolean,
+  onGateEntered: () => void,
+): { releaseGate: () => void; restore: () => void } {
+  let releaseGate!: () => void;
+  const gateHeld = new Promise<void>((resolve) => {
+    releaseGate = resolve;
+  });
+  const originalFindJobs = realBoss.findJobs.bind(realBoss);
+  realBoss.findJobs = (async <T>(name: string, options?: Parameters<PgBoss["findJobs"]>[1]) => {
+    const jobs = await originalFindJobs<T>(name, options);
+    if (shouldGate(name, options) && jobs.length > 0) {
+      onGateEntered();
+      await gateHeld;
+    }
+    return jobs;
+  }) as PgBoss["findJobs"];
+  return {
+    releaseGate: () => releaseGate(),
+    restore: () => {
+      realBoss.findJobs = originalFindJobs;
+    },
+  };
+}
+
+async function deleteQueueJobs(boss: PgBoss): Promise<void> {
+  for (const queue of CLEANUP_QUEUES) {
+    const jobs = await boss.findJobs(queue, {});
+    if (jobs.length > 0) {
+      await boss.deleteJob(
+        queue,
+        jobs.map((job) => job.id),
+      );
+    }
+  }
+}
+
+async function activatePgBossJob(pool: Pool, jobId: string): Promise<void> {
+  await pool.query(
+    `UPDATE pgboss.job
+        SET state = 'active', started_on = now(), heartbeat_on = now()
+      WHERE id = $1`,
+    [jobId],
+  );
+}
+
+describe.skipIf(!hasDatabase)("intake transaction and singleton visibility (integration)", () => {
+  let pool: Pool;
+  let boss: PgBoss;
+
+  beforeAll(async () => {
+    pool = integrationPool();
+    await runMigrations(pool);
+    await pool.query("DELETE FROM agent_work_items WHERE owner = $1", [OWNER]);
+    await pool.query("DELETE FROM webhook_events WHERE event_name = $1", [EVENT]);
+    boss = await createStartedBoss({ databaseUrl: DATABASE_URL, role: "web" });
+    await ensureAgentQueues(boss, queueConfig);
+    await deleteQueueJobs(boss);
+  });
+
+  afterAll(async () => {
+    await stopBoss(boss, DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_SECONDS * 1000);
+    await pool.end();
+  });
+
+  afterEach(async () => {
+    await pool.query("DELETE FROM agent_work_items WHERE owner = $1", [OWNER]);
+    await pool.query("DELETE FROM webhook_events WHERE event_name = $1", [EVENT]);
+    await deleteQueueJobs(boss);
+  });
+
+  async function countWebhookRows(delivery?: string): Promise<number> {
+    const { rows } = await pool.query<{ count: string }>(
+      delivery
+        ? "SELECT COUNT(*)::text AS count FROM webhook_events WHERE event_name = $1 AND delivery_id = $2"
+        : "SELECT COUNT(*)::text AS count FROM webhook_events WHERE event_name = $1",
+      delivery ? [EVENT, delivery] : [EVENT],
+    );
+    return Number(rows[0]?.count ?? "0");
+  }
+
+  async function countWorkItems(): Promise<number> {
+    const { rows } = await pool.query<{ count: string }>(
+      "SELECT COUNT(*)::text AS count FROM agent_work_items WHERE owner = $1",
+      [OWNER],
+    );
+    return Number(rows[0]?.count ?? "0");
+  }
+
+  async function reviewJobsFor(ref: PrRef) {
+    const key = reviewSingletonKey(prResourceKey(ref.owner, ref.repo, ref.prNumber), AUTOMATED_REVIEW_LENS);
+    return boss.findJobs(REVIEW_QUEUE, { key });
+  }
+
+  function latestCreatedReviewJob(jobs: Awaited<ReturnType<typeof reviewJobsFor>>) {
+    return jobs.find((job) => job.state === "created") ?? jobs.at(-1);
+  }
+
+  it("happy path: one delivery commits webhook, work item, ack, and review jobs", async () => {
+    const ref = makePrRef("happy");
+    const delivery = "delivery-happy";
+
+    await applyAutomatedPullRequestIntake(
+      boss,
+      pool,
+      headers("synchronize", delivery),
+      ref,
+      "synchronize",
+      intakeLog(),
+    );
+
+    await expect(countWebhookRows(delivery)).resolves.toBe(1);
+    await expect(countWorkItems()).resolves.toBe(1);
+
+    const ackJobs = await boss.findJobs(ACK_QUEUE, {});
+    const reviewJobs = await reviewJobsFor(ref);
+    expect(ackJobs.length).toBeGreaterThanOrEqual(1);
+    expect(reviewJobs).toHaveLength(1);
+    expect(reviewJobs[0]?.state).toBe("created");
+  });
+
+  it("rollback atomicity: late send failure rolls back dedupe, work item, and jobs", async () => {
+    const ref = makePrRef("rollback");
+    const delivery = "delivery-rollback";
+    const failingBoss = withSendFailOnNth(boss, 2);
+    try {
+      await expect(
+        applyAutomatedPullRequestIntake(
+          boss,
+          pool,
+          headers("synchronize", delivery),
+          ref,
+          "synchronize",
+          intakeLog(),
+        ),
+      ).rejects.toThrow("injected send failure");
+    } finally {
+      failingBoss.restore();
+    }
+
+    await expect(countWebhookRows(delivery)).resolves.toBe(0);
+    await expect(countWorkItems()).resolves.toBe(0);
+    await expect(boss.findJobs(ACK_QUEUE, {})).resolves.toHaveLength(0);
+    await expect(reviewJobsFor(ref)).resolves.toHaveLength(0);
+  });
+
+  it("supersede flow: second delivery supersedes work item and cancels first review job", async () => {
+    const ref = makePrRef("supersede");
+
+    await applyAutomatedPullRequestIntake(
+      boss,
+      pool,
+      headers("synchronize", "delivery-supersede-a"),
+      ref,
+      "synchronize",
+      intakeLog(),
+    );
+    const firstJobs = await reviewJobsFor(ref);
+    const firstJobId = firstJobs[0]?.id;
+    expect(firstJobId).toBeDefined();
+
+    await applyAutomatedPullRequestIntake(
+      boss,
+      pool,
+      headers("synchronize", "delivery-supersede-b"),
+      ref,
+      "synchronize",
+      intakeLog(),
+    );
+
+    const { rows: workRows } = await pool.query<{ status: string }>(
+      `SELECT status FROM agent_work_items WHERE owner = $1 ORDER BY created_at`,
+      [OWNER],
+    );
+    expect(workRows.map((row) => row.status).toSorted()).toEqual(["queued", "superseded"]);
+
+    const firstJob = firstJobId ? await boss.getJobById(REVIEW_QUEUE, firstJobId) : null;
+    expect(firstJob?.state).toBe("cancelled");
+
+    const liveReviewJobs = (await reviewJobsFor(ref)).filter((job) => job.state === "created");
+    expect(liveReviewJobs).toHaveLength(1);
+    expect(liveReviewJobs[0]?.id).not.toBe(firstJobId);
+  });
+
+  it("cancel-visibility: poller activates job while supersede cancel is held in open transaction", async () => {
+    const ref = makePrRef("cancel-vis");
+    await applyAutomatedPullRequestIntake(
+      boss,
+      pool,
+      headers("synchronize", "delivery-cancel-a"),
+      ref,
+      "synchronize",
+      intakeLog(),
+    );
+
+    const reviewJobsAfterA = await reviewJobsFor(ref);
+    const createdJobA = latestCreatedReviewJob(reviewJobsAfterA);
+    expect(createdJobA?.state).toBe("created");
+
+    let gateEnteredResolve!: () => void;
+    const gateEntered = new Promise<void>((resolve) => {
+      gateEnteredResolve = resolve;
+    });
+
+    const { releaseGate, restore } = withFindJobsGate(
+      boss,
+      (queue, options) => queue === REVIEW_QUEUE && options?.db != null,
+      () => gateEnteredResolve(),
+    );
+
+    const intakeB = applyAutomatedPullRequestIntake(
+      boss,
+      pool,
+      headers("synchronize", "delivery-cancel-b"),
+      ref,
+      "synchronize",
+      intakeLog(),
+    );
+
+    await gateEntered;
+
+    try {
+      expect(createdJobA?.id).toBeDefined();
+      await activatePgBossJob(pool, createdJobA!.id);
+      const activeJob = await boss.getJobById(REVIEW_QUEUE, createdJobA!.id);
+      expect(activeJob?.state).toBe("active");
+
+      releaseGate();
+      await intakeB;
+
+      const cancelledA = await boss.getJobById(REVIEW_QUEUE, createdJobA!.id);
+      expect(cancelledA?.state).toBe("cancelled");
+
+      const liveReviewJobs = (await reviewJobsFor(ref)).filter((job) => job.state === "created");
+      expect(liveReviewJobs).toHaveLength(1);
+      expect(liveReviewJobs[0]?.id).not.toBe(createdJobA?.id);
+    } finally {
+      restore();
+    }
+  });
+
+  it("ignored-action flip: enqueue-first then ignored dedupes without extra work", async () => {
+    const ref = makePrRef("flip-enq-first");
+    const delivery = "delivery-flip-enq-first";
+
+    await applyAutomatedPullRequestIntake(
+      boss,
+      pool,
+      headers("synchronize", delivery),
+      ref,
+      "synchronize",
+      intakeLog(),
+    );
+    await applyAutomatedPullRequestIntake(
+      boss,
+      pool,
+      headers("labeled", delivery),
+      ref,
+      "labeled",
+      intakeLog(),
+    );
+
+    await expect(countWebhookRows(delivery)).resolves.toBe(1);
+    await expect(countWorkItems()).resolves.toBe(1);
+    await expect(reviewJobsFor(ref)).resolves.toHaveLength(1);
+  });
+
+  it("ignored-action flip: ignored-first then enqueue dedupes without creating work", async () => {
+    const ref = makePrRef("flip-ign-first");
+    const delivery = "delivery-flip-ign-first";
+
+    await applyAutomatedPullRequestIntake(
+      boss,
+      pool,
+      headers("labeled", delivery),
+      ref,
+      "labeled",
+      intakeLog(),
+    );
+    await applyAutomatedPullRequestIntake(
+      boss,
+      pool,
+      headers("synchronize", delivery),
+      ref,
+      "synchronize",
+      intakeLog(),
+    );
+
+    await expect(countWebhookRows(delivery)).resolves.toBe(1);
+    await expect(countWorkItems()).resolves.toBe(0);
+    await expect(reviewJobsFor(ref)).resolves.toHaveLength(0);
+
+    const { rows } = await pool.query<{ processing_decision: string }>(
+      "SELECT processing_decision FROM webhook_events WHERE event_name = $1",
+      [EVENT],
+    );
+    expect(rows[0]?.processing_decision).toBe("ignored_pull_request_labeled");
+  });
+});

--- a/test/integration/intakeTransaction.integration.test.ts
+++ b/test/integration/intakeTransaction.integration.test.ts
@@ -65,10 +65,7 @@ function intakeLog() {
   return createOperationLogger({ method: "POST", path: "/webhooks" });
 }
 
-function withSendFailOnNth(
-  realBoss: PgBoss,
-  failOnSend: number,
-): { restore: () => void } {
+function withSendFailOnNth(realBoss: PgBoss, failOnSend: number): { restore: () => void } {
   let sendCount = 0;
   const originalSend = realBoss.send.bind(realBoss);
   realBoss.send = (async (name: string, data?: object | null, options?: SendOptions) => {
@@ -176,7 +173,10 @@ describe.skipIf(!hasDatabase)("intake transaction and singleton visibility (inte
   }
 
   async function reviewJobsFor(ref: PrRef) {
-    const key = reviewSingletonKey(prResourceKey(ref.owner, ref.repo, ref.prNumber), AUTOMATED_REVIEW_LENS);
+    const key = reviewSingletonKey(
+      prResourceKey(ref.owner, ref.repo, ref.prNumber),
+      AUTOMATED_REVIEW_LENS,
+    );
     return boss.findJobs(REVIEW_QUEUE, { key });
   }
 
@@ -202,7 +202,7 @@ describe.skipIf(!hasDatabase)("intake transaction and singleton visibility (inte
 
     const ackJobs = await boss.findJobs(ACK_QUEUE, {});
     const reviewJobs = await reviewJobsFor(ref);
-    expect(ackJobs.length).toBeGreaterThanOrEqual(1);
+    expect(ackJobs).toHaveLength(1);
     expect(reviewJobs).toHaveLength(1);
     expect(reviewJobs[0]?.state).toBe("created");
   });
@@ -305,7 +305,12 @@ describe.skipIf(!hasDatabase)("intake transaction and singleton visibility (inte
       intakeLog(),
     );
 
-    await gateEntered;
+    await Promise.race([
+      gateEntered,
+      new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error("supersede findJobs gate timed out")), 10_000);
+      }),
+    ]);
 
     try {
       expect(createdJobA?.id).toBeDefined();


### PR DESCRIPTION
## Summary

Adds `test/integration/intakeTransaction.integration.test.ts` with six integration cases exercising automated PR intake against real pg-boss: happy-path commit visibility, rollback atomicity on late send failure, supersede cancel/replace, cancel-visibility under a held intake transaction, and ignored-action dedupe in both delivery orders.

Closes #96.

## Test plan

- [x] `DATABASE_URL=postgres://pr_agent:pr_agent@localhost:5432/pr_agent pnpm test:integration`
- [x] `pnpm test`
- [x] `pnpm typecheck`

___

## PR Agent Description

### PR Type

Tests

### Description

- Adds Postgres-backed integration tests for automated PR intake via `applyAutomatedPullRequestIntake`
- Covers happy path, rollback on late send failure, and supersede/cancel visibility
- Exercises ignored-action dedupe when enqueue-first vs ignored-first for same delivery

### Changes Diagram

```mermaid
flowchart LR
  A["Webhook delivery"] --> B["Intake transaction"]
  B --> C["Webhook dedupe and work item"]
  C --> D["Ack and review jobs"]
  E["Late send failure"] --> F["Full rollback"]
  G["Second delivery"] --> H["Supersede work item"]
  H --> I["Cancel prior review job"]
```

### File Walkthrough

<details>
<summary>Tests (1 file)</summary>

<details>
<summary>Intake transaction integration test suite</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/121/files#diff-af81a22de90c5a724ee4adc5e47d63493fd7312aded6401772c7752c31e433de"><code>test/integration/intakeTransaction.integration.test.ts</code></a>

- Boots real Postgres, migrations, and PgBoss queues with per-test cleanup
- Mocks send failures and findJobs gating to assert rollback and cancel visibility
- Six scenarios: happy path, rollback, supersede, cancel-visibility, and two ignored-action flips

</details>

</details>