### PR TITLE
Limit automatic review to once per PR (opened only)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -122,7 +122,8 @@ Work item retries are controlled only by pg-boss (`QUEUE_RETRY_LIMIT`, `QUEUE_RE
 | `RETENTION_QUEUE_POLLING_INTERVAL_SECONDS` | 60                                                                                                                                          |
 | `*_DEAD_LETTER_QUEUE`                      | DLQ names                                                                                                                                   |
 | `DEFERRED_HEAD_SHA`                        | worker resolves head SHA                                                                                                                    |
-| `AUTOMATED_PR_ACTIONS`                     | opened, synchronize, reopened                                                                                                               |
+| `AUTOMATED_PR_ACTIONS`                     | opened, synchronize, reopened — webhook-level gate for pull_request events                                                                  |
+| `AUTOMATED_REVIEW_ACTIONS`                 | opened — auto-review triggers; each PR gets one automatic review, use `/review` after that                                                  |
 | `DESCRIPTION_AUTO_ACTIONS` (env)           | `opened` — comma-separated `pull_request` actions that auto-run `/describe`; adding `synchronize` re-runs the description LLM on every push |
 | `AUTOMATED_REVIEW_LENS`                    | `review`                                                                                                                                    |
 | `ASK_PUBLISH_LENS`                         | `ask`                                                                                                                                       |

--- a/src/agentWork/intake/planner.ts
+++ b/src/agentWork/intake/planner.ts
@@ -1,4 +1,4 @@
-import { AUTOMATED_PR_ACTIONS } from "../../settings/index.js";
+import { AUTOMATED_REVIEW_ACTIONS } from "../../settings/index.js";
 
 /** Durable work kinds scheduled from automated pull_request webhooks. */
 type AutomatedPrIntakeKind = "review" | "description";
@@ -18,7 +18,7 @@ export function planAutomatedPullRequestIntake(
   opts: AutomatedPrIntakeOptions,
 ): AutomatedPrIntakePlan {
   const kinds: AutomatedPrIntakeKind[] = [];
-  if (AUTOMATED_PR_ACTIONS.has(action)) kinds.push("review");
+  if (AUTOMATED_REVIEW_ACTIONS.has(action)) kinds.push("review");
   if (opts.descriptionAutoActions.has(action)) kinds.push("description");
   return { action, kinds };
 }

--- a/src/settings/constants.ts
+++ b/src/settings/constants.ts
@@ -14,6 +14,9 @@ export const TRIAGE_DEAD_LETTER_QUEUE = "agent-work-triage-dead";
 export const DEFERRED_HEAD_SHA = "deferred-to-worker";
 
 export const AUTOMATED_PR_ACTIONS = new Set(["opened", "synchronize", "reopened"]);
+/** PR actions that trigger an automatic review. Only `opened` so each PR gets one
+ *  automatic review; subsequent reviews require `/review`. */
+export const AUTOMATED_REVIEW_ACTIONS = new Set(["opened"]);
 export const AUTOMATED_REVIEW_LENS = "review" as const;
 export const DESCRIPTION_PUBLISH_LENS = "description" as const;
 export const ASK_PUBLISH_LENS = "ask" as const;
@@ -393,7 +396,7 @@ export const SLASH_HELP_BODY = [
   "- `/triage` — fix earlier PR Agent findings on this PR: commits and pushes minimal fixes to the PR branch, resolves fixed threads (trigger-only; same-repo PRs). Post on the PR conversation to triage all findings, or reply `/triage` inside a bot inline finding thread to triage that finding only.",
   "",
   "Notes:",
-  "- Automated `/describe` runs on PR actions listed in `DESCRIPTION_AUTO_ACTIONS` (default `opened` only); `/review` runs on `opened` / `synchronize` / `reopened`.",
+  "- Automated `/describe` runs on PR actions listed in `DESCRIPTION_AUTO_ACTIONS` (default `opened` only); `/review` runs automatically on `opened` only (once per PR). Use `/review` to re-run manually.",
   "- `/describe` merges generated content below the PR Agent description header; your text above that header is preserved.",
   "- `/review`, `/review-security`, `/review-quality`, and `/review-tests` can each leave summary comments on the same PR (different sentinels).",
   "- `/ask` answers one question at a time; it does not remember prior `/ask` commands.",

--- a/test/intakePlanner.test.ts
+++ b/test/intakePlanner.test.ts
@@ -12,12 +12,12 @@ describe("planAutomatedPullRequestIntake", () => {
     ).toEqual(["review", "description"]);
   });
 
-  it("schedules review only on synchronize", () => {
+  it("does not schedule review on synchronize (review runs once per PR)", () => {
     expect(
       planAutomatedPullRequestIntake("synchronize", {
         descriptionAutoActions: defaultDescriptionActions,
       }).kinds,
-    ).toEqual(["review"]);
+    ).toEqual([]);
   });
 
   it("schedules nothing on unsupported action", () => {
@@ -28,7 +28,7 @@ describe("planAutomatedPullRequestIntake", () => {
     ).toEqual([]);
   });
 
-  it("includes review kind when automated review actions apply", () => {
+  it("includes review kind only on opened", () => {
     expect(
       planAutomatedPullRequestIntake("opened", {
         descriptionAutoActions: defaultDescriptionActions,
@@ -38,7 +38,12 @@ describe("planAutomatedPullRequestIntake", () => {
       planAutomatedPullRequestIntake("synchronize", {
         descriptionAutoActions: defaultDescriptionActions,
       }).kinds,
-    ).toContain("review");
+    ).not.toContain("review");
+    expect(
+      planAutomatedPullRequestIntake("reopened", {
+        descriptionAutoActions: defaultDescriptionActions,
+      }).kinds,
+    ).not.toContain("review");
     expect(
       planAutomatedPullRequestIntake("labeled", {
         descriptionAutoActions: defaultDescriptionActions,
@@ -64,6 +69,6 @@ describe("planAutomatedPullRequestIntake", () => {
       planAutomatedPullRequestIntake("synchronize", {
         descriptionAutoActions: new Set(["opened", "synchronize"]),
       }).kinds,
-    ).toEqual(["review", "description"]);
+    ).toEqual(["description"]);
   });
 });

--- a/test/schedulerAutomatedDescribe.test.ts
+++ b/test/schedulerAutomatedDescribe.test.ts
@@ -77,7 +77,7 @@ describe("makeAgentWorkScheduler automated describe", () => {
     expect(sentQueues).toContain(DESCRIPTION_QUEUE);
   });
 
-  it("does not enqueue description on synchronize", async () => {
+  it("does not enqueue description or review on synchronize (review runs once per PR)", async () => {
     const sentQueues: string[] = [];
     const boss = {
       send: vi.fn(async (queue: string) => {
@@ -86,9 +86,9 @@ describe("makeAgentWorkScheduler automated describe", () => {
       }),
     } as unknown as PgBoss;
 
-    const client = mockAutomatedClient();
-    const pool = {} as Pool;
-    vi.spyOn(postgres, "inTransaction").mockImplementation(async (_pool, fn) => fn(client));
+    const pool = {
+      query: vi.fn(async () => ({ rows: [{ id: "event-ignored" }] })),
+    } as unknown as Pool;
 
     const scheduler = makeAgentWorkScheduler(pool, boss, intakeCfg);
     const intakeLog = createOperationLogger({
@@ -105,8 +105,7 @@ describe("makeAgentWorkScheduler automated describe", () => {
       ),
     );
 
-    expect(sentQueues).toContain(REVIEW_QUEUE);
-    expect(sentQueues).toContain(ACK_QUEUE);
+    expect(sentQueues).not.toContain(REVIEW_QUEUE);
     expect(sentQueues).not.toContain(DESCRIPTION_QUEUE);
   });
 


### PR DESCRIPTION
## Summary

Automatic reviews now only trigger on PR `opened` — each PR gets exactly one automatic review. Subsequent reviews (after pushes via `synchronize`, or `reopened`) must be manually triggered via `/review`.

## Changes

### `src/settings/constants.ts`
- Added `AUTOMATED_REVIEW_ACTIONS` constant (`Set(["opened"])`) — controls which PR actions trigger an automatic review
- `AUTOMATED_PR_ACTIONS` remains unchanged (`opened`, `synchronize`, `reopened`) as the webhook-level parsing gate
- Updated `/help` notes to reflect once-per-PR auto-review behavior

### `src/agentWork/intake/planner.ts`
- Changed the planner to use `AUTOMATED_REVIEW_ACTIONS` instead of `AUTOMATED_PR_ACTIONS` for review scheduling decisions

### `docs/configuration.md`
- Documented `AUTOMATED_REVIEW_ACTIONS` and clarified the role of `AUTOMATED_PR_ACTIONS`

### Tests
- Updated `intakePlanner.test.ts` — `synchronize` and `reopened` no longer schedule reviews
- Updated `schedulerAutomatedDescribe.test.ts` — `synchronize` is now treated as ignored for reviews

## Design Notes
- `AUTOMATED_PR_ACTIONS` still gates webhook parsing so that `synchronize`/`reopened` events are parsed (needed if `DESCRIPTION_AUTO_ACTIONS` includes them)
- `/review` slash command is unaffected and works on any push

___

## PR Agent Description

### PR Type

Enhancement, Bug fix, Tests

### Description

- Split out AUTOMATED_REVIEW_ACTIONS from AUTOMATED_PR_ACTIONS, restricting auto-review to `opened` only
- Update planner to check the new constant so synchronize/reopened no longer trigger review
- Adjust tests to expect no review kind on synchronize and reopened
- Update documentation and slash-help text to reflect the new once-per-PR review behaviour

### File Walkthrough

<details>
<summary>Enhancement (1 file)</summary>

<details>
<summary>Add AUTOMATED_REVIEW_ACTIONS constant</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/163/files#diff-0ff20bf86329037153bc6b9dc8593498e91c9eed21750c634f60fe1f5a7e2ea3"><code>src/settings/constants.ts</code></a>

- Introduce AUTOMATED_REVIEW_ACTIONS set to `["opened"]`
- Keep AUTOMATED_PR_ACTIONS unchanged for webhook-level gating

</details>

</details>

<details>
<summary>Bug fix (1 file)</summary>

<details>
<summary>Use AUTOMATED_REVIEW_ACTIONS in planner</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/163/files#diff-84dbcd1f8574e7907e99f78b4797197a95955a9a9229c92883fea40f071731a2"><code>src/agentWork/intake/planner.ts</code></a>

- Swap AUTOMATED_PR_ACTIONS import for AUTOMATED_REVIEW_ACTIONS
- Review is now gated only by the new set

</details>

</details>

<details>
<summary>Tests (2 files)</summary>

<details>
<summary>Update planner tests for review gating</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/163/files#diff-3572e9bf3ccf7c051fcda1d1f5cd2839d300b126076357fabf02b69cb4283395"><code>test/intakePlanner.test.ts</code></a>

- synchronize no longer gets review kind
- reopened no longer gets review kind
- Only `opened` action includes review

</details>

<details>
<summary>Update scheduler test for synchronize</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/163/files#diff-6151c480aec4a522c4839770a0c9a1c85c890f776056675e151ccb27a4b2483d"><code>test/schedulerAutomatedDescribe.test.ts</code></a>

- synchronize no longer enqueues REVIEW_QUEUE
- Simplify test setup by removing unused mock

</details>

</details>

<details>
<summary>Documentation (1 file)</summary>

<details>
<summary>Document new AUTOMATED_REVIEW_ACTIONS</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/163/files#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180"><code>docs/configuration.md</code></a>

- Add table entry for AUTOMATED_REVIEW_ACTIONS
- Clarify that review runs once per PR

</details>

</details>