### PR TITLE
Fix triage discovery and add scoped /triage runs

### DIFF
--- a/src/agent/providers/cursor/agentRunner.ts
+++ b/src/agent/providers/cursor/agentRunner.ts
@@ -9,6 +9,7 @@ import type {
 import { attachCursorRunContext } from "./runContext.js";
 import { getCursorModel, toCursorSdkModelSelection } from "./models.js";
 import { createMcpBridge } from "./mcpBridge.js";
+import { assertCursorRipgrepConfigured } from "./ripgrepBoot.js";
 
 function assistantText(content: Context["messages"][number]): string {
   if (content.role !== "assistant" || !Array.isArray(content.content)) return "";
@@ -44,6 +45,7 @@ export const cursorAgentRunnerProvider: AgentRunnerProvider = {
       maxToolRounds: () => activeMaxToolRounds,
       toolRoundCounter,
     });
+    assertCursorRipgrepConfigured();
     const agent = await Agent.create({
       apiKey,
       model: sdkModelSelection,

--- a/src/agent/providers/cursor/agentRunner.ts
+++ b/src/agent/providers/cursor/agentRunner.ts
@@ -38,6 +38,7 @@ export const cursorAgentRunnerProvider: AgentRunnerProvider = {
     if (!apiKey) {
       throw new Error("CURSOR_API_KEY is required for Cursor provider runs");
     }
+    assertCursorRipgrepConfigured();
     const bridge = await createMcpBridge({
       tools: () => context.tools ?? [],
       executors: () => activeExecutors,
@@ -45,7 +46,6 @@ export const cursorAgentRunnerProvider: AgentRunnerProvider = {
       maxToolRounds: () => activeMaxToolRounds,
       toolRoundCounter,
     });
-    assertCursorRipgrepConfigured();
     const agent = await Agent.create({
       apiKey,
       model: sdkModelSelection,

--- a/src/agent/providers/cursor/cursorAnalytics.ts
+++ b/src/agent/providers/cursor/cursorAnalytics.ts
@@ -1,0 +1,32 @@
+import { posthog } from "../../../posthog.js";
+
+const WORKER_DISTINCT_ID = "worker";
+
+export function captureCursorWorkerEvent(
+  event: string,
+  properties?: Record<string, unknown>,
+): void {
+  posthog.capture({
+    distinctId: WORKER_DISTINCT_ID,
+    event,
+    properties: { provider: "cursor", ...properties },
+  });
+}
+
+export function captureCursorWorkerFailure(
+  step: string,
+  error: unknown,
+  properties?: Record<string, unknown>,
+): void {
+  const errorObj = error instanceof Error ? error : new Error(String(error));
+  captureCursorWorkerEvent("cursor worker failed", {
+    step,
+    error_message: errorObj.message,
+    ...properties,
+  });
+  posthog.captureException(errorObj, WORKER_DISTINCT_ID, {
+    type: "cursor",
+    step,
+    ...properties,
+  });
+}

--- a/src/agent/providers/cursor/ripgrepBoot.ts
+++ b/src/agent/providers/cursor/ripgrepBoot.ts
@@ -6,7 +6,10 @@ import { captureCursorWorkerEvent, captureCursorWorkerFailure } from "./cursorAn
 
 export function configureCursorRipgrepPath(): string | undefined {
   const configured = process.env.CURSOR_RIPGREP_PATH?.trim();
-  if (configured) return configured;
+  if (configured) {
+    process.env.CURSOR_RIPGREP_PATH = configured;
+    return configured;
+  }
 
   const rgName = process.platform === "win32" ? "rg.exe" : "rg";
   try {
@@ -33,7 +36,10 @@ export function configureCursorRipgrepPath(): string | undefined {
 
 export function assertCursorRipgrepConfigured(): string {
   const configured = process.env.CURSOR_RIPGREP_PATH?.trim();
-  if (configured) return configured;
+  if (configured) {
+    process.env.CURSOR_RIPGREP_PATH = configured;
+    return configured;
+  }
 
   const error = new Error(
     "Ripgrep path not configured for Cursor local agent. Call configureCursorRipgrepPath() at worker boot.",

--- a/src/agent/providers/cursor/ripgrepBoot.ts
+++ b/src/agent/providers/cursor/ripgrepBoot.ts
@@ -1,0 +1,43 @@
+import { accessSync, constants } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { captureCursorWorkerEvent, captureCursorWorkerFailure } from "./cursorAnalytics.js";
+
+export function configureCursorRipgrepPath(): string | undefined {
+  const configured = process.env.CURSOR_RIPGREP_PATH?.trim();
+  if (configured) return configured;
+
+  const rgName = process.platform === "win32" ? "rg.exe" : "rg";
+  try {
+    const baseRequire = createRequire(fileURLToPath(import.meta.url));
+    const sdkEntry = baseRequire.resolve("@cursor/sdk");
+    const sdkRequire = createRequire(path.join(path.dirname(sdkEntry), "index.js"));
+    const platformPkgJson = sdkRequire.resolve(
+      `@cursor/sdk-${process.platform}-${process.arch}/package.json`,
+    );
+    const rgPath = path.join(path.dirname(platformPkgJson), "bin", rgName);
+    accessSync(rgPath, constants.X_OK);
+    process.env.CURSOR_RIPGREP_PATH = rgPath;
+    captureCursorWorkerEvent("cursor ripgrep configured", {
+      source: "platform_package",
+    });
+    return rgPath;
+  } catch (error) {
+    captureCursorWorkerFailure("ripgrep_resolve", error, {
+      platform: `${process.platform}-${process.arch}`,
+    });
+    return undefined;
+  }
+}
+
+export function assertCursorRipgrepConfigured(): string {
+  const configured = process.env.CURSOR_RIPGREP_PATH?.trim();
+  if (configured) return configured;
+
+  const error = new Error(
+    "Ripgrep path not configured for Cursor local agent. Call configureCursorRipgrepPath() at worker boot.",
+  );
+  captureCursorWorkerFailure("ripgrep_required", error);
+  throw error;
+}

--- a/src/agent/providers/cursor/ripgrepBoot.ts
+++ b/src/agent/providers/cursor/ripgrepBoot.ts
@@ -15,7 +15,7 @@ export function configureCursorRipgrepPath(): string | undefined {
   try {
     const baseRequire = createRequire(fileURLToPath(import.meta.url));
     const sdkEntry = baseRequire.resolve("@cursor/sdk");
-    const sdkRequire = createRequire(path.join(path.dirname(sdkEntry), "index.js"));
+    const sdkRequire = createRequire(sdkEntry);
     const platformPkgJson = sdkRequire.resolve(
       `@cursor/sdk-${process.platform}-${process.arch}/package.json`,
     );
@@ -35,7 +35,7 @@ export function configureCursorRipgrepPath(): string | undefined {
 }
 
 export function assertCursorRipgrepConfigured(): string {
-  const configured = process.env.CURSOR_RIPGREP_PATH?.trim();
+  const configured = process.env.CURSOR_RIPGREP_PATH?.trim() || configureCursorRipgrepPath();
   if (configured) {
     process.env.CURSOR_RIPGREP_PATH = configured;
     return configured;

--- a/src/agent/providers/cursor/streamCursor.ts
+++ b/src/agent/providers/cursor/streamCursor.ts
@@ -10,6 +10,7 @@ import { approximateCursorUsage, buildCursorSendText } from "./promptBuilder.js"
 import { createMcpBridge } from "./mcpBridge.js";
 import { detachCursorRunContext, getCursorRunContext } from "./runContext.js";
 import { formatCursorRunError, formatCursorStartupError } from "./errors.js";
+import { assertCursorRipgrepConfigured } from "./ripgrepBoot.js";
 
 function makeInitialMessage(model: Model<Api>): AssistantMessage {
   return {
@@ -88,6 +89,9 @@ export const streamCursor: StreamFunction<"cursor-sdk"> = (model, context, optio
       const textDeltas: string[] = [];
       let abortListener: (() => void) | undefined;
 
+      if (!runContext.agent) {
+        assertCursorRipgrepConfigured();
+      }
       agent =
         runContext.agent ??
         (await Agent.create({

--- a/src/agent/providers/cursor/workerBoot.ts
+++ b/src/agent/providers/cursor/workerBoot.ts
@@ -9,17 +9,20 @@ import {
   assertCursorModelId,
   listTopCursorModelIds,
 } from "./models.js";
+import { configureCursorRipgrepPath } from "./ripgrepBoot.js";
 import { registerCursorProvider } from "./register.js";
 
 export type CursorWorkerBootInfo = {
   readonly modelCount: number;
   readonly topModels: readonly string[];
   readonly fastModels: readonly string[];
+  readonly ripgrepPath?: string;
 };
 
 export async function initCursorWorker(
   cfg: Pick<Config, "cursorApiKey" | "piModel">,
 ): Promise<CursorWorkerBootInfo> {
+  const ripgrepPath = configureCursorRipgrepPath();
   await initCursorModelCapabilities(cfg.cursorApiKey);
   assertCursorModelId(cfg.piModel);
   assertCursorModelFastSelection(cfg.piModel);
@@ -28,5 +31,6 @@ export async function initCursorWorker(
     modelCount: getCursorCatalogItems().length,
     topModels: listTopCursorModelIds(10),
     fastModels: [...getFastParamModelIds()],
+    ripgrepPath,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { startEffectWebhookServer } from "./effect/server.js";
 import { prewarmAppBotIdentity } from "./github/appAuth.js";
 import { startAgentWorker } from "./worker.js";
 import { captureCursorWorkerFailure } from "./agent/providers/cursor/cursorAnalytics.js";
+import { shutdownPostHog } from "./posthog.js";
 async function main() {
   let cfg: Config;
   try {
@@ -43,6 +44,7 @@ async function main() {
       } catch (e) {
         captureCursorWorkerFailure("worker_boot", e);
         console.error(e instanceof Error ? e.message : e);
+        await shutdownPostHog();
         process.exit(1);
         return;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { initEvlog, logDebug, logInfo } from "./evlog.js";
 import { startEffectWebhookServer } from "./effect/server.js";
 import { prewarmAppBotIdentity } from "./github/appAuth.js";
 import { startAgentWorker } from "./worker.js";
+import { captureCursorWorkerFailure } from "./agent/providers/cursor/cursorAnalytics.js";
 async function main() {
   let cfg: Config;
   try {
@@ -37,8 +38,10 @@ async function main() {
           model_count: boot.modelCount,
           top_models: boot.topModels,
           fast_models: boot.fastModels,
+          ripgrep_configured: boot.ripgrepPath != null,
         });
       } catch (e) {
+        captureCursorWorkerFailure("worker_boot", e);
         console.error(e instanceof Error ? e.message : e);
         process.exit(1);
         return;

--- a/src/posthog.ts
+++ b/src/posthog.ts
@@ -5,7 +5,7 @@ const host = process.env.POSTHOG_HOST;
 
 export const posthog = new PostHog(apiKey, {
   ...(host ? { host } : {}),
-  enableExceptionAutocapture: false,
+  enableExceptionAutocapture: true,
 });
 
 export function shutdownPostHog(): Promise<void> {

--- a/test/cursorAnalytics.test.ts
+++ b/test/cursorAnalytics.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  capture: vi.fn(),
+  captureException: vi.fn(),
+}));
+
+vi.mock("../src/posthog.js", () => ({
+  posthog: {
+    capture: mocks.capture,
+    captureException: mocks.captureException,
+  },
+}));
+
+import {
+  captureCursorWorkerEvent,
+  captureCursorWorkerFailure,
+} from "../src/agent/providers/cursor/cursorAnalytics.js";
+
+describe("cursorAnalytics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("captures cursor worker events with worker distinct id", () => {
+    captureCursorWorkerEvent("cursor ripgrep configured", { source: "platform_package" });
+
+    expect(mocks.capture).toHaveBeenCalledWith({
+      distinctId: "worker",
+      event: "cursor ripgrep configured",
+      properties: {
+        provider: "cursor",
+        source: "platform_package",
+      },
+    });
+  });
+
+  it("captures cursor worker failures and exceptions with step context", () => {
+    captureCursorWorkerFailure("ripgrep_required", new Error("missing rg"), {
+      platform: "linux-x64",
+    });
+
+    expect(mocks.capture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "cursor worker failed",
+        properties: expect.objectContaining({
+          step: "ripgrep_required",
+          error_message: "missing rg",
+          platform: "linux-x64",
+        }),
+      }),
+    );
+    expect(mocks.captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      "worker",
+      expect.objectContaining({
+        type: "cursor",
+        step: "ripgrep_required",
+      }),
+    );
+  });
+});

--- a/test/cursorRipgrepBoot.test.ts
+++ b/test/cursorRipgrepBoot.test.ts
@@ -56,10 +56,25 @@ describe("configureCursorRipgrepPath", () => {
     expect(mocks.capture).not.toHaveBeenCalled();
   });
 
-  it("throws and reports to posthog when ripgrep is required but missing", () => {
+  it("configures ripgrep on demand when assert runs without prior boot", () => {
     delete process.env.CURSOR_RIPGREP_PATH;
 
-    expect(() => assertCursorRipgrepConfigured()).toThrow(/Ripgrep path not configured/);
+    const rgPath = assertCursorRipgrepConfigured();
+
+    expect(rgPath).toBeTruthy();
+    expect(process.env.CURSOR_RIPGREP_PATH).toBe(rgPath);
+  });
+
+  it("throws and reports to posthog when ripgrep is required but missing", () => {
+    delete process.env.CURSOR_RIPGREP_PATH;
+    const arch = process.arch;
+    Object.defineProperty(process, "arch", { value: "fakearch", configurable: true });
+
+    try {
+      expect(() => assertCursorRipgrepConfigured()).toThrow(/Ripgrep path not configured/);
+    } finally {
+      Object.defineProperty(process, "arch", { value: arch, configurable: true });
+    }
     expect(mocks.captureException).toHaveBeenCalledWith(
       expect.any(Error),
       "worker",

--- a/test/cursorRipgrepBoot.test.ts
+++ b/test/cursorRipgrepBoot.test.ts
@@ -1,0 +1,69 @@
+import * as fs from "node:fs";
+import { constants } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  capture: vi.fn(),
+  captureException: vi.fn(),
+}));
+
+vi.mock("../src/posthog.js", () => ({
+  posthog: {
+    capture: mocks.capture,
+    captureException: mocks.captureException,
+  },
+}));
+
+import {
+  assertCursorRipgrepConfigured,
+  configureCursorRipgrepPath,
+} from "../src/agent/providers/cursor/ripgrepBoot.js";
+
+describe("configureCursorRipgrepPath", () => {
+  const previous = process.env.CURSOR_RIPGREP_PATH;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (previous === undefined) {
+      delete process.env.CURSOR_RIPGREP_PATH;
+    } else {
+      process.env.CURSOR_RIPGREP_PATH = previous;
+    }
+  });
+
+  it("resolves bundled rg from the cursor platform optional package", () => {
+    delete process.env.CURSOR_RIPGREP_PATH;
+
+    const rgPath = configureCursorRipgrepPath();
+
+    expect(rgPath).toBeTruthy();
+    expect(process.env.CURSOR_RIPGREP_PATH).toBe(rgPath);
+    fs.accessSync(rgPath!, constants.X_OK);
+    expect(mocks.capture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "cursor ripgrep configured",
+      }),
+    );
+  });
+
+  it("keeps an explicit CURSOR_RIPGREP_PATH", () => {
+    process.env.CURSOR_RIPGREP_PATH = "/custom/rg";
+
+    expect(configureCursorRipgrepPath()).toBe("/custom/rg");
+    expect(mocks.capture).not.toHaveBeenCalled();
+  });
+
+  it("throws and reports to posthog when ripgrep is required but missing", () => {
+    delete process.env.CURSOR_RIPGREP_PATH;
+
+    expect(() => assertCursorRipgrepConfigured()).toThrow(/Ripgrep path not configured/);
+    expect(mocks.captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      "worker",
+      expect.objectContaining({ step: "ripgrep_required" }),
+    );
+  });
+});

--- a/test/posthog.test.ts
+++ b/test/posthog.test.ts
@@ -33,7 +33,7 @@ describe("posthog client", () => {
     delete process.env.POSTHOG_HOST;
   });
 
-  it("constructs the client without process-wide exception autocapture", async () => {
+  it("constructs the client with exception autocapture enabled", async () => {
     process.env.POSTHOG_PROJECT_TOKEN = "token";
     process.env.POSTHOG_HOST = "https://posthog.example";
 
@@ -41,7 +41,7 @@ describe("posthog client", () => {
 
     expect(mockPostHog.PostHog).toHaveBeenCalledWith("token", {
       host: "https://posthog.example",
-      enableExceptionAutocapture: false,
+      enableExceptionAutocapture: true,
     });
   });
 

--- a/test/setup/cursor-sdk-mock.ts
+++ b/test/setup/cursor-sdk-mock.ts
@@ -18,3 +18,5 @@ vi.mock("@cursor/sdk", () => ({
   },
   CursorAgentError: MockCursorAgentError,
 }));
+
+process.env.CURSOR_RIPGREP_PATH ??= "/test/rg";


### PR DESCRIPTION
## Summary

- Fix triage inventory discovery with review-pointer lens markers, publish_records backfill, and `review-tests` eligibility
- Add scoped `/triage`: PR conversation runs all findings; inline-thread reply runs one finding, with clearer acks and outcome messaging
- Instrument triage intake, executor, and publish paths in PostHog
- Harden scoped triage edge cases (missing anchor, resolved threads, webhook reply targeting)
- Configure Cursor SDK ripgrep at worker boot and report cursor worker failures to PostHog; enable exception autocapture

## Test plan

- [x] `pnpm run check:code`
- [x] Unit tests for triage executor, slash intake, prior feedback, analytics, cursor ripgrep boot
- [ ] `/triage` on a PR with zeus-review inline threads confirms non-zero inventory
- [ ] Inline-thread `/triage` scopes to one finding; worker boot logs `ripgrep_configured: true`

___

## PR Agent Description

### PR Type

Enhancement, Tests

### Description

- Auto-resolve bundled ripgrep from Cursor SDK platform packages at worker boot
- Guard agent creation with ripgrep path assertion when not preconfigured
- Add PostHog helpers for cursor worker events and boot failures
- Enable PostHog exception autocapture for worker error reporting

### Changes Diagram

```mermaid
flowchart LR
  A["Worker boot"] --> B["Resolve ripgrep path"]
  B --> C["Assert before Agent.create"]
  B --> D["PostHog worker events"]
  E["Boot or resolve failure"] --> F["captureException"]
```

### File Walkthrough

<details>
<summary>Enhancement (7 files)</summary>

<details>
<summary>Resolve bundled ripgrep at worker boot</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/132/files#diff-721f402390c606e7e50ffea72b1a996b5b1121351373bf086d5d82e80897d742"><code>src/agent/providers/cursor/ripgrepBoot.ts</code></a>

- Resolves rg from @cursor/sdk platform optional package
- Honors explicit CURSOR_RIPGREP_PATH when already set
- Reports resolve failures via cursor analytics helpers

</details>

<details>
<summary>PostHog helpers for cursor worker</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/132/files#diff-f5a7e3566f045ebc649c4d6cf3519807905673f48e47325746f553df061dd432"><code>src/agent/providers/cursor/cursorAnalytics.ts</code></a>

- captureCursorWorkerEvent with worker distinct id
- captureCursorWorkerFailure sends event and exception

</details>

<details>
<summary>Wire ripgrep config into worker init</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/132/files#diff-148cda89a8dd2502f5b77a57a2d3b420d87c9718d69e874f978477638ef0c7d3"><code>src/agent/providers/cursor/workerBoot.ts</code></a>

- Calls configureCursorRipgrepPath during initCursorWorker
- Exposes ripgrepPath on CursorWorkerBootInfo

</details>

<details>
<summary>Require ripgrep before agent runner</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/132/files#diff-6352813a80313c6af522043bde13cb05526b19753b6d304121d8048418b32c7d"><code>src/agent/providers/cursor/agentRunner.ts</code></a>

- Calls assertCursorRipgrepConfigured before Agent.create

</details>

<details>
<summary>Require ripgrep before streaming agent</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/132/files#diff-20e182127e246fa8372af090f291b3e649e8f01718179612f87e89a955f91032"><code>src/agent/providers/cursor/streamCursor.ts</code></a>

- Asserts ripgrep configured when creating new agent

</details>

<details>
<summary>Log ripgrep status and boot failures</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/132/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80"><code>src/index.ts</code></a>

- Logs ripgrep_configured in worker boot output
- Captures worker_boot failures to PostHog

</details>

<details>
<summary>Enable PostHog exception autocapture</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/132/files#diff-670e7b7e8ff0b66cc1ead10124c11a98d983724b787033043b7eacce36811458"><code>src/posthog.ts</code></a>

- Sets enableExceptionAutocapture to true

</details>

</details>

<details>
<summary>Tests (4 files)</summary>

<details>
<summary>Tests for ripgrep boot resolution</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/132/files#diff-cf8519d8238398ac127734a03aa34be946cc54ff14a6e6c74f22611628b3fb4b"><code>test/cursorRipgrepBoot.test.ts</code></a>

- Covers bundled rg resolution and explicit env override
- Verifies assert throws and reports when missing

</details>

<details>
<summary>Tests for cursor worker analytics</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/132/files#diff-a475c0475cf705ebc30c737b92e9e4418ef061c8eb61615375171bc5e6fb5f54"><code>test/cursorAnalytics.test.ts</code></a>

- Verifies event capture with worker distinct id
- Verifies failure events and captureException calls

</details>

<details>
<summary>Update PostHog client construction test</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/132/files#diff-6ffd92d3656e9266eaec6cda7d92b251ee88254378e944a034b379bc5501a55d"><code>test/posthog.test.ts</code></a>

- Expects enableExceptionAutocapture true

</details>

<details>
<summary>Default ripgrep path in test setup</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/132/files#diff-2ee348e3f0e61e9c06c90985de1cf2d5e24b673b3710d54631cdc313371e5e1c"><code>test/setup/cursor-sdk-mock.ts</code></a>

- Sets CURSOR_RIPGREP_PATH for cursor SDK mocks

</details>

</details>