### PR TITLE
Add direct executor tests and shrink reviewExecutor mock surface

### DIFF
--- a/test/askExecutor.test.ts
+++ b/test/askExecutor.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   runDurableWorkItem: vi.fn(),
   withPrRepositoryView: vi.fn(),
   postSlashReply: vi.fn(),
+  createComment: vi.fn(),
 }));
 
 vi.mock("../src/agentWork/repository.js", () => ({
@@ -44,7 +45,7 @@ vi.mock("../src/agentWork/githubPrSurface.js", () => ({
 vi.mock("../src/github/appAuth.js", () => ({
   installationOctokit: vi.fn(() => ({
     rest: {
-      issues: { createComment: vi.fn() },
+      issues: { createComment: mocks.createComment },
     },
   })),
 }));
@@ -221,5 +222,92 @@ describe("executeAskJob", () => {
 
     expect(mocks.postSlashReply).toHaveBeenCalledTimes(1);
     expect(mocks.postSlashReply.mock.calls[0]?.[4]).toBe("answer");
+  });
+
+  it("falls back to a PR comment when inline thread reply fails", async () => {
+    const item: AgentWorkItem = {
+      ...askItem(),
+      payload: {
+        question: "why this line?",
+        replyTarget: {
+          kind: "inlineReviewThread",
+          prNumber: 1,
+          inReplyToCommentId: 55,
+        },
+        commentId: 99,
+      },
+    };
+    mocks.postSlashReply.mockRejectedValueOnce(new Error("thread unavailable"));
+    mocks.createComment.mockResolvedValue(undefined);
+    mocks.runDurableWorkItem.mockImplementation(async (spec: DurableJobSpec) => {
+      await spec.execute(item, {
+        installation: {
+          token: "tok",
+          expiresAtTs: 1_000_000,
+          ttlMs: 60_000,
+        },
+        headSha: "head",
+      });
+    });
+
+    await executeAskJob(cfg, pool, boss, askJob());
+
+    expect(mocks.postSlashReply).toHaveBeenCalledTimes(1);
+    expect(mocks.createComment).toHaveBeenCalledWith({
+      owner: "o",
+      repo: "r",
+      issue_number: 1,
+      body: expect.stringContaining("Could not reply in the review thread"),
+    });
+    expect(mocks.createComment.mock.calls[0]?.[0].body).toContain("answer");
+  });
+
+  it("posts terminal failure reply when the ask never delivered an answer", async () => {
+    mocks.runAskRun.mockRejectedValue(new Error("agent failed"));
+    mocks.runDurableWorkItem.mockImplementation(async (spec: DurableJobSpec) => {
+      const item = askItem();
+      const installation = {
+        token: "tok",
+        expiresAtTs: 1_000_000,
+        ttlMs: 60_000,
+      };
+      await expect(
+        spec.execute(item, {
+          installation,
+          headSha: "head",
+        }),
+      ).rejects.toThrow("agent failed");
+      await spec.onTerminalFailure?.(item, installation, new Error("dead"));
+    });
+
+    await executeAskJob(cfg, pool, boss, askJob());
+
+    expect(mocks.postSlashReply).toHaveBeenCalledTimes(1);
+    expect(mocks.postSlashReply.mock.calls[0]?.[4]).toContain(
+      "could not complete this ask after retries",
+    );
+    expect(mocks.postSlashReply.mock.calls[0]?.[4]).toContain("**Question:** what changed?");
+  });
+
+  it("does not post terminal failure reply on non-terminal retry", async () => {
+    mocks.runAskRun.mockRejectedValue(new Error("transient"));
+    mocks.runDurableWorkItem.mockImplementation(async (spec: DurableJobSpec) => {
+      const item = askItem();
+      const installation = {
+        token: "tok",
+        expiresAtTs: 1_000_000,
+        ttlMs: 60_000,
+      };
+      await expect(
+        spec.execute(item, {
+          installation,
+          headSha: "head",
+        }),
+      ).rejects.toThrow("transient");
+    });
+
+    await executeAskJob(cfg, pool, boss, askJob());
+
+    expect(mocks.postSlashReply).not.toHaveBeenCalled();
   });
 });

--- a/test/descriptionExecutor.test.ts
+++ b/test/descriptionExecutor.test.ts
@@ -1,0 +1,250 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Pool } from "pg";
+import type { JobWithMetadata, PgBoss } from "pg-boss";
+import type { DurableJobSpec } from "../src/agentWork/durableJob.js";
+import type { AgentWorkItem, DescriptionJobData } from "../src/agentWork/types.js";
+import { DESCRIPTION_FAILURE_MESSAGE } from "../src/settings/index.js";
+import { makeTestConfig } from "./helpers/config.js";
+import * as repo from "../src/agentWork/repository.js";
+import {
+  makeDurableJobMetadata,
+  mockFetchedWorkItem,
+  setupDefaultDurableAuthMocks,
+  setupDefaultDurableRepositoryMocks,
+} from "./helpers/executorDurableHarness.js";
+
+const mocks = vi.hoisted(() => ({
+  runDescriptionRun: vi.fn(),
+  runDurableWorkItem: vi.fn(),
+  withPrRepositoryView: vi.fn(),
+  createComment: vi.fn(),
+}));
+
+vi.mock("../src/agentWork/repository.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/agentWork/repository.js")>();
+  return {
+    ...actual,
+    shouldSkipWork: vi.fn().mockResolvedValue(false),
+    getWorkItemCore: vi.fn(),
+    getWorkItemPayload: vi.fn(),
+    claimWorkForExecution: vi.fn().mockResolvedValue(true),
+    markWorkCompleted: vi.fn().mockResolvedValue(true),
+    markWorkFailed: vi.fn().mockResolvedValue(true),
+    markWorkRetrying: vi.fn().mockResolvedValue(true),
+    markWorkCancelled: vi.fn().mockResolvedValue(undefined),
+    markWorkPublishDegraded: vi.fn().mockResolvedValue(undefined),
+    updateRunningWorkHeadSha: vi.fn().mockResolvedValue(true),
+    recordPublishStep: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock("../src/agent/descriptionRun.js", () => ({
+  runFullPrDescription: mocks.runDescriptionRun,
+}));
+
+vi.mock("../src/agentWork/durableJob.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/agentWork/durableJob.js")>();
+  return {
+    ...actual,
+    runDurableWorkItem: mocks.runDurableWorkItem,
+  };
+});
+
+vi.mock("../src/prWorkspace/index.js", () => ({
+  withPrRepositoryView: mocks.withPrRepositoryView,
+}));
+
+vi.mock("../src/github/appAuth.js", () => ({
+  mintInstallationAuth: vi.fn(),
+  getAppBotIdentity: vi.fn(),
+  installationOctokit: vi.fn(() => ({
+    rest: {
+      issues: { createComment: mocks.createComment },
+    },
+  })),
+}));
+
+import { runDurableWorkItem } from "../src/agentWork/durableJob.js";
+import { executeDescriptionJob } from "../src/agentWork/executors/descriptionExecutor.js";
+
+const cfg = makeTestConfig({ piModel: "test" });
+const pool = {} as Pool;
+const boss = {} as PgBoss;
+
+function descriptionItem(source: "slash" | "auto" = "slash"): AgentWorkItem {
+  return {
+    id: "wi-1",
+    webhookEventId: "ev-1",
+    type: "description",
+    source,
+    status: "running",
+    owner: "o",
+    repo: "r",
+    prNumber: 1,
+    installationId: 42,
+    headSha: "head",
+    reviewLens: null,
+    resourceKey: "o/r#1",
+    attemptCount: 0,
+    payload: { source },
+    cancelRequestedAt: null,
+  };
+}
+
+function descriptionJob(retryCount = 0, retryLimit = 3): JobWithMetadata<DescriptionJobData> {
+  const now = new Date();
+  return {
+    id: "job-1",
+    name: "agent-work-description",
+    data: { kind: "description", workItemId: "wi-1" },
+    expireInSeconds: 3600,
+    heartbeatSeconds: null,
+    signal: new AbortController().signal,
+    priority: 0,
+    state: "active",
+    retryLimit,
+    retryCount,
+    retryDelay: 0,
+    retryBackoff: false,
+    startAfter: now,
+    startedOn: now,
+    singletonKey: null,
+    singletonOn: null,
+    deleteAfterSeconds: 0,
+    createdOn: now,
+    completedOn: null,
+    keepUntil: now,
+    policy: "standard",
+    heartbeatOn: null,
+    deadLetter: "",
+    output: {},
+  };
+}
+
+function mockDurableExecution(item = descriptionItem()): void {
+  mocks.runDurableWorkItem.mockImplementation(async (spec: DurableJobSpec) => {
+    const installation = {
+      token: "tok",
+      expiresAtTs: Date.now() + 60_000,
+      ttlMs: 60_000,
+    };
+    const result = await spec.execute(item, {
+      installation,
+      headSha: "head",
+    });
+    if (result?.degraded) {
+      await repo.markWorkPublishDegraded(pool, item.id);
+    }
+  });
+}
+
+describe("executeDescriptionJob", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDefaultDurableRepositoryMocks();
+    mocks.runDescriptionRun.mockResolvedValue({
+      published: true,
+      publishSuperseded: false,
+    });
+    mocks.createComment.mockResolvedValue(undefined);
+    mocks.withPrRepositoryView.mockImplementation(async (_params, run) =>
+      run({
+        agentCwd: "/tmp/pr-agent",
+        workspace: undefined,
+      }),
+    );
+    mockDurableExecution();
+  });
+
+  it("posts slash failure comment on terminal pg-boss attempt", async () => {
+    const item = descriptionItem("slash");
+    mocks.runDurableWorkItem.mockImplementation(async (spec: DurableJobSpec) => {
+      const installation = {
+        token: "tok",
+        expiresAtTs: Date.now() + 60_000,
+        ttlMs: 60_000,
+      };
+      await spec.onTerminalFailure?.(item, installation, new Error("dead"));
+    });
+
+    await executeDescriptionJob(cfg, pool, boss, descriptionJob(3, 3));
+
+    expect(mocks.createComment).toHaveBeenCalledWith({
+      owner: "o",
+      repo: "r",
+      issue_number: 1,
+      body: DESCRIPTION_FAILURE_MESSAGE,
+    });
+  });
+
+  it("stays silent on terminal failure for auto source", async () => {
+    const item = descriptionItem("auto");
+    mocks.runDurableWorkItem.mockImplementation(async (spec: DurableJobSpec) => {
+      const installation = {
+        token: "tok",
+        expiresAtTs: Date.now() + 60_000,
+        ttlMs: 60_000,
+      };
+      await spec.onTerminalFailure?.(item, installation, new Error("dead"));
+    });
+
+    await executeDescriptionJob(cfg, pool, boss, descriptionJob(3, 3));
+
+    expect(mocks.createComment).not.toHaveBeenCalled();
+  });
+
+  it("marks publish degraded when description run reports unpublished output", async () => {
+    mocks.runDescriptionRun.mockResolvedValue({
+      published: false,
+      publishSuperseded: false,
+    });
+
+    await executeDescriptionJob(cfg, pool, boss, descriptionJob());
+
+    expect(repo.markWorkPublishDegraded).toHaveBeenCalledWith(pool, "wi-1");
+  });
+
+  it("does not mark publish degraded when description publishes successfully", async () => {
+    await executeDescriptionJob(cfg, pool, boss, descriptionJob());
+
+    expect(repo.markWorkPublishDegraded).not.toHaveBeenCalled();
+  });
+
+  it("does not mark publish degraded when publish was superseded", async () => {
+    mocks.runDescriptionRun.mockResolvedValue({
+      published: false,
+      publishSuperseded: true,
+    });
+
+    await executeDescriptionJob(cfg, pool, boss, descriptionJob());
+
+    expect(repo.markWorkPublishDegraded).not.toHaveBeenCalled();
+  });
+
+  it("marks publish degraded through real durable scaffolding", async () => {
+    setupDefaultDurableAuthMocks();
+    mockFetchedWorkItem(descriptionItem());
+    mocks.runDescriptionRun.mockResolvedValue({
+      published: false,
+      publishSuperseded: false,
+    });
+
+    await runDurableWorkItem({
+      cfg,
+      pool,
+      boss,
+      job: makeDurableJobMetadata(),
+      type: "description",
+      resolveHeadSha: async () => ({ headSha: "head" }),
+      execute: async (_item, _env) => {
+        const result = await mocks.runDescriptionRun({});
+        if (!result.published && !result.publishSuperseded) {
+          return { degraded: true };
+        }
+        return {};
+      },
+    });
+
+    expect(repo.markWorkPublishDegraded).toHaveBeenCalledWith(pool, "wi-1");
+  });
+});

--- a/test/helpers/executorDurableHarness.ts
+++ b/test/helpers/executorDurableHarness.ts
@@ -1,0 +1,55 @@
+import { vi } from "vitest";
+import type { JobWithMetadata } from "pg-boss";
+import type { AgentWorkItem } from "../../src/agentWork/types.js";
+import { clearDurableAuthCachesForTest } from "../../src/agentWork/durableJob.js";
+import * as appAuth from "../../src/github/appAuth.js";
+import * as repo from "../../src/agentWork/repository.js";
+
+export function coreOf(item: AgentWorkItem): Omit<AgentWorkItem, "payload"> {
+  const { payload: _payload, ...core } = item;
+  return core;
+}
+
+export function mockFetchedWorkItem(item: AgentWorkItem | null): void {
+  vi.mocked(repo.getWorkItemCore).mockResolvedValue(item ? coreOf(item) : null);
+  vi.mocked(repo.getWorkItemPayload).mockResolvedValue(item?.payload ?? null);
+}
+
+export function setupDefaultDurableRepositoryMocks(): void {
+  vi.mocked(repo.shouldSkipWork).mockResolvedValue(false);
+  vi.mocked(repo.claimWorkForExecution).mockResolvedValue(true);
+  vi.mocked(repo.updateRunningWorkHeadSha).mockResolvedValue(true);
+  vi.mocked(repo.markWorkCompleted).mockResolvedValue(true);
+  vi.mocked(repo.markWorkFailed).mockResolvedValue(true);
+  vi.mocked(repo.markWorkRetrying).mockResolvedValue(true);
+  vi.mocked(repo.markWorkCancelled).mockResolvedValue(undefined);
+  vi.mocked(repo.markWorkPublishDegraded).mockResolvedValue(undefined);
+}
+
+export function setupDefaultDurableAuthMocks(): void {
+  clearDurableAuthCachesForTest();
+  vi.mocked(appAuth.mintInstallationAuth).mockResolvedValue({
+    type: "token",
+    tokenType: "installation",
+    token: "tok",
+    expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+    installationId: 42,
+  } as Awaited<ReturnType<typeof appAuth.mintInstallationAuth>>);
+  vi.mocked(appAuth.getAppBotIdentity).mockResolvedValue({
+    userId: 999,
+    login: "pr-agent[bot]",
+  } as Awaited<ReturnType<typeof appAuth.getAppBotIdentity>>);
+}
+
+export function makeDurableJobMetadata(
+  workItemId = "wi-1",
+  retryCount = 0,
+  retryLimit = 3,
+): JobWithMetadata<{ workItemId: string }> {
+  return {
+    id: "job-1",
+    data: { workItemId },
+    retryCount,
+    retryLimit,
+  } as unknown as JobWithMetadata<{ workItemId: string }>;
+}

--- a/test/reviewExecutor.test.ts
+++ b/test/reviewExecutor.test.ts
@@ -10,7 +10,6 @@ const mocks = vi.hoisted(() => ({
   lightweight: vi.fn(),
   runFullPrReview: vi.fn(),
   withPrRepositoryView: vi.fn(),
-  runDurableWorkItem: vi.fn(),
   buildStaleReschedule: vi.fn(),
   buildTrustedContext: vi.fn(),
   fetchPriorFeedback: vi.fn(),
@@ -19,48 +18,14 @@ const mocks = vi.hoisted(() => ({
   logWarn: vi.fn(),
 }));
 
-vi.mock("../src/agentWork/durableJob.js", () => ({
-  makeInstallationTokenRefresher: vi.fn(() => async () => ({
-    token: "t",
-    expiresAtTs: Date.now() + 60_000,
-  })),
-  resolveWorkItemHead: vi.fn(async () => ({ headSha: "head" })),
-  runDurableWorkItem: mocks.runDurableWorkItem,
-}));
-
 vi.mock("../src/agentWork/repository.js", () => ({
   loadReviewExecutorPublishContext: mocks.loadPublishContext,
   recordPublishStep: vi.fn(),
   shouldSkipWork: vi.fn(),
 }));
 
-vi.mock("../src/github/listPullRequestFiles.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../src/github/listPullRequestFiles.js")>();
-  return {
-    assertPullRequestFilesHeadSha: actual.assertPullRequestFilesHeadSha,
-    fetchPullRequestFiles: mocks.fetchPrFiles,
-  };
-});
-
-vi.mock("../src/agentWork/reviewLightweightCompletion.js", () => ({
-  tryLightweightAutoReviewCompletion: mocks.lightweight,
-}));
-
 vi.mock("../src/review/reviewRun.js", () => ({
   runFullPrReview: mocks.runFullPrReview,
-}));
-
-vi.mock("../src/agentWork/reviewReschedule.js", () => ({
-  buildStaleSlashReviewRescheduleResult: mocks.buildStaleReschedule,
-}));
-
-vi.mock("../src/prWorkspace/index.js", () => ({
-  withPrRepositoryView: mocks.withPrRepositoryView,
-}));
-
-vi.mock("../src/review/reviewTrustedContext.js", () => ({
-  buildTrustedReviewContextForReview: mocks.buildTrustedContext,
-  fetchPriorInlineFeedbackBlockForReview: mocks.fetchPriorFeedback,
 }));
 
 vi.mock("../src/agentWork/githubPrSurface.js", () => ({
@@ -69,22 +34,15 @@ vi.mock("../src/agentWork/githubPrSurface.js", () => ({
   getPullRequestHeadSha: vi.fn(async () => "head"),
 }));
 
-vi.mock("../src/evlog.js", () => ({
-  logInfo: mocks.logInfo,
-  logWarn: mocks.logWarn,
-}));
-
-vi.mock("../src/github/reviewPublish.js", () => ({
-  upsertReviewSummaryComment: vi.fn(),
-}));
-
-vi.mock("../src/review/reviewRunMetrics.js", () => ({
-  initReviewRunMetrics: vi.fn(),
-  logReviewRunCompleted: vi.fn(),
-  recordReviewPhaseSpan: vi.fn(async (_phase: string, run: () => Promise<unknown>) => run()),
-  setReviewRunMetricFields: vi.fn(),
-}));
-
+import * as durableJob from "../src/agentWork/durableJob.js";
+import * as listPullRequestFiles from "../src/github/listPullRequestFiles.js";
+import * as reviewLightweightCompletion from "../src/agentWork/reviewLightweightCompletion.js";
+import * as prWorkspace from "../src/prWorkspace/index.js";
+import * as reviewTrustedContext from "../src/review/reviewTrustedContext.js";
+import * as reviewReschedule from "../src/agentWork/reviewReschedule.js";
+import * as evlog from "../src/evlog.js";
+import * as reviewPublish from "../src/github/reviewPublish.js";
+import * as reviewRunMetrics from "../src/review/reviewRunMetrics.js";
 import { executeReviewJob } from "../src/agentWork/executors/reviewExecutor.js";
 
 const cfg = makeTestConfig({ piModel: "test" });
@@ -164,9 +122,50 @@ function reviewJob(): JobWithMetadata<ReviewJobData> {
   };
 }
 
+function mockDurableExecution(source: "auto" | "slash" = "slash"): void {
+  vi.spyOn(durableJob, "runDurableWorkItem").mockImplementation(async (spec) => {
+    const item = makeItem(source);
+    await spec.execute(item, {
+      installation: {
+        token: "tok",
+        expiresAtTs: Date.now() + 60_000,
+        ttlMs: 60_000,
+      },
+      headSha: "head",
+      pullRequest: source === "slash" ? pullRequest : undefined,
+    });
+  });
+}
+
 describe("executeReviewJob", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.spyOn(listPullRequestFiles, "fetchPullRequestFiles").mockImplementation(mocks.fetchPrFiles);
+    vi.spyOn(reviewLightweightCompletion, "tryLightweightAutoReviewCompletion").mockImplementation(
+      mocks.lightweight,
+    );
+    vi.spyOn(prWorkspace, "withPrRepositoryView").mockImplementation(mocks.withPrRepositoryView);
+    vi.spyOn(reviewReschedule, "buildStaleSlashReviewRescheduleResult").mockImplementation(
+      mocks.buildStaleReschedule,
+    );
+    vi.spyOn(reviewTrustedContext, "buildTrustedReviewContextForReview").mockImplementation(
+      mocks.buildTrustedContext,
+    );
+    vi.spyOn(reviewTrustedContext, "fetchPriorInlineFeedbackBlockForReview").mockImplementation(
+      mocks.fetchPriorFeedback,
+    );
+    vi.spyOn(evlog, "logInfo").mockImplementation(mocks.logInfo);
+    vi.spyOn(evlog, "logWarn").mockImplementation(mocks.logWarn);
+    vi.spyOn(reviewPublish, "upsertReviewSummaryComment").mockResolvedValue({
+      id: 1,
+      updated: false,
+    });
+    vi.spyOn(reviewRunMetrics, "initReviewRunMetrics").mockImplementation(() => undefined);
+    vi.spyOn(reviewRunMetrics, "logReviewRunCompleted").mockImplementation(() => undefined);
+    vi.spyOn(reviewRunMetrics, "setReviewRunMetricFields").mockImplementation(() => undefined);
+    vi.spyOn(reviewRunMetrics, "recordReviewPhaseSpan").mockImplementation(async (_phase, run) =>
+      run(),
+    );
     mocks.getAppBotIdentity.mockResolvedValue({ userId: 1 });
     mocks.loadPublishContext.mockResolvedValue({
       publishState: {
@@ -188,18 +187,7 @@ describe("executeReviewJob", () => {
     mocks.buildTrustedContext.mockResolvedValue("trusted");
     mocks.fetchPriorFeedback.mockResolvedValue(undefined);
     mockRepositoryView();
-    mocks.runDurableWorkItem.mockImplementation(async (spec) => {
-      const item = makeItem("slash");
-      await spec.execute(item, {
-        installation: {
-          token: "tok",
-          expiresAtTs: Date.now() + 60_000,
-          ttlMs: 60_000,
-        },
-        headSha: "head",
-        pullRequest,
-      });
-    });
+    mockDurableExecution("slash");
   });
 
   it("loads publish context in one batched db-read span", async () => {
@@ -218,17 +206,7 @@ describe("executeReviewJob", () => {
   });
 
   it("runs auto preflight and lightweight completion before full review", async () => {
-    mocks.runDurableWorkItem.mockImplementation(async (spec) => {
-      const item = makeItem("auto");
-      await spec.execute(item, {
-        installation: {
-          token: "tok",
-          expiresAtTs: Date.now() + 60_000,
-          ttlMs: 60_000,
-        },
-        headSha: "head",
-      });
-    });
+    mockDurableExecution("auto");
     mocks.lightweight.mockResolvedValue({ handled: true, published: true });
 
     await executeReviewJob(cfg, pool, boss, reviewJob());
@@ -250,17 +228,7 @@ describe("executeReviewJob", () => {
   });
 
   it("passes auto preflight files into repository preparation", async () => {
-    mocks.runDurableWorkItem.mockImplementation(async (spec) => {
-      const item = makeItem("auto");
-      await spec.execute(item, {
-        installation: {
-          token: "tok",
-          expiresAtTs: Date.now() + 60_000,
-          ttlMs: 60_000,
-        },
-        headSha: "head",
-      });
-    });
+    mockDurableExecution("auto");
 
     await executeReviewJob(cfg, pool, boss, reviewJob());
 


### PR DESCRIPTION
## Summary

- Extended `askExecutor` tests with inline-thread fallback to PR comment, terminal failure publishing, and non-terminal retry silence
- Added `descriptionExecutor` tests for slash-only terminal failure comments and degraded publish propagation via `markWorkPublishDegraded`
- Rewrote `reviewExecutor` tests to three `vi.mock` boundaries (repository, review run, GitHub PR surface); other dependencies stubbed with `vi.spyOn`
- Added `test/helpers/executorDurableHarness.ts` for shared durable-scaffolding setup

All seven pre-rewrite `reviewExecutor` `it` titles are preserved. No mock-only assertions were dropped.

Closes #83

## Test plan

- [x] `pnpm test -- askExecutor descriptionExecutor reviewExecutor`
- [x] `pnpm test`
- [x] `pnpm typecheck`
- [x] `pnpm lint && pnpm fmt:check`
- [x] `grep -c "vi.mock" test/reviewExecutor.test.ts` → 3
- [x] `git status` shows only `test/` modifications

___

## PR Agent Description

### PR Type

Tests

### Description

- Add shared durable executor test harness for repository and auth mocks
- Add description executor tests for terminal failure and publish degraded paths
- Expand ask executor tests for thread fallback and terminal failure replies
- Refactor review executor tests to use spies instead of module mocks

### Changes Diagram

```mermaid
flowchart LR
  A["executorDurableHarness"] --> B["descriptionExecutor tests"]
  A --> C["askExecutor tests"]
  D["reviewExecutor refactor"] --> E["vi.spyOn setup"]
  B --> F["terminal failure and degraded publish"]
  C --> G["thread fallback and retry behavior"]
```

### File Walkthrough

<details>
<summary>Tests (4 files)</summary>

<details>
<summary>Shared durable executor test harness</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/123/files#diff-8d4a8b0933763541d04c0655c2845dea15f809c0496da46a9ebbd20b95de472a"><code>test/helpers/executorDurableHarness.ts</code></a>

- Extracts repository, auth, and job metadata helpers
- Provides mockFetchedWorkItem and setupDefaultDurableRepositoryMocks

</details>

<details>
<summary>Description executor durable job coverage</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/123/files#diff-e43cd6eb8835e60343aea7bbd8f767c81cf86e4df49a3dbfd9ae01be696632a6"><code>test/descriptionExecutor.test.ts</code></a>

- Tests slash failure comment on terminal pg-boss attempt
- Verifies auto source stays silent on terminal failure
- Covers publish degraded marking for unpublished and superseded runs

</details>

<details>
<summary>Ask executor failure and fallback tests</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/123/files#diff-9b5ec9954af60442fc0c5bc9ff6f0e932e97a0c5a4672461b9555ca13c9a8ea8"><code>test/askExecutor.test.ts</code></a>

- Falls back to PR comment when inline thread reply fails
- Posts terminal failure reply only after exhausted retries
- Skips failure reply on non-terminal retry attempts

</details>

<details>
<summary>Review executor test mock refactor</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/123/files#diff-4b7c17671ada06fec767fe2ef9bad54e5f77b932caa90f9061ba1e7ce71793fe"><code>test/reviewExecutor.test.ts</code></a>

- Replaces vi.mock with vi.spyOn for dependencies
- Extracts mockDurableExecution helper for slash and auto sources

</details>

</details>