### PR TITLE
Data model cleanup: drop max_attempts, surface auto-describe failures, reuse stored comment ids

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,14 +95,7 @@ Loaded by `loadConfig()` into a redaction-safe map and never logged. Set the sec
 
 ---
 
-## Retry model split (document only)
-
-| Mechanism                       | Default | Where                              |
-| ------------------------------- | ------- | ---------------------------------- |
-| `agent_work_items.max_attempts` | `3`     | SQL migration `001_agent_work.sql` |
-| pg-boss `QUEUE_RETRY_LIMIT`     | `3`     | `src/agentWork/boss.ts`            |
-
-These are related but not wired together on INSERT today.
+Work item retries are controlled only by pg-boss (`QUEUE_RETRY_LIMIT`, `QUEUE_RETRY_DELAY`, `QUEUE_RETRY_BACKOFF`).
 
 ---
 

--- a/migrations/010_drop_max_attempts.sql
+++ b/migrations/010_drop_max_attempts.sql
@@ -1,0 +1,1 @@
+ALTER TABLE agent_work_items DROP COLUMN IF EXISTS max_attempts;

--- a/src/agentWork/executors/ackExecutor.ts
+++ b/src/agentWork/executors/ackExecutor.ts
@@ -1,12 +1,15 @@
 import type { Pool } from "pg";
 import type { Config } from "../../config.js";
-import { upsertReviewSummaryComment } from "../../github/reviewPublish.js";
+import {
+  resolveVerifiedSummaryCommentRef,
+  upsertReviewSummaryComment,
+} from "../../github/reviewPublish.js";
 import { logDebug, logWarn } from "../../evlog.js";
 import { reviewSummarySentinelForMode } from "../../review/reviewSchema.js";
 import { upsertSummaryCommentWithCreationClaim } from "../../review/publish/publishReview.js";
 import { DEFERRED_HEAD_SHA } from "../../settings/index.js";
 import { mintInstallationToken } from "../durableJob.js";
-import { recordPublishStep } from "../repository.js";
+import { getSummaryCommentGithubId, recordPublishStep } from "../repository.js";
 import { renderReviewProgressComment } from "../../review/progressComment.js";
 import {
   getAppBotIdentity,
@@ -69,30 +72,46 @@ export async function executeAckJob(cfg: Config, pool: Pool, data: AckJobData): 
     });
     const resourceKey = `${data.owner}/${data.repo}#${data.prNumber}`;
     const sentinel = reviewSummarySentinelForMode(data.progress.lens);
-    const summary = data.workItemId
-      ? await upsertSummaryCommentWithCreationClaim({
-          pool,
-          workItemId: data.workItemId,
-          resourceKey,
-          reviewLens: data.progress.lens,
-          token: installation.token,
-          owner: data.owner,
-          repo: data.repo,
-          prNumber: data.prNumber,
-          body,
-          sentinel,
-          expiresAtTs: installation.expiresAtTs,
-        })
-      : await upsertReviewSummaryComment(
-          installation.token,
-          data.owner,
-          data.repo,
-          data.prNumber,
-          body,
-          sentinel,
-          undefined,
-          installation.expiresAtTs,
-        );
+    let summary;
+    if (data.workItemId) {
+      summary = await upsertSummaryCommentWithCreationClaim({
+        pool,
+        workItemId: data.workItemId,
+        resourceKey,
+        reviewLens: data.progress.lens,
+        token: installation.token,
+        owner: data.owner,
+        repo: data.repo,
+        prNumber: data.prNumber,
+        body,
+        sentinel,
+        expiresAtTs: installation.expiresAtTs,
+      });
+    } else {
+      const storedId = await getSummaryCommentGithubId(pool, resourceKey, data.progress.lens);
+      const verified =
+        storedId != null
+          ? await resolveVerifiedSummaryCommentRef(
+              installation.token,
+              data.owner,
+              data.repo,
+              data.prNumber,
+              sentinel,
+              storedId,
+              installation.expiresAtTs,
+            )
+          : null;
+      summary = await upsertReviewSummaryComment(
+        installation.token,
+        data.owner,
+        data.repo,
+        data.prNumber,
+        body,
+        sentinel,
+        verified ? { id: verified.id, url: verified.url } : undefined,
+        installation.expiresAtTs,
+      );
+    }
     if (data.workItemId) {
       await recordPublishStep(pool, {
         workItemId: data.workItemId,

--- a/src/agentWork/executors/descriptionExecutor.ts
+++ b/src/agentWork/executors/descriptionExecutor.ts
@@ -4,7 +4,11 @@ import type { Config } from "../../config.js";
 import { runFullPrDescription } from "../../agent/descriptionRun.js";
 import { installationOctokit } from "../../github/appAuth.js";
 import { logWarn } from "../../evlog.js";
-import { DESCRIPTION_FAILURE_MESSAGE, DESCRIPTION_PUBLISH_LENS } from "../../settings/index.js";
+import {
+  DESCRIPTION_AGENT_HEADER,
+  DESCRIPTION_FAILURE_MESSAGE,
+  DESCRIPTION_PUBLISH_LENS,
+} from "../../settings/index.js";
 import { withPrRepositoryView } from "../../prWorkspace/index.js";
 import { recordPublishStep, shouldSkipWork } from "../repository.js";
 import {
@@ -85,8 +89,15 @@ export async function executeDescriptionJob(
     onTerminalFailure: async (item, installation) => {
       if (!installation) return;
       const payload = item.payload as DescriptionWorkPayload;
-      if (payload.source !== "slash") return;
       const octokit = installationOctokit(installation.token, installation.expiresAtTs);
+      if (payload.source !== "slash") {
+        const { data: pr } = await octokit.rest.pulls.get({
+          owner: item.owner,
+          repo: item.repo,
+          pull_number: item.prNumber,
+        });
+        if ((pr.body ?? "").includes(DESCRIPTION_AGENT_HEADER)) return;
+      }
       await octokit.rest.issues.createComment({
         owner: item.owner,
         repo: item.repo,

--- a/src/agentWork/reviewLightweightCompletion.ts
+++ b/src/agentWork/reviewLightweightCompletion.ts
@@ -3,8 +3,11 @@ import { evaluateTrivialChangeExemption } from "../review/reviewChangeGate.js";
 import type { ReviewPreflightMetadata } from "../review/reviewPreflightFiles.js";
 import { renderLightweightReviewCompletion } from "../review/reviewRender.js";
 import { reviewSummarySentinelForMode, type ReviewMode } from "../review/reviewSchema.js";
-import { upsertReviewSummaryComment } from "../github/reviewPublish.js";
-import { recordPublishStep, shouldSkipWork } from "./repository.js";
+import {
+  resolveVerifiedSummaryCommentRef,
+  upsertReviewSummaryComment,
+} from "../github/reviewPublish.js";
+import { getSummaryCommentGithubId, recordPublishStep, shouldSkipWork } from "./repository.js";
 import type { AgentWorkItem } from "./types.js";
 
 export type LightweightAutoReviewResult =
@@ -44,28 +47,35 @@ export async function tryLightweightAutoReviewCompletion(
   }
 
   const body = renderLightweightReviewCompletion(params.reviewLens);
-  let summary;
-  if (params.tokenExpiresAtTs == null) {
-    summary = await upsertReviewSummaryComment(
-      params.token,
-      params.item.owner,
-      params.item.repo,
-      params.item.prNumber,
-      body,
-      reviewSummarySentinelForMode(params.reviewLens),
-    );
-  } else {
-    summary = await upsertReviewSummaryComment(
-      params.token,
-      params.item.owner,
-      params.item.repo,
-      params.item.prNumber,
-      body,
-      reviewSummarySentinelForMode(params.reviewLens),
-      undefined,
-      params.tokenExpiresAtTs,
-    );
-  }
+  const sentinel = reviewSummarySentinelForMode(params.reviewLens);
+  const storedId = await getSummaryCommentGithubId(
+    pool,
+    params.item.resourceKey,
+    params.reviewLens,
+  );
+  const verified =
+    storedId != null
+      ? await resolveVerifiedSummaryCommentRef(
+          params.token,
+          params.item.owner,
+          params.item.repo,
+          params.item.prNumber,
+          sentinel,
+          storedId,
+          params.tokenExpiresAtTs,
+        )
+      : null;
+  const knownExisting = verified ? { id: verified.id, url: verified.url } : undefined;
+  const summary = await upsertReviewSummaryComment(
+    params.token,
+    params.item.owner,
+    params.item.repo,
+    params.item.prNumber,
+    body,
+    sentinel,
+    knownExisting,
+    params.tokenExpiresAtTs,
+  );
   await recordPublishStep(pool, {
     workItemId: params.item.id,
     resourceKey: params.item.resourceKey,

--- a/test/ackExecutor.test.ts
+++ b/test/ackExecutor.test.ts
@@ -20,10 +20,12 @@ vi.mock("../src/agentWork/githubPrSurface.js", () => ({
 }));
 
 vi.mock("../src/github/reviewPublish.js", () => ({
-  upsertReviewSummaryComment: vi.fn(),
+  resolveVerifiedSummaryCommentRef: vi.fn(),
+  upsertReviewSummaryComment: vi.fn(async () => ({ id: 77, updated: true })),
 }));
 
 vi.mock("../src/agentWork/repository.js", () => ({
+  getSummaryCommentGithubId: vi.fn(async () => null),
   recordPublishStep: vi.fn(),
   claimSummaryCommentCreation: vi.fn(async () => true),
 }));
@@ -37,8 +39,12 @@ vi.mock("../src/review/publish/publishReview.js", async (importOriginal) => {
 });
 
 import { safeReaction } from "../src/agentWork/githubPrSurface.js";
+import {
+  resolveVerifiedSummaryCommentRef,
+  upsertReviewSummaryComment,
+} from "../src/github/reviewPublish.js";
 import { upsertSummaryCommentWithCreationClaim } from "../src/review/publish/publishReview.js";
-import { recordPublishStep } from "../src/agentWork/repository.js";
+import { getSummaryCommentGithubId, recordPublishStep } from "../src/agentWork/repository.js";
 
 const cfg = {} as Config;
 const pool = {} as Pool;
@@ -97,6 +103,41 @@ describe("executeAckJob", () => {
         step: "progress_comment",
         githubId: 42,
       }),
+    );
+  });
+
+  it("uses stored summary id without resolve scan when progress has no work item id", async () => {
+    vi.mocked(getSummaryCommentGithubId).mockResolvedValue(55);
+    vi.mocked(resolveVerifiedSummaryCommentRef).mockResolvedValue({
+      id: 55,
+      url: "https://example.com/55",
+      source: "hint",
+    });
+
+    await executeAckJob(cfg, pool, {
+      ...ackData(),
+      progress: { lens: "review", headSha: "sha", source: "auto" },
+    });
+
+    expect(getSummaryCommentGithubId).toHaveBeenCalledWith(pool, "o/r#1", "review");
+    expect(resolveVerifiedSummaryCommentRef).toHaveBeenCalledWith(
+      "tok",
+      "o",
+      "r",
+      1,
+      expect.any(String),
+      55,
+      expect.any(Number),
+    );
+    expect(upsertReviewSummaryComment).toHaveBeenCalledWith(
+      "tok",
+      "o",
+      "r",
+      1,
+      expect.any(String),
+      expect.any(String),
+      { id: 55, url: "https://example.com/55" },
+      expect.any(Number),
     );
   });
 });

--- a/test/descriptionExecutor.test.ts
+++ b/test/descriptionExecutor.test.ts
@@ -3,7 +3,7 @@ import type { Pool } from "pg";
 import type { JobWithMetadata, PgBoss } from "pg-boss";
 import type { DurableJobSpec } from "../src/agentWork/durableJob.js";
 import type { AgentWorkItem, DescriptionJobData } from "../src/agentWork/types.js";
-import { DESCRIPTION_FAILURE_MESSAGE } from "../src/settings/index.js";
+import { DESCRIPTION_AGENT_HEADER, DESCRIPTION_FAILURE_MESSAGE } from "../src/settings/index.js";
 import { makeTestConfig } from "./helpers/config.js";
 import * as repo from "../src/agentWork/repository.js";
 import {
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
   runDescriptionRun: vi.fn(),
   runDurableWorkItem: vi.fn(),
   withPrRepositoryView: vi.fn(),
+  pullsGet: vi.fn(),
   createComment: vi.fn(),
 }));
 
@@ -59,6 +60,7 @@ vi.mock("../src/github/appAuth.js", () => ({
   getAppBotIdentity: vi.fn(),
   installationOctokit: vi.fn(() => ({
     rest: {
+      pulls: { get: mocks.pullsGet },
       issues: { createComment: mocks.createComment },
     },
   })),
@@ -138,6 +140,23 @@ function mockDurableExecution(item = descriptionItem()): void {
   });
 }
 
+async function runTerminalFailure(
+  source: "slash" | "auto",
+  prBody = "manual pr body",
+): Promise<void> {
+  mocks.pullsGet.mockResolvedValue({ data: { body: prBody } });
+  const item = descriptionItem(source);
+  mocks.runDurableWorkItem.mockImplementation(async (spec: DurableJobSpec) => {
+    const installation = {
+      token: "tok",
+      expiresAtTs: Date.now() + 60_000,
+      ttlMs: 60_000,
+    };
+    await spec.onTerminalFailure?.(item, installation, new Error("dead"));
+  });
+  await executeDescriptionJob(cfg, pool, boss, descriptionJob(3, 3));
+}
+
 describe("executeDescriptionJob", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -147,6 +166,7 @@ describe("executeDescriptionJob", () => {
       publishSuperseded: false,
     });
     mocks.createComment.mockResolvedValue(undefined);
+    mocks.pullsGet.mockResolvedValue({ data: { body: "manual pr body" } });
     mocks.withPrRepositoryView.mockImplementation(async (_params, run) =>
       run({
         agentCwd: "/tmp/pr-agent",
@@ -157,18 +177,9 @@ describe("executeDescriptionJob", () => {
   });
 
   it("posts slash failure comment on terminal pg-boss attempt", async () => {
-    const item = descriptionItem("slash");
-    mocks.runDurableWorkItem.mockImplementation(async (spec: DurableJobSpec) => {
-      const installation = {
-        token: "tok",
-        expiresAtTs: Date.now() + 60_000,
-        ttlMs: 60_000,
-      };
-      await spec.onTerminalFailure?.(item, installation, new Error("dead"));
-    });
+    await runTerminalFailure("slash");
 
-    await executeDescriptionJob(cfg, pool, boss, descriptionJob(3, 3));
-
+    expect(mocks.pullsGet).not.toHaveBeenCalled();
     expect(mocks.createComment).toHaveBeenCalledWith({
       owner: "o",
       repo: "r",
@@ -177,19 +188,17 @@ describe("executeDescriptionJob", () => {
     });
   });
 
-  it("stays silent on terminal failure for auto source", async () => {
-    const item = descriptionItem("auto");
-    mocks.runDurableWorkItem.mockImplementation(async (spec: DurableJobSpec) => {
-      const installation = {
-        token: "tok",
-        expiresAtTs: Date.now() + 60_000,
-        ttlMs: 60_000,
-      };
-      await spec.onTerminalFailure?.(item, installation, new Error("dead"));
-    });
+  it("posts auto failure comment when description header is absent", async () => {
+    await runTerminalFailure("auto", "manual pr body");
 
-    await executeDescriptionJob(cfg, pool, boss, descriptionJob(3, 3));
+    expect(mocks.pullsGet).toHaveBeenCalled();
+    expect(mocks.createComment).toHaveBeenCalled();
+  });
 
+  it("stays silent for auto terminal failure when description header is present", async () => {
+    await runTerminalFailure("auto", `intro\n${DESCRIPTION_AGENT_HEADER}\ncontent`);
+
+    expect(mocks.pullsGet).toHaveBeenCalled();
     expect(mocks.createComment).not.toHaveBeenCalled();
   });
 

--- a/test/integration/migrations.integration.test.ts
+++ b/test/integration/migrations.integration.test.ts
@@ -11,6 +11,9 @@ const EXPECTED_MIGRATIONS = [
   "005_retention_indexes.sql",
   "006_retention_fk_indexes.sql",
   "007_ask_publish_records.sql",
+  "008_review_tests_lens.sql",
+  "009_summary_comment_claim.sql",
+  "010_drop_max_attempts.sql",
 ];
 
 describe.skipIf(!hasDatabase)("migrations (integration)", () => {

--- a/test/reviewLightweightCompletion.test.ts
+++ b/test/reviewLightweightCompletion.test.ts
@@ -4,16 +4,25 @@ import { tryLightweightAutoReviewCompletion } from "../src/agentWork/reviewLight
 import type { AgentWorkItem } from "../src/agentWork/types.js";
 
 vi.mock("../src/github/reviewPublish.js", () => ({
+  resolveVerifiedSummaryCommentRef: vi.fn(async () => null),
   upsertReviewSummaryComment: vi.fn(async () => ({ id: 42, updated: true })),
 }));
 
 vi.mock("../src/agentWork/repository.js", () => ({
+  getSummaryCommentGithubId: vi.fn(async () => null),
   shouldSkipWork: vi.fn(),
   recordPublishStep: vi.fn(async () => undefined),
 }));
 
-import { upsertReviewSummaryComment } from "../src/github/reviewPublish.js";
-import { recordPublishStep, shouldSkipWork } from "../src/agentWork/repository.js";
+import {
+  resolveVerifiedSummaryCommentRef,
+  upsertReviewSummaryComment,
+} from "../src/github/reviewPublish.js";
+import {
+  getSummaryCommentGithubId,
+  recordPublishStep,
+  shouldSkipWork,
+} from "../src/agentWork/repository.js";
 
 const pool = {} as Pool;
 
@@ -85,6 +94,49 @@ describe("tryLightweightAutoReviewCompletion", () => {
     expect(recordPublishStep).toHaveBeenCalledWith(
       pool,
       expect.objectContaining({ step: "summary_comment", githubId: 42 }),
+    );
+  });
+
+  it("uses stored summary id without scanning when verified", async () => {
+    vi.mocked(getSummaryCommentGithubId).mockResolvedValue(55);
+    vi.mocked(resolveVerifiedSummaryCommentRef).mockResolvedValue({
+      id: 55,
+      url: "https://example.com/55",
+      source: "hint",
+    });
+
+    await tryLightweightAutoReviewCompletion(pool, {
+      item: autoReviewItem(),
+      reviewLens: "review",
+      token: "tok",
+      tokenExpiresAtTs: 1_000_000,
+      preflight: {
+        files: [{ filename: "README.md" }],
+        truncated: false,
+        fileCount: 1,
+        totalChanges: 1,
+      },
+    });
+
+    expect(getSummaryCommentGithubId).toHaveBeenCalledWith(pool, "o/r#1", "review");
+    expect(resolveVerifiedSummaryCommentRef).toHaveBeenCalledWith(
+      "tok",
+      "o",
+      "r",
+      1,
+      expect.any(String),
+      55,
+      1_000_000,
+    );
+    expect(upsertReviewSummaryComment).toHaveBeenCalledWith(
+      "tok",
+      "o",
+      "r",
+      1,
+      expect.any(String),
+      expect.any(String),
+      { id: 55, url: "https://example.com/55" },
+      1_000_000,
     );
   });
 });


### PR DESCRIPTION
## Summary

- Drop dead `agent_work_items.max_attempts` column (`010_drop_max_attempts.sql`) and document pg-boss-only retries in configuration.
- Post auto-description terminal failure comments when the PR body still lacks the agent description header; slash behavior unchanged.
- Pass verified `publish_records` summary/progress comment ids into ack and lightweight summary upserts to skip sentinel scans when a stored id is available.

## Test plan

- [x] `pnpm test -- ackExecutor reviewLightweightCompletion descriptionExecutor`
- [x] `pnpm test`
- [x] `pnpm test:integration`
- [x] `pnpm typecheck && pnpm lint && pnpm fmt:check`

Closes #82

___

## PR Agent Description

### PR Type

Enhancement, Bug fix, Tests, Documentation

### Description

- Drop unused `max_attempts` column; pg-boss owns all work-item retries
- Reuse stored summary comment IDs in ack and lightweight review paths
- Skip auto description failure comments when PR body already has agent header
- Add executor tests and register migrations 008–010 in integration suite

### Changes Diagram

```mermaid
flowchart LR
  A["Agent work cleanup"] --> B["Drop max_attempts column"]
  B --> C["pg-boss controls retries"]
  A --> D["Summary comment publish"]
  D --> E["Load stored GitHub ID"]
  E --> F["Verify and upsert comment"]
  A --> G["Description terminal failure"]
  G --> H["Skip if header in PR body"]
```

### File Walkthrough

<details>
<summary>Enhancement (3 files)</summary>

<details>
<summary>Remove unused max_attempts column</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/124/files#diff-4faf77ac0af6ba590d4a30583b6e07bcd396070f2bb2f033f8755e63f2d5092b"><code>migrations/010_drop_max_attempts.sql</code></a>

- Drops `agent_work_items.max_attempts` via migration 010
- Retries are handled solely by pg-boss queue settings

</details>

<details>
<summary>Reuse stored summary ID on ack</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/124/files#diff-e6d6e214faadfaeb3ff1ee70099c91c9425a27b07c7c1a20561e70fe513ac648"><code>src/agentWork/executors/ackExecutor.ts</code></a>

- Looks up persisted summary comment GitHub ID from repository
- Verifies ref before upsert when no work item ID is present

</details>

<details>
<summary>Reuse stored ID for lightweight reviews</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/124/files#diff-e566aec5a920378ca6927d34b0f585be187634e08b74870ab3c35ea92f691f1f"><code>src/agentWork/reviewLightweightCompletion.ts</code></a>

- Same stored-ID lookup and verify path as ack executor
- Consolidates token-expiry branches into one upsert call

</details>

</details>

<details>
<summary>Documentation (1 file)</summary>

<details>
<summary>Document pg-boss-only retry model</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/124/files#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180"><code>docs/configuration.md</code></a>

- Removes dual retry-model table referencing SQL and queue limits
- States retries are controlled only by pg-boss env vars

</details>

</details>

<details>
<summary>Bug fix (1 file)</summary>

<details>
<summary>Guard auto description failure comments</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/124/files#diff-7b530f5b445722986df21f12bea8627bf45d1d668b8f398cf93c0187b766157f"><code>src/agentWork/executors/descriptionExecutor.ts</code></a>

- Auto source now posts failure comment only when PR body lacks agent header
- Slash source still always posts the failure message

</details>

</details>

<details>
<summary>Tests (4 files)</summary>

<details>
<summary>Cover description terminal failure paths</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/124/files#diff-e43cd6eb8835e60343aea7bbd8f767c81cf86e4df49a3dbfd9ae01be696632a6"><code>test/descriptionExecutor.test.ts</code></a>

- Tests slash, auto-without-header, and auto-with-header cases
- Asserts pulls.get and createComment call behavior

</details>

<details>
<summary>Test ack stored summary ID path</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/124/files#diff-949066e410b71b4b31024e1e9ef429c35a34f0fe2fd5db741056583c41b9715f"><code>test/ackExecutor.test.ts</code></a>

- Mocks getSummaryCommentGithubId and resolveVerifiedSummaryCommentRef
- Verifies known-existing ref passed to upsertReviewSummaryComment

</details>

<details>
<summary>Test lightweight stored ID reuse</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/124/files#diff-c9bda6d4f21ba9d3525578a881d1de648f289eae38fe7554d89de296611e5246"><code>test/reviewLightweightCompletion.test.ts</code></a>

- Adds case for verified stored summary comment ID
- Updates mocks for new repository and publish helpers

</details>

<details>
<summary>Register migrations 008 through 010</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/124/files#diff-2387ac32523fda5cdb960df29d6649a13de46d04995707e0886e09c1515f010a"><code>test/integration/migrations.integration.test.ts</code></a>

- Adds expected entries for review-tests lens, summary claim, and drop max_attempts

</details>

</details>