### PR TITLE
Tune Postgres pool, retention deletes, and container settings

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,6 +2,19 @@
 # Usage: docker compose -f docker-compose.yml -f docker-compose.prod.yml up
 services:
   postgres:
+    shm_size: 128mb
+    command:
+      - postgres
+      - -c
+      - shared_buffers=${POSTGRES_SHARED_BUFFERS:-256MB}
+      - -c
+      - effective_cache_size=${POSTGRES_EFFECTIVE_CACHE_SIZE:-768MB}
+      - -c
+      - maintenance_work_mem=${POSTGRES_MAINTENANCE_WORK_MEM:-128MB}
+      - -c
+      - wal_compression=${POSTGRES_WAL_COMPRESSION:-on}
+      - -c
+      - random_page_cost=${POSTGRES_RANDOM_PAGE_COST:-1.1}
     environment:
       POSTGRES_DB: ${POSTGRES_DB:?set POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER:?set POSTGRES_USER}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,19 @@
 services:
   postgres:
     image: postgres:16-alpine
+    shm_size: 128mb
+    command:
+      - postgres
+      - -c
+      - shared_buffers=${POSTGRES_SHARED_BUFFERS:-256MB}
+      - -c
+      - effective_cache_size=${POSTGRES_EFFECTIVE_CACHE_SIZE:-768MB}
+      - -c
+      - maintenance_work_mem=${POSTGRES_MAINTENANCE_WORK_MEM:-128MB}
+      - -c
+      - wal_compression=${POSTGRES_WAL_COMPRESSION:-on}
+      - -c
+      - random_page_cost=${POSTGRES_RANDOM_PAGE_COST:-1.1}
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-pr_agent}
       POSTGRES_USER: ${POSTGRES_USER:-pr_agent}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -143,6 +143,7 @@ Work item retries are controlled only by pg-boss (`QUEUE_RETRY_LIMIT`, `QUEUE_RE
 | `ASK_PUBLISH_LENS`                         | `ask`                                                                                                                                                                       |
 | `TRIAGE_PUBLISH_LENS`                      | `triage`                                                                                                                                                                    |
 | `MAX_STORED_COMMENT_TEXT_LEN`              | 16384                                                                                                                                                                       |
+| `RETENTION_DELETE_BATCH_SIZE`              | 5000, rows per batch in the retention sweep (each batch is its own transaction)                                                                                             |
 
 ### Review output
 
@@ -309,12 +310,15 @@ lensOverrides:
 
 ### Postgres pool
 
-| Symbol                           | Default |
-| -------------------------------- | ------- |
-| `POSTGRES_POOL_MAX`              | 10      |
-| `POSTGRES_IDLE_TIMEOUT_MS`       | 30000   |
-| `POSTGRES_CONNECTION_TIMEOUT_MS` | 5000    |
-| `POSTGRES_STATEMENT_TIMEOUT_MS`  | 60000   |
+| Symbol                                    | Default | Role                                   |
+| ----------------------------------------- | ------- | -------------------------------------- |
+| `POSTGRES_POOL_MAX`                       | 10      | pool size                              |
+| `POSTGRES_IDLE_TIMEOUT_MS`                | 30000   | idle client reap                       |
+| `POSTGRES_CONNECTION_TIMEOUT_MS`          | 5000    | connect timeout                        |
+| `POSTGRES_STATEMENT_TIMEOUT_MS`           | 60000   | per-statement timeout                  |
+| `POSTGRES_KEEPALIVE_INITIAL_DELAY_MS`     | 10000   | TCP keepalive initial delay            |
+| `POSTGRES_LOCK_TIMEOUT_MS`                | 10000   | per-statement lock acquisition timeout |
+| `POSTGRES_IDLE_IN_TRANSACTION_TIMEOUT_MS` | 60000   | idle-in-transaction session timeout    |
 
 ### Other
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -59,6 +59,8 @@ Compose sets `environment.PORT=7224` and **`7224:7224`** publishing. For a host 
 
 **Requires Docker Engine with Compose v2.** `env_file` defaults to **`.env`**; use host env **`PR_AGENT_ENV_FILE`** for an alternate path.
 
+The Compose `postgres` service sets `shm_size: 128mb` and conservative server tuning flags (`shared_buffers`, `effective_cache_size`, `maintenance_work_mem`, `wal_compression`, `random_page_cost`). Override them with the `POSTGRES_SHARED_BUFFERS`, `POSTGRES_EFFECTIVE_CACHE_SIZE`, `POSTGRES_MAINTENANCE_WORK_MEM`, `POSTGRES_WAL_COMPRESSION`, and `POSTGRES_RANDOM_PAGE_COST` Compose env vars; the production override mirrors the same flags.
+
 ```bash
 PR_AGENT_ENV_FILE=/abs/path/to/.env docker compose up
 ```

--- a/src/agentWork/retention.ts
+++ b/src/agentWork/retention.ts
@@ -1,7 +1,7 @@
 import type { Pool } from "pg";
 import type { PgBoss } from "pg-boss";
 import type { Config } from "../config.js";
-import { RETENTION_QUEUE } from "../settings/index.js";
+import { RETENTION_DELETE_BATCH_SIZE, RETENTION_QUEUE } from "../settings/index.js";
 
 const TERMINAL_STATUSES = ["completed", "failed", "cancelled", "superseded"];
 
@@ -14,28 +14,56 @@ export type RetentionResult = {
  * Delete terminal agent work items and aged webhook events. Work items go first so
  * their `webhook_event_id` references clear before the webhook rows are removed
  * (the FK is ON DELETE SET NULL, so either order is safe).
+ *
+ * Each table is drained in fixed-size batches (`RETENTION_DELETE_BATCH_SIZE`); every
+ * batch is its own implicit transaction (`pool.query`) so a large backlog never holds
+ * one long open transaction. The two tables run concurrently via `Promise.all`. A
+ * batch that deletes fewer rows than the batch size means the table is drained.
  */
 export async function runRetention(
   pool: Pool,
   cfg: Pick<Config, "agentWorkRetentionSeconds" | "webhookEventsRetentionSeconds">,
 ): Promise<RetentionResult> {
-  const [workItems, webhookEvents] = await Promise.all([
-    pool.query(
-      `DELETE FROM agent_work_items
-       WHERE status = ANY($1::text[])
-         AND COALESCE(completed_at, updated_at) < now() - ($2::bigint * interval '1 second')`,
-      [TERMINAL_STATUSES, cfg.agentWorkRetentionSeconds],
-    ),
-    pool.query(
-      `DELETE FROM webhook_events
-       WHERE received_at < now() - ($1::bigint * interval '1 second')`,
-      [cfg.webhookEventsRetentionSeconds],
-    ),
+  const [workItemsDeleted, webhookEventsDeleted] = await Promise.all([
+    (async () => {
+      let deleted = 0;
+      for (;;) {
+        const result = await pool.query(
+          `DELETE FROM agent_work_items
+            WHERE id IN (
+              SELECT id FROM agent_work_items
+               WHERE status = ANY($1::text[])
+                 AND COALESCE(completed_at, updated_at) < now() - ($2::bigint * interval '1 second')
+               LIMIT $3::int
+            )`,
+          [TERMINAL_STATUSES, cfg.agentWorkRetentionSeconds, RETENTION_DELETE_BATCH_SIZE],
+        );
+        const batch = result.rowCount ?? 0;
+        deleted += batch;
+        if (batch < RETENTION_DELETE_BATCH_SIZE) break;
+      }
+      return deleted;
+    })(),
+    (async () => {
+      let deleted = 0;
+      for (;;) {
+        const result = await pool.query(
+          `DELETE FROM webhook_events
+            WHERE id IN (
+              SELECT id FROM webhook_events
+               WHERE received_at < now() - ($1::bigint * interval '1 second')
+               LIMIT $2::int
+            )`,
+          [cfg.webhookEventsRetentionSeconds, RETENTION_DELETE_BATCH_SIZE],
+        );
+        const batch = result.rowCount ?? 0;
+        deleted += batch;
+        if (batch < RETENTION_DELETE_BATCH_SIZE) break;
+      }
+      return deleted;
+    })(),
   ]);
-  return {
-    workItemsDeleted: workItems.rowCount ?? 0,
-    webhookEventsDeleted: webhookEvents.rowCount ?? 0,
-  };
+  return { workItemsDeleted, webhookEventsDeleted };
 }
 
 export async function ensureRetentionSchedule(

--- a/src/db/postgres.ts
+++ b/src/db/postgres.ts
@@ -3,18 +3,26 @@ import type { Db } from "pg-boss";
 import type { Config } from "../config.js";
 import {
   POSTGRES_CONNECTION_TIMEOUT_MS,
+  POSTGRES_IDLE_IN_TRANSACTION_TIMEOUT_MS,
   POSTGRES_IDLE_TIMEOUT_MS,
+  POSTGRES_KEEPALIVE_INITIAL_DELAY_MS,
+  POSTGRES_LOCK_TIMEOUT_MS,
   POSTGRES_POOL_MAX,
   POSTGRES_STATEMENT_TIMEOUT_MS,
 } from "../settings/index.js";
 
-export function createPgPool(cfg: Pick<Config, "databaseUrl">): Pool {
+export function createPgPool(cfg: Pick<Config, "databaseUrl" | "role">): Pool {
   return new Pool({
     connectionString: cfg.databaseUrl,
     max: POSTGRES_POOL_MAX,
     idleTimeoutMillis: POSTGRES_IDLE_TIMEOUT_MS,
     connectionTimeoutMillis: POSTGRES_CONNECTION_TIMEOUT_MS,
     statement_timeout: POSTGRES_STATEMENT_TIMEOUT_MS,
+    keepAlive: true,
+    keepAliveInitialDelayMillis: POSTGRES_KEEPALIVE_INITIAL_DELAY_MS,
+    lock_timeout: POSTGRES_LOCK_TIMEOUT_MS,
+    idle_in_transaction_session_timeout: POSTGRES_IDLE_IN_TRANSACTION_TIMEOUT_MS,
+    application_name: `pr-agent-${cfg.role}`,
   });
 }
 

--- a/src/settings/constants.ts
+++ b/src/settings/constants.ts
@@ -6,6 +6,8 @@ export const DESCRIPTION_QUEUE = "agent-work-description";
 export const TRIAGE_QUEUE = "agent-work-triage";
 export const RETENTION_QUEUE = "agent-work-retention";
 export const RETENTION_QUEUE_POLLING_INTERVAL_SECONDS = 60;
+/** Rows deleted per batch in the retention sweep (each batch is its own transaction). */
+export const RETENTION_DELETE_BATCH_SIZE = 5_000;
 export const ACK_DEAD_LETTER_QUEUE = "agent-work-ack-dead";
 export const REVIEW_DEAD_LETTER_QUEUE = "agent-work-review-dead";
 export const ASK_DEAD_LETTER_QUEUE = "agent-work-ask-dead";
@@ -361,6 +363,9 @@ export const POSTGRES_POOL_MAX = 10;
 export const POSTGRES_IDLE_TIMEOUT_MS = 30_000;
 export const POSTGRES_CONNECTION_TIMEOUT_MS = 5_000;
 export const POSTGRES_STATEMENT_TIMEOUT_MS = 60_000;
+export const POSTGRES_KEEPALIVE_INITIAL_DELAY_MS = 10_000;
+export const POSTGRES_LOCK_TIMEOUT_MS = 10_000;
+export const POSTGRES_IDLE_IN_TRANSACTION_TIMEOUT_MS = 60_000;
 export const GITHUB_WEBHOOK_RESPONSE_MARGIN_MS = 2_000;
 
 export const TOKEN_EXPIRED_TOOL_MESSAGE =

--- a/test/retention.test.ts
+++ b/test/retention.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Pool } from "pg";
+import { runRetention } from "../src/agentWork/retention.js";
+import { RETENTION_DELETE_BATCH_SIZE } from "../src/settings/index.js";
+
+const RETENTION = {
+  agentWorkRetentionSeconds: 30 * 86_400,
+  webhookEventsRetentionSeconds: 30 * 86_400,
+};
+
+describe("runRetention batched delete loop", () => {
+  it("keeps deleting until a short batch is returned, accumulating row counts", async () => {
+    // Work items: one full batch then a short remainder; webhook events: one full
+    // batch then an empty short batch. Each loop must issue exactly two queries.
+    const workBatches = [RETENTION_DELETE_BATCH_SIZE, 2];
+    const webhookBatches = [RETENTION_DELETE_BATCH_SIZE, 0];
+    let workCalls = 0;
+    let webhookCalls = 0;
+
+    const pool = {
+      query: vi.fn(async (text: string) => {
+        if (text.includes("agent_work_items")) {
+          return { rowCount: workBatches[workCalls++] ?? 0 };
+        }
+        return { rowCount: webhookBatches[webhookCalls++] ?? 0 };
+      }),
+    } as unknown as Pool;
+
+    const result = await runRetention(pool, RETENTION);
+
+    expect(result.workItemsDeleted).toBe(RETENTION_DELETE_BATCH_SIZE + 2);
+    expect(result.webhookEventsDeleted).toBe(RETENTION_DELETE_BATCH_SIZE);
+    expect(workCalls).toBe(2);
+    expect(webhookCalls).toBe(2);
+  });
+
+  it("stops after a single short batch when the table is already small", async () => {
+    let workCalls = 0;
+    let webhookCalls = 0;
+
+    const pool = {
+      query: vi.fn(async (text: string) => {
+        if (text.includes("agent_work_items")) {
+          workCalls += 1;
+          return { rowCount: 3 };
+        }
+        webhookCalls += 1;
+        return { rowCount: 0 };
+      }),
+    } as unknown as Pool;
+
+    const result = await runRetention(pool, RETENTION);
+
+    expect(result.workItemsDeleted).toBe(3);
+    expect(result.webhookEventsDeleted).toBe(0);
+    expect(workCalls).toBe(1);
+    expect(webhookCalls).toBe(1);
+  });
+});

--- a/test/retention.test.ts
+++ b/test/retention.test.ts
@@ -20,9 +20,20 @@ describe("runRetention batched delete loop", () => {
     const pool = {
       query: vi.fn(async (text: string) => {
         if (text.includes("agent_work_items")) {
-          return { rowCount: workBatches[workCalls++] ?? 0 };
+          const batch = workBatches[workCalls++];
+          if (batch === undefined) {
+            throw new Error("unexpected extra agent_work_items query");
+          }
+          return { rowCount: batch };
         }
-        return { rowCount: webhookBatches[webhookCalls++] ?? 0 };
+        if (text.includes("webhook_events")) {
+          const batch = webhookBatches[webhookCalls++];
+          if (batch === undefined) {
+            throw new Error("unexpected extra webhook_events query");
+          }
+          return { rowCount: batch };
+        }
+        throw new Error(`unexpected query: ${text}`);
       }),
     } as unknown as Pool;
 
@@ -44,8 +55,11 @@ describe("runRetention batched delete loop", () => {
           workCalls += 1;
           return { rowCount: 3 };
         }
-        webhookCalls += 1;
-        return { rowCount: 0 };
+        if (text.includes("webhook_events")) {
+          webhookCalls += 1;
+          return { rowCount: 0 };
+        }
+        throw new Error(`unexpected query: ${text}`);
       }),
     } as unknown as Pool;
 


### PR DESCRIPTION
## Summary

### Connection pool hardening
- Enable TCP keepalive (10s initial delay) so stale connections are detected instead of surfacing as intermittent ECONNRESET
- Set `application_name` to `pr-agent-<role>` so web and worker connections are distinguishable in `pg_stat_activity`
- Add session safety limits: `lock_timeout` 10s and `idle_in_transaction_session_timeout` 60s

### Retention sweep
- Batch the terminal work-item and webhook-event DELETEs (5,000 rows per batch, one implicit transaction each) so a large backlog never holds a single long transaction that pins the xmin horizon

### Deployment
- Set `shm_size: 128mb` on the postgres service (container default /dev/shm is 64MB)
- Add env-overridable conservative server tuning flags: `shared_buffers=256MB`, `effective_cache_size=768MB`, `maintenance_work_mem=128MB`, `wal_compression=on`, `random_page_cost=1.1`

### Docs and tests
- New constants documented in `docs/configuration.md`; deployment note in `docs/operations.md`
- New `test/retention.test.ts` covering the batch-drain loop

___

## PR Agent Description

### PR Type

Enhancement, Tests

### Description

- Batch retention deletes into per-transaction chunks to avoid long-running transactions
- Add Postgres pool hardening: keepalive, lock timeout, idle-in-transaction timeout, and application_name
- Tune Compose postgres service with shared_buffers, WAL compression, and cache settings
- Add unit tests verifying the batched delete loop terminates correctly

### Changes Diagram

```mermaid
flowchart LR
  A["runRetention"] --> B["Batch delete agent_work_items"]
  A --> C["Batch delete webhook_events"]
  B --> D["< batch size? loop stops"]
  C --> E["< batch size? loop stops"]
  F["createPgPool"] --> G["keepalive + lock_timeout + idle_in_transaction_timeout + app_name"]
  H["Compose postgres"] --> I["shared_buffers, wal_compression, random_page_cost"]
```

### File Walkthrough

<details>
<summary>Enhancement (5 files)</summary>

<details>
<summary>Batched deletion loop for retention</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/168/files#diff-30727ad1940cfccf9c19fe65553247112ffebc71aea8cabf22ebdeac5f2b8500"><code>src/agentWork/retention.ts</code></a>

- Replace single DELETE with a loop using LIMIT-batched deletes
- Each batch is its own transaction via pool.query
- Two tables drain concurrently via Promise.all

</details>

<details>
<summary>Pool hardening with keepalive and timeouts</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/168/files#diff-db1fffcd5e8241d0999eb4ce95532c3af348a49a6852da3f153c4fbef6a2d1e8"><code>src/db/postgres.ts</code></a>

- Add keepAlive + keepAliveInitialDelayMillis
- Add lock_timeout and idle_in_transaction_session_timeout
- Set application_name from cfg.role

</details>

<details>
<summary>New Postgres and retention constants</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/168/files#diff-0ff20bf86329037153bc6b9dc8593498e91c9eed21750c634f60fe1f5a7e2ea3"><code>src/settings/constants.ts</code></a>

- Add RETENTION_DELETE_BATCH_SIZE = 5000
- Add POSTGRES_KEEPALIVE_INITIAL_DELAY_MS, LOCK_TIMEOUT_MS, IDLE_IN_TRANSACTION_TIMEOUT_MS

</details>

<details>
<summary>Postgres server tuning flags (dev)</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/168/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3"><code>docker-compose.yml</code></a>

- Add shm_size: 128mb
- Set shared_buffers, effective_cache_size, maintenance_work_mem, wal_compression, random_page_cost

</details>

<details>
<summary>Postgres server tuning flags (prod)</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/168/files#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3"><code>docker-compose.prod.yml</code></a>

- Mirror the same tuning flags as in docker-compose.yml

</details>

</details>

<details>
<summary>Tests (1 file)</summary>

<details>
<summary>Unit tests for batch delete loop</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/168/files#diff-096784c3371ff1e7942038ea93a89681749a7d89dd801fb4cf084afbc4d07150"><code>test/retention.test.ts</code></a>

- Test loop terminates after short batch
- Test accumulates row counts across multiple batches

</details>

</details>

<details>
<summary>Documentation (2 files)</summary>

<details>
<summary>Document new Postgres and retention settings</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/168/files#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180"><code>docs/configuration.md</code></a>

- Document RETENTION_DELETE_BATCH_SIZE
- Add Role column to Postgres pool config table with new timeout params

</details>

<details>
<summary>Document Compose postgres tuning</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/168/files#diff-ad74991b96593fdee570962fc5b1e319080abd55e16614f556f74b7de8fd02d1"><code>docs/operations.md</code></a>

- Describe shm_size and server tuning env vars for override

</details>

</details>