### PR TITLE
Fix Docker runtime missing @earendil-works/pi-ai

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,10 @@ RUN --mount=type=cache,id=nub-store,target=/root/.local/share/nub/store \
   && nub install --no-frozen-lockfile
 
 FROM deps AS prod-deps
-RUN nub prune --prod
+# Nub's virtual store uses absolute symlinks into the PM cache; copying node_modules
+# alone breaks between stages. pnpm deploy materializes a self-contained prod tree.
+RUN corepack enable && corepack prepare pnpm@10.34.1 --activate
+RUN pnpm deploy --filter=pr-agent --prod --legacy /app/prod
 
 FROM deps AS build
 COPY tsconfig.base.json tsconfig.build.json ./
@@ -30,8 +33,8 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends git ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
-COPY package.json ./
-COPY --from=prod-deps /app/node_modules ./node_modules
+COPY --from=prod-deps /app/prod/package.json ./package.json
+COPY --from=prod-deps /app/prod/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/migrations ./migrations
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ FROM deps AS prod-deps
 # Nub's virtual store uses absolute symlinks into the PM cache; copying node_modules
 # alone breaks between stages. pnpm deploy materializes a self-contained prod tree.
 RUN corepack enable && corepack prepare pnpm@10.34.1 --activate
-RUN pnpm deploy --filter=pr-agent --prod --legacy /app/prod
+RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
+  pnpm deploy --filter=pr-agent --prod --legacy /app/prod
 
 FROM deps AS build
 COPY tsconfig.base.json tsconfig.build.json ./


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The production Docker image crashed on startup with `ERR_MODULE_NOT_FOUND` for `@earendil-works/pi-ai` when loading `dist/config.js`.

## Root cause

After migrating to Nub, `node_modules` uses absolute symlinks into the Nub package-manager cache. Copying `node_modules` from the `prod-deps` build stage into the runtime stage leaves those symlinks pointing at paths that do not exist in the final image.

## Fix

Replace `nub prune --prod` + direct `node_modules` copy with `pnpm deploy --filter=pr-agent --prod --legacy /app/prod`, which materializes a self-contained production dependency tree with relative symlinks. The runtime stage now copies from `/app/prod`.

## Verification

- Built the Docker image locally
- Confirmed `import('@earendil-works/pi-ai')` and `import('./dist/config.js')` succeed in the runtime container
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60e9a83c-3bfa-45d0-b121-6630f7e56828"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60e9a83c-3bfa-45d0-b121-6630f7e56828"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

