### PR TITLE
Record agent token and tool usage in review metrics

### DIFF
--- a/src/agent/providers/cursor/agentRunner.ts
+++ b/src/agent/providers/cursor/agentRunner.ts
@@ -115,11 +115,8 @@ export const cursorAgentRunnerProvider: AgentRunnerProvider = {
           content: prompt,
           timestamp: Date.now(),
         });
-        const hasPriorAssistantMessage = context.messages
-          .slice(0, -1)
-          .some((message) => message.role === "assistant");
         const { text: sendText, inputChars } = buildCursorSendText(context, {
-          reuseAgentConversation: hasPriorAssistantMessage,
+          reuseAgentConversation: true,
         });
         const assistant = await complete(model, context, {
           apiKey: cfg.cursorApiKey,

--- a/src/agent/providers/cursor/agentRunner.ts
+++ b/src/agent/providers/cursor/agentRunner.ts
@@ -6,8 +6,10 @@ import type {
   AgentRunnerSendOptions,
   AgentRunnerToolExecutor,
 } from "../interface.js";
+import { estimatedUsageFromTokenCounts } from "../usageMetadata.js";
 import { attachCursorRunContext } from "./runContext.js";
 import { getCursorModel, toCursorSdkModelSelection } from "./models.js";
+import { buildCursorSendText } from "./promptBuilder.js";
 import { createMcpBridge } from "./mcpBridge.js";
 import { assertCursorRipgrepConfigured } from "./ripgrepBoot.js";
 import { initCursorWorker, type CursorWorkerBootInfo } from "./workerBoot.js";
@@ -113,11 +115,24 @@ export const cursorAgentRunnerProvider: AgentRunnerProvider = {
           content: prompt,
           timestamp: Date.now(),
         });
+        const hasPriorAssistantMessage = context.messages
+          .slice(0, -1)
+          .some((message) => message.role === "assistant");
+        const { text: sendText, inputChars } = buildCursorSendText(context, {
+          reuseAgentConversation: hasPriorAssistantMessage,
+        });
         const assistant = await complete(model, context, {
           apiKey: cfg.cursorApiKey,
         });
         context.messages.push(assistant);
-        return { text: assistantText(assistant) };
+        return {
+          text: assistantText(assistant),
+          prompt: {
+            inputCharacters: inputChars,
+            inputBytes: Buffer.byteLength(sendText, "utf8"),
+          },
+          usage: estimatedUsageFromTokenCounts(assistant.usage.input, assistant.usage.output),
+        };
       },
       restrictToTools(nextTools, nextExecutors) {
         savedTools = [...(context.tools ?? [])];

--- a/src/agent/providers/cursor/mcpBridge.ts
+++ b/src/agent/providers/cursor/mcpBridge.ts
@@ -241,8 +241,16 @@ export async function createMcpBridge(options: McpBridgeOptions): Promise<McpBri
       return mcpResult;
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
-      safeRecordReviewMetric({ kind: "tool_call", name: toolName, ok: false });
-      return executorResultToMcp(message, true);
+      const mcpResult = executorResultToMcp(message, true);
+      const resultSize = mcpResultSize(mcpResult);
+      safeRecordReviewMetric({
+        kind: "tool_call",
+        name: toolName,
+        ok: false,
+        resultBytes: resultSize.resultBytes,
+        resultCharacters: resultSize.resultCharacters,
+      });
+      return mcpResult;
     } finally {
       extra.signal?.removeEventListener("abort", linkAbort);
       options.signal?.removeEventListener("abort", linkAbort);

--- a/src/agent/providers/cursor/mcpBridge.ts
+++ b/src/agent/providers/cursor/mcpBridge.ts
@@ -75,6 +75,17 @@ function executorResultToMcp(result: unknown, isError = false): CallToolResult {
   };
 }
 
+function mcpResultSize(result: CallToolResult): {
+  resultBytes: number;
+  resultCharacters: number;
+} {
+  const text = result.content.map((block) => (block.type === "text" ? block.text : "")).join("");
+  return {
+    resultCharacters: text.length,
+    resultBytes: Buffer.byteLength(text, "utf8"),
+  };
+}
+
 function checkBearerAuth(req: IncomingMessage, token: string): boolean {
   const header = req.headers.authorization;
   return checkMcpBearerAuth(Array.isArray(header) ? header[0] : header, token);
@@ -217,13 +228,17 @@ export async function createMcpBridge(options: McpBridgeOptions): Promise<McpBri
           ? request.params.arguments
           : {};
       const out = await runWithAbortSignal(() => exec(args), abortController.signal);
+      const mcpResult = executorResultToMcp(out);
+      const resultSize = mcpResultSize(mcpResult);
       safeRecordReviewMetric({
         kind: "tool_call",
         name: toolName,
         ok: true,
         durationMs: Date.now() - toolStarted,
+        resultBytes: resultSize.resultBytes,
+        resultCharacters: resultSize.resultCharacters,
       });
-      return executorResultToMcp(out);
+      return mcpResult;
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       safeRecordReviewMetric({ kind: "tool_call", name: toolName, ok: false });

--- a/src/agent/providers/interface.ts
+++ b/src/agent/providers/interface.ts
@@ -1,11 +1,14 @@
 import type { Tool as PiTool } from "@earendil-works/pi-ai";
 import type { Config } from "../../config.js";
+import type {
+  AgentRunnerPromptMetadata,
+  AgentRunnerTurn,
+  AgentRunnerUsageMetadata,
+} from "./usageMetadata.js";
+
+export type { AgentRunnerPromptMetadata, AgentRunnerTurn, AgentRunnerUsageMetadata };
 
 export type AgentRunnerToolExecutor = (args: Record<string, unknown>) => Promise<unknown>;
-
-type AgentRunnerTurn = {
-  readonly text: string;
-};
 
 export type AgentRunnerSendOptions = {
   readonly maxToolRounds?: number;

--- a/src/agent/providers/pi/index.ts
+++ b/src/agent/providers/pi/index.ts
@@ -27,6 +27,7 @@ import {
 } from "../usageMetadata.js";
 
 function toolResultToText(result: unknown): string {
+  if (result === undefined) return "";
   return typeof result === "string" ? result : JSON.stringify(result);
 }
 

--- a/src/agent/providers/pi/index.ts
+++ b/src/agent/providers/pi/index.ts
@@ -70,24 +70,30 @@ function toCodingAgentTool(
     parameters: tool.parameters as never,
     execute: async (_toolCallId: string, params: Record<string, unknown>) => {
       if (!executor) {
+        safeRecordToolCallMetric({ kind: "tool_call", name: tool.name, ok: false });
         throw new Error(`No executor registered for tool ${tool.name}`);
       }
-      if (refreshBeforeTool) {
-        await refreshBeforeTool(tool.name);
+      try {
+        if (refreshBeforeTool) {
+          await refreshBeforeTool(tool.name);
+        }
+        const result = await executor(params);
+        const size = toolResultSize(result);
+        safeRecordToolCallMetric({
+          kind: "tool_call",
+          name: tool.name,
+          ok: true,
+          resultBytes: size.resultBytes,
+          resultCharacters: size.resultCharacters,
+        });
+        return {
+          content: [{ type: "text" as const, text: toolResultToText(result) }],
+          details: result && typeof result === "object" ? (result as Record<string, unknown>) : {},
+        };
+      } catch (error) {
+        safeRecordToolCallMetric({ kind: "tool_call", name: tool.name, ok: false });
+        throw error;
       }
-      const result = await executor(params);
-      const size = toolResultSize(result);
-      safeRecordToolCallMetric({
-        kind: "tool_call",
-        name: tool.name,
-        ok: true,
-        resultBytes: size.resultBytes,
-        resultCharacters: size.resultCharacters,
-      });
-      return {
-        content: [{ type: "text" as const, text: toolResultToText(result) }],
-        details: result && typeof result === "object" ? (result as Record<string, unknown>) : {},
-      };
     },
   });
 }

--- a/src/agent/providers/pi/index.ts
+++ b/src/agent/providers/pi/index.ts
@@ -14,14 +14,38 @@ import type { TextContent, Tool as PiTool } from "@earendil-works/pi-ai";
 import { mkdtemp, rm, chmod } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { recordReviewMetric } from "../../../review/run/reviewRunMetrics.js";
 import type {
   AgentRunnerProvider,
   AgentRunnerSendOptions,
   AgentRunnerToolExecutor,
 } from "../interface.js";
+import {
+  exactUsageFromProviderUsage,
+  mergeExactUsage,
+  promptMetadataFromText,
+} from "../usageMetadata.js";
 
 function toolResultToText(result: unknown): string {
   return typeof result === "string" ? result : JSON.stringify(result);
+}
+
+function toolResultSize(result: unknown): { resultBytes: number; resultCharacters: number } {
+  const text = toolResultToText(result);
+  return {
+    resultCharacters: text.length,
+    resultBytes: Buffer.byteLength(text, "utf8"),
+  };
+}
+
+function safeRecordToolCallMetric(
+  event: Extract<Parameters<typeof recordReviewMetric>[0], { kind: "tool_call" }>,
+): void {
+  try {
+    recordReviewMetric(event);
+  } catch {
+    // metrics are best-effort outside review runs
+  }
 }
 
 function assistantMessageText(message: TurnEndEvent["message"]): string {
@@ -51,6 +75,14 @@ function toCodingAgentTool(
         await refreshBeforeTool(tool.name);
       }
       const result = await executor(params);
+      const size = toolResultSize(result);
+      safeRecordToolCallMetric({
+        kind: "tool_call",
+        name: tool.name,
+        ok: true,
+        resultBytes: size.resultBytes,
+        resultCharacters: size.resultCharacters,
+      });
       return {
         content: [{ type: "text" as const, text: toolResultToText(result) }],
         details: result && typeof result === "object" ? (result as Record<string, unknown>) : {},
@@ -115,6 +147,7 @@ export const piAgentRunnerProvider: AgentRunnerProvider = {
       async send(prompt: string, opts?: AgentRunnerSendOptions) {
         let sessionToolTurnCount = 0;
         let finalText = "";
+        let aggregatedUsage: ReturnType<typeof exactUsageFromProviderUsage> | undefined;
         // Inactivity (idle) budget, not a total wall-clock cap: a single prompt() drives the whole
         // multi-round agentic loop, whose duration scales with PR/repo size. We abort only when the
         // provider goes silent (no streamed message/tool/turn events) for the configured window, so
@@ -147,6 +180,12 @@ export const piAgentRunnerProvider: AgentRunnerProvider = {
           markActivity();
           if (event.type !== "turn_end") return;
           sessionToolTurnCount += 1;
+          if (event.message.role === "assistant" && event.message.usage) {
+            aggregatedUsage = mergeExactUsage(
+              aggregatedUsage,
+              exactUsageFromProviderUsage(event.message.usage),
+            );
+          }
           // A tool-free turn is the terminal turn of prompt(); capture only that answer text.
           if (event.toolResults.length === 0) {
             finalText = assistantMessageText(event.message);
@@ -166,7 +205,10 @@ export const piAgentRunnerProvider: AgentRunnerProvider = {
           } else {
             await run;
           }
-          return { text: finalText };
+          const promptMeta = promptMetadataFromText(prompt);
+          return aggregatedUsage
+            ? { text: finalText, prompt: promptMeta, usage: aggregatedUsage }
+            : { text: finalText, prompt: promptMeta };
         } finally {
           if (idleCheckHandle) clearInterval(idleCheckHandle);
           unsubscribe();

--- a/src/agent/providers/usageMetadata.ts
+++ b/src/agent/providers/usageMetadata.ts
@@ -52,6 +52,11 @@ export function exactUsageFromProviderUsage(usage: Usage): AgentRunnerUsageMetad
   };
 }
 
+function mergeOptionalCount(left?: number, right?: number): number | undefined {
+  if (left === undefined && right === undefined) return undefined;
+  return (left ?? 0) + (right ?? 0);
+}
+
 export function mergeExactUsage(
   left: AgentRunnerUsageMetadata | undefined,
   right: AgentRunnerUsageMetadata | undefined,
@@ -60,10 +65,10 @@ export function mergeExactUsage(
   if (!right) return left;
   return {
     estimated: false,
-    inputTokens: (left.inputTokens ?? 0) + (right.inputTokens ?? 0),
-    outputTokens: (left.outputTokens ?? 0) + (right.outputTokens ?? 0),
-    cacheReadTokens: (left.cacheReadTokens ?? 0) + (right.cacheReadTokens ?? 0),
-    cacheWriteTokens: (left.cacheWriteTokens ?? 0) + (right.cacheWriteTokens ?? 0),
-    totalTokens: (left.totalTokens ?? 0) + (right.totalTokens ?? 0),
+    inputTokens: mergeOptionalCount(left.inputTokens, right.inputTokens),
+    outputTokens: mergeOptionalCount(left.outputTokens, right.outputTokens),
+    cacheReadTokens: mergeOptionalCount(left.cacheReadTokens, right.cacheReadTokens),
+    cacheWriteTokens: mergeOptionalCount(left.cacheWriteTokens, right.cacheWriteTokens),
+    totalTokens: mergeOptionalCount(left.totalTokens, right.totalTokens),
   };
 }

--- a/src/agent/providers/usageMetadata.ts
+++ b/src/agent/providers/usageMetadata.ts
@@ -1,0 +1,69 @@
+import type { Usage } from "@earendil-works/pi-ai";
+
+export type AgentRunnerUsageMetadata = {
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+  readonly cacheReadTokens?: number;
+  readonly cacheWriteTokens?: number;
+  readonly totalTokens?: number;
+  readonly estimated: boolean;
+};
+
+export type AgentRunnerPromptMetadata = {
+  readonly inputCharacters: number;
+  readonly inputBytes: number;
+};
+
+export type AgentRunnerTurn = {
+  readonly text: string;
+  readonly usage?: AgentRunnerUsageMetadata;
+  readonly prompt?: AgentRunnerPromptMetadata;
+};
+
+export function promptMetadataFromText(text: string): AgentRunnerPromptMetadata {
+  return {
+    inputCharacters: text.length,
+    inputBytes: Buffer.byteLength(text, "utf8"),
+  };
+}
+
+export function estimatedUsageFromTokenCounts(
+  inputTokens: number,
+  outputTokens: number,
+): AgentRunnerUsageMetadata {
+  return {
+    estimated: true,
+    inputTokens,
+    outputTokens,
+    totalTokens: inputTokens + outputTokens,
+  };
+}
+
+export function exactUsageFromProviderUsage(usage: Usage): AgentRunnerUsageMetadata | undefined {
+  const hasTokenData = usage.totalTokens > 0 || usage.input > 0 || usage.output > 0;
+  if (!hasTokenData) return undefined;
+  return {
+    estimated: false,
+    inputTokens: usage.input,
+    outputTokens: usage.output,
+    cacheReadTokens: usage.cacheRead,
+    cacheWriteTokens: usage.cacheWrite,
+    totalTokens: usage.totalTokens,
+  };
+}
+
+export function mergeExactUsage(
+  left: AgentRunnerUsageMetadata | undefined,
+  right: AgentRunnerUsageMetadata | undefined,
+): AgentRunnerUsageMetadata | undefined {
+  if (!left) return right;
+  if (!right) return left;
+  return {
+    estimated: false,
+    inputTokens: (left.inputTokens ?? 0) + (right.inputTokens ?? 0),
+    outputTokens: (left.outputTokens ?? 0) + (right.outputTokens ?? 0),
+    cacheReadTokens: (left.cacheReadTokens ?? 0) + (right.cacheReadTokens ?? 0),
+    cacheWriteTokens: (left.cacheWriteTokens ?? 0) + (right.cacheWriteTokens ?? 0),
+    totalTokens: (left.totalTokens ?? 0) + (right.totalTokens ?? 0),
+  };
+}

--- a/src/agentRun/sessionHelpers.ts
+++ b/src/agentRun/sessionHelpers.ts
@@ -1,7 +1,7 @@
 import type { Api, AssistantMessage, KnownProvider, Provider } from "@earendil-works/pi-ai";
 import type { Tool as PiTool } from "@earendil-works/pi-ai";
 import type { Config } from "../config.js";
-import type { AgentRunnerSession } from "../agent/providers/interface.js";
+import type { AgentRunnerSession, AgentRunnerTurn } from "../agent/providers/interface.js";
 import { CURSOR_API, CURSOR_PROVIDER } from "../agent/providers/cursor/models.js";
 
 function sessionAssistantApi(runProvider: string, piProvider: KnownProvider): Api {
@@ -39,10 +39,14 @@ export async function runSubmitOnlyRound(
     readonly executors: Record<string, (args: Record<string, unknown>) => Promise<unknown>>;
   },
   prompt: string,
+  send: (session: AgentRunnerSession, prompt: string) => Promise<AgentRunnerTurn> = (
+    activeSession,
+    activePrompt,
+  ) => activeSession.send(activePrompt),
 ): Promise<string> {
   session.restrictToTools(submitOnly.piTools, submitOnly.executors);
   try {
-    return (await session.send(prompt)).text;
+    return (await send(session, prompt)).text;
   } finally {
     session.restoreTools();
   }

--- a/src/review/run/reviewRun.ts
+++ b/src/review/run/reviewRun.ts
@@ -30,6 +30,7 @@ import {
   buildSubmitOnlyReviewSessionTools,
   shouldContinueReviewRun,
 } from "./reviewRunSetup.js";
+import { sendReviewAgentTurn } from "./reviewRunAgentSend.js";
 
 export type { ReviewRunParams, ReviewRunResult } from "./reviewRunTypes.js";
 
@@ -69,7 +70,12 @@ export async function runFullPrReview(params: ReviewRunParams): Promise<ReviewRu
   let publishAttempts = 0;
 
   const sendSubmitOnlyRepair = async (prompt: string): Promise<string> =>
-    runSubmitOnlyRound(session, buildSubmitOnlyReviewSessionTools(setup), prompt);
+    runSubmitOnlyRound(
+      session,
+      buildSubmitOnlyReviewSessionTools(setup),
+      prompt,
+      sendReviewAgentTurn,
+    );
 
   const runValidationRepair = async () => {
     await runValidationRepairLoop({
@@ -93,7 +99,7 @@ export async function runFullPrReview(params: ReviewRunParams): Promise<ReviewRu
 
   const runInvestigationPhase = async () => {
     const investigationOpts = { maxToolRounds: cfg.maxToolRounds };
-    lastText = (await session.send(setup.userContent, investigationOpts)).text;
+    lastText = (await sendReviewAgentTurn(session, setup.userContent, investigationOpts)).text;
     if (!shouldContinueReviewRun(setup)) return;
 
     let anchorMenuBlock: string | undefined;
@@ -153,7 +159,8 @@ export async function runFullPrReview(params: ReviewRunParams): Promise<ReviewRu
       round++
     ) {
       lastText = (
-        await session.send(
+        await sendReviewAgentTurn(
+          session,
           [
             prompt,
             `Minimal valid ReviewPayload example:\n${JSON.stringify(REVIEW_PAYLOAD_MINIMAL_EXAMPLE, null, 2)}`,

--- a/src/review/run/reviewRunAgentSend.ts
+++ b/src/review/run/reviewRunAgentSend.ts
@@ -1,0 +1,24 @@
+import type {
+  AgentRunnerSendOptions,
+  AgentRunnerSession,
+  AgentRunnerTurn,
+} from "../../agent/providers/interface.js";
+import { recordReviewMetric } from "./reviewRunMetrics.js";
+
+export function recordAgentTurnMetrics(turn: AgentRunnerTurn): void {
+  recordReviewMetric({
+    kind: "model_turn",
+    ...(turn.usage ? { usage: turn.usage } : {}),
+    ...(turn.prompt ? { prompt: turn.prompt } : {}),
+  });
+}
+
+export async function sendReviewAgentTurn(
+  session: AgentRunnerSession,
+  prompt: string,
+  opts?: AgentRunnerSendOptions,
+): Promise<AgentRunnerTurn> {
+  const turn = await session.send(prompt, opts);
+  recordAgentTurnMetrics(turn);
+  return turn;
+}

--- a/src/review/run/reviewRunMetrics.ts
+++ b/src/review/run/reviewRunMetrics.ts
@@ -13,6 +13,23 @@ export type ReviewMetricEvent =
       readonly name: string;
       readonly ok: boolean;
       readonly durationMs?: number;
+      readonly resultBytes?: number;
+      readonly resultCharacters?: number;
+    }
+  | {
+      readonly kind: "model_turn";
+      readonly usage?: {
+        readonly estimated: boolean;
+        readonly inputTokens?: number;
+        readonly outputTokens?: number;
+        readonly cacheReadTokens?: number;
+        readonly cacheWriteTokens?: number;
+        readonly totalTokens?: number;
+      };
+      readonly prompt?: {
+        readonly inputCharacters: number;
+        readonly inputBytes: number;
+      };
     }
   | { readonly kind: "submit_validated"; readonly coercions: readonly string[] }
   | {
@@ -57,6 +74,18 @@ export type ReviewRunMetricsSnapshot = {
   readonly diffCacheEmptyAtFirstSubmit: boolean;
   readonly toolCallCount: number;
   readonly toolCallErrors: number;
+  readonly toolResultBytes: number;
+  readonly toolResultCharacters: number;
+  readonly modelTurnCount: number;
+  readonly promptBytes: number;
+  readonly promptCharacters: number;
+  readonly estimatedInputTokens: number;
+  readonly estimatedOutputTokens: number;
+  readonly providerInputTokens: number;
+  readonly providerOutputTokens: number;
+  readonly cacheReadTokens: number | null;
+  readonly cacheWriteTokens: number | null;
+  readonly estimatedTurnCount: number;
   readonly findingsCount: number;
   readonly severities: readonly string[];
   readonly wallClockMs: number;
@@ -84,6 +113,18 @@ type MutableReviewRunMetrics = {
   diffCacheEmptyAtFirstSubmit: boolean;
   toolCallCount: number;
   toolCallErrors: number;
+  toolResultBytes: number;
+  toolResultCharacters: number;
+  modelTurnCount: number;
+  promptBytes: number;
+  promptCharacters: number;
+  estimatedInputTokens: number;
+  estimatedOutputTokens: number;
+  providerInputTokens: number;
+  providerOutputTokens: number;
+  cacheReadTokens: number | null;
+  cacheWriteTokens: number | null;
+  estimatedTurnCount: number;
   findingsCount: number;
   severities: string[];
   lightweight?: boolean;
@@ -115,6 +156,18 @@ function createEmptyMetrics(meta: {
     diffCacheEmptyAtFirstSubmit: false,
     toolCallCount: 0,
     toolCallErrors: 0,
+    toolResultBytes: 0,
+    toolResultCharacters: 0,
+    modelTurnCount: 0,
+    promptBytes: 0,
+    promptCharacters: 0,
+    estimatedInputTokens: 0,
+    estimatedOutputTokens: 0,
+    providerInputTokens: 0,
+    providerOutputTokens: 0,
+    cacheReadTokens: null,
+    cacheWriteTokens: null,
+    estimatedTurnCount: 0,
     findingsCount: 0,
     severities: [],
   };
@@ -140,6 +193,28 @@ function bumpRecord(map: Record<string, number>, key: string, delta = 1): void {
   map[key] = (map[key] ?? 0) + delta;
 }
 
+function addKnownCacheTotal(current: number | null, delta: number | undefined): number | null {
+  if (delta === undefined) return null;
+  if (current === null) return delta;
+  return current + delta;
+}
+
+function recordModelTurnUsage(
+  metrics: MutableReviewRunMetrics,
+  usage: NonNullable<Extract<ReviewMetricEvent, { kind: "model_turn" }>["usage"]>,
+): void {
+  if (usage.estimated) {
+    metrics.estimatedTurnCount += 1;
+    metrics.estimatedInputTokens += usage.inputTokens ?? 0;
+    metrics.estimatedOutputTokens += usage.outputTokens ?? 0;
+  } else {
+    metrics.providerInputTokens += usage.inputTokens ?? 0;
+    metrics.providerOutputTokens += usage.outputTokens ?? 0;
+    metrics.cacheReadTokens = addKnownCacheTotal(metrics.cacheReadTokens, usage.cacheReadTokens);
+    metrics.cacheWriteTokens = addKnownCacheTotal(metrics.cacheWriteTokens, usage.cacheWriteTokens);
+  }
+}
+
 export function recordReviewMetric(event: ReviewMetricEvent): void {
   const metrics = getOrInitMetrics();
   if (!metrics) return;
@@ -154,6 +229,10 @@ export function recordReviewMetric(event: ReviewMetricEvent): void {
     case "tool_call":
       metrics.toolCallCount += 1;
       if (!event.ok) metrics.toolCallErrors += 1;
+      if (event.resultBytes != null) metrics.toolResultBytes += event.resultBytes;
+      if (event.resultCharacters != null) {
+        metrics.toolResultCharacters += event.resultCharacters;
+      }
       break;
     case "submit_validated":
       for (const rule of event.coercions) {
@@ -193,6 +272,14 @@ export function recordReviewMetric(event: ReviewMetricEvent): void {
       metrics.published = true;
       metrics.findingsCount = event.findingsCount;
       metrics.severities = [...event.severities];
+      break;
+    case "model_turn":
+      metrics.modelTurnCount += 1;
+      if (event.prompt) {
+        metrics.promptBytes += event.prompt.inputBytes;
+        metrics.promptCharacters += event.prompt.inputCharacters;
+      }
+      if (event.usage) recordModelTurnUsage(metrics, event.usage);
       break;
     default: {
       const exhaustive: never = event;
@@ -261,6 +348,18 @@ export function snapshotReviewRunMetrics(): ReviewRunMetricsSnapshot | null {
     diffCacheEmptyAtFirstSubmit: metrics.diffCacheEmptyAtFirstSubmit,
     toolCallCount: metrics.toolCallCount,
     toolCallErrors: metrics.toolCallErrors,
+    toolResultBytes: metrics.toolResultBytes,
+    toolResultCharacters: metrics.toolResultCharacters,
+    modelTurnCount: metrics.modelTurnCount,
+    promptBytes: metrics.promptBytes,
+    promptCharacters: metrics.promptCharacters,
+    estimatedInputTokens: metrics.estimatedInputTokens,
+    estimatedOutputTokens: metrics.estimatedOutputTokens,
+    providerInputTokens: metrics.providerInputTokens,
+    providerOutputTokens: metrics.providerOutputTokens,
+    cacheReadTokens: metrics.cacheReadTokens,
+    cacheWriteTokens: metrics.cacheWriteTokens,
+    estimatedTurnCount: metrics.estimatedTurnCount,
     findingsCount: metrics.findingsCount,
     severities: [...metrics.severities],
     wallClockMs,

--- a/src/review/run/reviewRunMetrics.ts
+++ b/src/review/run/reviewRunMetrics.ts
@@ -194,7 +194,7 @@ function bumpRecord(map: Record<string, number>, key: string, delta = 1): void {
 }
 
 function addKnownCacheTotal(current: number | null, delta: number | undefined): number | null {
-  if (delta === undefined) return null;
+  if (delta === undefined) return current;
   if (current === null) return delta;
   return current + delta;
 }

--- a/test/cursorAgentRunner.test.ts
+++ b/test/cursorAgentRunner.test.ts
@@ -7,11 +7,34 @@ import { Agent } from "@cursor/sdk";
 import { makeTestConfig } from "./helpers/config.js";
 
 const completeMock = vi.hoisted(() =>
-  vi.fn(async (_model: unknown, context: { messages: unknown[] }) => ({
-    role: "assistant",
-    content: [{ type: "text", text: `answer ${context.messages.length}` }],
-    timestamp: Date.now(),
-  })),
+  vi.fn(async (_model: unknown, context: { messages: unknown[]; systemPrompt?: string }) => {
+    const lastUser = [...context.messages].toReversed().find((message) => {
+      return (
+        typeof message === "object" &&
+        message != null &&
+        "role" in message &&
+        (message as { role: string }).role === "user"
+      );
+    }) as { content: string } | undefined;
+    const promptText = lastUser?.content ?? "";
+    const inputChars =
+      context.messages.length === 1
+        ? (context.systemPrompt?.length ?? 0) + promptText.length + 10
+        : promptText.length;
+    return {
+      role: "assistant",
+      content: [{ type: "text", text: `answer ${context.messages.length}` }],
+      usage: {
+        input: Math.ceil(inputChars / 4),
+        output: 4,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: Math.ceil(inputChars / 4) + 4,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      timestamp: Date.now(),
+    };
+  }),
 );
 const bridgeDisposeMock = vi.hoisted(() => vi.fn(async () => undefined));
 const createMcpBridgeMock = vi.hoisted(() =>
@@ -147,8 +170,31 @@ describe("cursorAgentRunnerProvider", () => {
       executors: {},
     });
 
-    await expect(session.send("one")).resolves.toEqual({ text: "answer 1" });
-    await expect(session.send("two")).resolves.toEqual({ text: "answer 3" });
+    await expect(session.send("one")).resolves.toMatchObject({
+      text: "answer 1",
+      prompt: {
+        inputCharacters: expect.any(Number),
+        inputBytes: expect.any(Number),
+      },
+      usage: {
+        estimated: true,
+        inputTokens: expect.any(Number),
+        outputTokens: 4,
+        totalTokens: expect.any(Number),
+      },
+    });
+    await expect(session.send("two")).resolves.toMatchObject({
+      text: "answer 3",
+      prompt: {
+        inputCharacters: 3,
+        inputBytes: 3,
+      },
+      usage: {
+        estimated: true,
+        inputTokens: 1,
+        outputTokens: 4,
+      },
+    });
     await session.dispose();
 
     expect(createMcpBridgeMock).toHaveBeenCalledTimes(1);

--- a/test/cursorMcpBridge.test.ts
+++ b/test/cursorMcpBridge.test.ts
@@ -98,6 +98,7 @@ describe("createMcpBridge", () => {
         const result = await client.callTool({ name: "noop", arguments: {} });
         expect(result.isError).not.toBe(true);
         expect(snapshotReviewRunMetrics()?.toolCallCount).toBe(1);
+        expect(snapshotReviewRunMetrics()?.toolResultBytes).toBeGreaterThan(0);
         await client.close();
       });
     });
@@ -121,6 +122,8 @@ describe("createMcpBridge", () => {
         expect(snapshotReviewRunMetrics()).toMatchObject({
           toolCallCount: 1,
           toolCallErrors: 1,
+          toolResultBytes: expect.any(Number),
+          toolResultCharacters: expect.any(Number),
         });
         await client.close();
       });

--- a/test/piAgentRunner.test.ts
+++ b/test/piAgentRunner.test.ts
@@ -309,7 +309,10 @@ describe("piAgentRunnerProvider.send", () => {
         message: makeAssistantMessage("Final answer."),
       });
       resolvePrompt?.();
-      await expect(sendPromise).resolves.toMatchObject({ text: "Final answer." });
+      await expect(sendPromise).resolves.toEqual({
+        text: "Final answer.",
+        prompt: { inputCharacters: 8, inputBytes: 8 },
+      });
       expect(abort).not.toHaveBeenCalled();
       expect(setIntervalSpy).toHaveBeenCalledTimes(1);
     } finally {

--- a/test/piAgentRunner.test.ts
+++ b/test/piAgentRunner.test.ts
@@ -6,6 +6,20 @@ type MockTurnEndEvent = {
   toolResults: unknown[];
   message: {
     role: "assistant";
+    usage?: {
+      input: number;
+      output: number;
+      cacheRead: number;
+      cacheWrite: number;
+      totalTokens: number;
+      cost: {
+        input: number;
+        output: number;
+        cacheRead: number;
+        cacheWrite: number;
+        total: number;
+      };
+    };
     content: Array<
       | { type: "text"; text: string }
       | { type: "thinking"; thinking: string }
@@ -105,6 +119,49 @@ describe("piAgentRunnerProvider.send", () => {
 
     const result = await runnerSession.send("question");
     expect(result.text).toBe("End-user summary and testing checklist.");
+    expect(result.prompt).toEqual({
+      inputCharacters: "question".length,
+      inputBytes: Buffer.byteLength("question", "utf8"),
+    });
+    expect(result.usage).toBeUndefined();
+  });
+
+  it("returns exact usage when mocked turn events include provider token data", async () => {
+    const session = buildMockSession((emit) => {
+      emit({
+        type: "turn_end",
+        toolResults: [],
+        message: {
+          ...makeAssistantMessage("Final answer."),
+          usage: {
+            input: 20,
+            output: 8,
+            cacheRead: 5,
+            cacheWrite: 0,
+            totalTokens: 28,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+        },
+      });
+    });
+    vi.mocked(createAgentSession).mockResolvedValue({ session } as never);
+
+    const runnerSession = await piAgentRunnerProvider.createSession({
+      cfg,
+      systemPrompt: "test",
+      tools: [],
+      executors: {},
+    });
+
+    const result = await runnerSession.send("question");
+    expect(result.usage).toEqual({
+      estimated: false,
+      inputTokens: 20,
+      outputTokens: 8,
+      cacheReadTokens: 5,
+      cacheWriteTokens: 0,
+      totalTokens: 28,
+    });
   });
 
   it("returns empty text when aborted before a terminal answer turn", async () => {
@@ -252,7 +309,7 @@ describe("piAgentRunnerProvider.send", () => {
         message: makeAssistantMessage("Final answer."),
       });
       resolvePrompt?.();
-      await expect(sendPromise).resolves.toEqual({ text: "Final answer." });
+      await expect(sendPromise).resolves.toMatchObject({ text: "Final answer." });
       expect(abort).not.toHaveBeenCalled();
       expect(setIntervalSpy).toHaveBeenCalledTimes(1);
     } finally {

--- a/test/reviewRun.cursor.test.ts
+++ b/test/reviewRun.cursor.test.ts
@@ -153,6 +153,10 @@ describe("runFullPrReview cursor provider", () => {
       expect.objectContaining({
         provider: "cursor",
         model: cursorCfg.piModel,
+        modelTurnCount: expect.any(Number),
+        promptBytes: expect.any(Number),
+        estimatedInputTokens: expect.any(Number),
+        cacheReadTokens: null,
       }),
     );
     infoSpy.mockRestore();

--- a/test/reviewRunMetrics.test.ts
+++ b/test/reviewRunMetrics.test.ts
@@ -37,6 +37,8 @@ describe("reviewRunMetrics", () => {
         kind: "tool_call",
         name: "listPullRequestFiles",
         ok: true,
+        resultBytes: 120,
+        resultCharacters: 118,
       });
       recordReviewMetric({
         kind: "tool_call",
@@ -67,6 +69,28 @@ describe("reviewRunMetrics", () => {
         findingsCount: 1,
         severities: ["P1"],
       });
+      recordReviewMetric({
+        kind: "model_turn",
+        prompt: { inputCharacters: 100, inputBytes: 104 },
+        usage: {
+          estimated: true,
+          inputTokens: 25,
+          outputTokens: 10,
+          totalTokens: 35,
+        },
+      });
+      recordReviewMetric({
+        kind: "model_turn",
+        prompt: { inputCharacters: 40, inputBytes: 40 },
+        usage: {
+          estimated: false,
+          inputTokens: 12,
+          outputTokens: 6,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 3,
+          totalTokens: 18,
+        },
+      });
       setReviewRunMetricFields({ published: true, publishAttempts: 1 });
 
       const snapshot = snapshotReviewRunMetrics();
@@ -89,6 +113,18 @@ describe("reviewRunMetrics", () => {
         diffCacheEmptyAtFirstSubmit: true,
         toolCallCount: 2,
         toolCallErrors: 1,
+        toolResultBytes: 120,
+        toolResultCharacters: 118,
+        modelTurnCount: 2,
+        promptBytes: 144,
+        promptCharacters: 140,
+        estimatedInputTokens: 25,
+        estimatedOutputTokens: 10,
+        providerInputTokens: 12,
+        providerOutputTokens: 6,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 3,
+        estimatedTurnCount: 1,
         findingsCount: 1,
         severities: ["P1"],
       });
@@ -108,17 +144,19 @@ describe("reviewRunMetrics", () => {
       setReviewRunMetricFields({ published: false, publishAttempts: 2 });
       logReviewRunCompleted({ extra: true });
     });
-    expect(infoSpy).toHaveBeenCalledWith(
-      "review_run_completed",
-      expect.objectContaining({
-        provider: "cursor",
-        model: "composer-2.5",
-        mode: "review-security",
-        published: false,
-        publishAttempts: 2,
-        extra: true,
-      }),
-    );
+    const payload = infoSpy.mock.calls.find(([event]) => event === "review_run_completed")?.[1];
+    expect(payload).toMatchObject({
+      provider: "cursor",
+      model: "composer-2.5",
+      mode: "review-security",
+      published: false,
+      publishAttempts: 2,
+      extra: true,
+      modelTurnCount: 0,
+      cacheReadTokens: null,
+      cacheWriteTokens: null,
+    });
+    expect(JSON.stringify(payload)).not.toMatch(/submitReview|password|BEGIN RSA/i);
     infoSpy.mockRestore();
   });
 });

--- a/test/usageMetadata.test.ts
+++ b/test/usageMetadata.test.ts
@@ -78,4 +78,35 @@ describe("usageMetadata", () => {
       totalTokens: 20,
     });
   });
+
+  it("preserves unknown cache metrics when merging turns without cache data", () => {
+    const withTokens = exactUsageFromProviderUsage({
+      input: 10,
+      output: 5,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 15,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    });
+    const withoutCache = {
+      estimated: false as const,
+      inputTokens: 3,
+      outputTokens: 2,
+      totalTokens: 5,
+    };
+    expect(mergeExactUsage(withTokens, withoutCache)).toEqual({
+      estimated: false,
+      inputTokens: 13,
+      outputTokens: 7,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      totalTokens: 20,
+    });
+    expect(mergeExactUsage(withoutCache, withoutCache)).toEqual({
+      estimated: false,
+      inputTokens: 6,
+      outputTokens: 4,
+      totalTokens: 10,
+    });
+  });
 });

--- a/test/usageMetadata.test.ts
+++ b/test/usageMetadata.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  estimatedUsageFromTokenCounts,
+  exactUsageFromProviderUsage,
+  mergeExactUsage,
+  promptMetadataFromText,
+} from "../src/agent/providers/usageMetadata.js";
+
+describe("usageMetadata", () => {
+  it("builds prompt metadata from text without logging content", () => {
+    const meta = promptMetadataFromText("hello 🌍");
+    expect(meta.inputCharacters).toBe(8);
+    expect(meta.inputBytes).toBeGreaterThan(meta.inputCharacters);
+  });
+
+  it("marks estimated usage explicitly", () => {
+    expect(estimatedUsageFromTokenCounts(10, 5)).toEqual({
+      estimated: true,
+      inputTokens: 10,
+      outputTokens: 5,
+      totalTokens: 15,
+    });
+  });
+
+  it("returns exact provider usage only when token data exists", () => {
+    expect(
+      exactUsageFromProviderUsage({
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      }),
+    ).toBeUndefined();
+    expect(
+      exactUsageFromProviderUsage({
+        input: 12,
+        output: 4,
+        cacheRead: 3,
+        cacheWrite: 0,
+        totalTokens: 16,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      }),
+    ).toEqual({
+      estimated: false,
+      inputTokens: 12,
+      outputTokens: 4,
+      cacheReadTokens: 3,
+      cacheWriteTokens: 0,
+      totalTokens: 16,
+    });
+  });
+
+  it("merges exact usage across turns", () => {
+    const left = exactUsageFromProviderUsage({
+      input: 10,
+      output: 5,
+      cacheRead: 1,
+      cacheWrite: 0,
+      totalTokens: 15,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    });
+    const right = exactUsageFromProviderUsage({
+      input: 3,
+      output: 2,
+      cacheRead: 0,
+      cacheWrite: 2,
+      totalTokens: 5,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    });
+    expect(mergeExactUsage(left, right)).toEqual({
+      estimated: false,
+      inputTokens: 13,
+      outputTokens: 7,
+      cacheReadTokens: 1,
+      cacheWriteTokens: 2,
+      totalTokens: 20,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Extend agent runner turns with prompt size metadata and optional token usage, with an explicit estimated flag for Cursor.
- Aggregate model-turn and tool-result byte counts into review run metrics and `review_run_completed` logs without logging raw prompts or tool output.
- Route review agent sends through a metrics helper and record tool-result sizes from both Cursor MCP and Pi custom tools.

## Test plan

- [x] `nub run check:code`
- [x] `nub run test`
- [x] Cursor and Pi agent runner tests cover estimated vs exact usage metadata
- [x] Review metrics tests cover model-turn aggregation and tool-result sizes

Closes #147

___

## PR Agent Description

### PR Type

Enhancement, Tests

### Description

- Add shared usage metadata types and helpers (estimated, exact, merge)
- Record prompt characters/bytes and token usage on every agent turn
- Log tool result sizes (bytes/characters) in MCP bridge and PI runner
- Surface new metrics (modelTurnCount, promptBytes, token counts) in review snapshots

### Changes Diagram

```mermaid
flowchart LR
  A["Agent sends prompt"] --> B["buildCursorSendText / promptMetadataFromText"]
  B --> C["AgentRunnerTurn { text, prompt, usage }"]
  C --> D["sendReviewAgentTurn records model_turn metric"]
  D --> E["reviewRunMetrics aggregates tokens, chars, bytes"]
  F["Tool call (MCP/PI)"] --> G["toolResultBytes + toolResultCharacters"]
  G --> E
  E --> H["Snapshot: modelTurnCount, promptBytes, providerInputTokens, ..."]
```

### File Walkthrough

<details>
<summary>Enhancement (9 files)</summary>

<details>
<summary>New usage metadata types and helpers</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/152/files#diff-24edd380fabd1e5d4c1bf84162840ec875f1b55e9f17997b5c7a4b258531f2bc"><code>src/agent/providers/usageMetadata.ts</code></a>

- AgentRunnerUsageMetadata, AgentRunnerPromptMetadata, AgentRunnerTurn types
- promptMetadataFromText, estimatedUsageFromTokenCounts, exactUsageFromProviderUsage
- mergeExactUsage for aggregating across multi-turn rounds

</details>

<details>
<summary>Re-export usage types from interface</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/152/files#diff-7318d230cb109b71ef2eb61f22ef7237cb2ce46ef9946313b61f0c79ecd97392"><code>src/agent/providers/interface.ts</code></a>

- Replace inline AgentRunnerTurn with shared type
- Re-export usage metadata types for consumers

</details>

<details>
<summary>Include prompt and estimated usage in cursor turns</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/152/files#diff-6352813a80313c6af522043bde13cb05526b19753b6d304121d8048418b32c7d"><code>src/agent/providers/cursor/agentRunner.ts</code></a>

- Compute send text characters via buildCursorSendText
- Attach prompt metadata and estimated usage to each turn result

</details>

<details>
<summary>Record tool result byte/character sizes</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/152/files#diff-cce54ea3162621df5436768433e3941521b031af288d6cad2800ee6778ccc458"><code>src/agent/providers/cursor/mcpBridge.ts</code></a>

- Add mcpResultSize helper to measure text content
- Pass resultBytes and resultCharacters in tool_call metrics

</details>

<details>
<summary>Exact usage and tool result metrics in PI runner</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/152/files#diff-d6e5d01d6bf6a26a3f9144be0ed3b060dcdaffdca0ad71ded51f8269537d0054"><code>src/agent/providers/pi/index.ts</code></a>

- Aggregate exact usage from provider turn_end events with mergeExactUsage
- Record resultBytes/resultCharacters on every tool call
- Attach prompt metadata to final turn result

</details>

<details>
<summary>Make send injectable in runSubmitOnlyRound</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/152/files#diff-093f627385904c440a8526cdd5aa41c50a4a070ddbed431d4f87bb13437e340c"><code>src/agentRun/sessionHelpers.ts</code></a>

- Accept optional send override to enable metric recording in review runs

</details>

<details>
<summary>New wrapper recording model_turn metrics</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/152/files#diff-0dcb431996b95570fd2435e40d04ee09d5f27b8e718a796fe5587e8323613056"><code>src/review/run/reviewRunAgentSend.ts</code></a>

- sendReviewAgentTurn wraps session.send and records model_turn events
- recordAgentTurnMetrics extracts usage and prompt info

</details>

<details>
<summary>Route review sends through metric-recording wrapper</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/152/files#diff-207db95b84c820a833151da9435e23daac8a9ab2b70a5e54b45c02aa688eb1ab"><code>src/review/run/reviewRun.ts</code></a>

- Replace direct session.send calls with sendReviewAgentTurn
- Pass send wrapper into runSubmitOnlyRound for repair phase

</details>

<details>
<summary>Extended metrics snapshot with token and size fields</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/152/files#diff-7386217900a15467f14d9dc8bf9af19ee4d1f33cc2f86041c203b6b0b47af21c"><code>src/review/run/reviewRunMetrics.ts</code></a>

- Add modelTurnCount, promptBytes, promptCharacters, toolResultBytes, toolResultCharacters
- Add estimatedInputTokens, estimatedOutputTokens, providerInputTokens/OutputTokens
- Add cacheRead/cacheWrite tokens and estimatedTurnCount

</details>

</details>

<details>
<summary>Tests (6 files)</summary>

<details>
<summary>Unit tests for usage metadata helpers</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/152/files#diff-792b1d60bc6424540b96f2ecb5c56644a43caf9112c5b3273772866231218bbf"><code>test/usageMetadata.test.ts</code></a>

- Verify promptMetadata, estimatedUsage, exactUsage and mergeExactUsage

</details>

<details>
<summary>Assert prompt and usage in cursor agent turns</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/152/files#diff-32a5af2c235614bfd32a222a515d9ac41920ee752c17f9332dab7342fc21e9ef"><code>test/cursorAgentRunner.test.ts</code></a>

- Update mock to return usage; assert toMatchObject on prompt and usage

</details>

<details>
<summary>Assert tool result size metrics</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/152/files#diff-d96b634d7d3e8a4ee8d50ac9a5c8f7e2af1d00238e6a1b68bda07d36e3b3f9ff"><code>test/cursorMcpBridge.test.ts</code></a>

- Verify toolResultBytes > 0 on success; toolResultBytes/Characters on error

</details>

<details>
<summary>Test exact usage and prompt metadata in PI</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/152/files#diff-0138010b84778d1ff7229007098a31d57d9733e9ffdb2831781e724a5fea3ead"><code>test/piAgentRunner.test.ts</code></a>

- Add mock usage in turn_end events; assert usage and prompt in result
- Relax exact equality to toMatchObject for backward compat

</details>

<details>
<summary>Assert new metrics in review snapshot</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/152/files#diff-77104d3fd2c94c5d50454e60b8aeb5e72c705401761b471105a040965e90a33a"><code>test/reviewRun.cursor.test.ts</code></a>

- Verify modelTurnCount, promptBytes, estimatedInputTokens, cacheReadTokens are present

</details>

<details>
<summary>Assert aggregated model_turn and tool size metrics</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/152/files#diff-f25f760d4e24838e2edb6aaa7fb1970421df8968c1577775e7e307eba0e251e6"><code>test/reviewRunMetrics.test.ts</code></a>

- Record model_turn events with estimated and exact usage
- Verify all new snapshot fields and log payload completeness

</details>

</details>