### PR TITLE
Add offline prompt-cost compression eval harness

### DIFF
--- a/docs/adr/0022-prompt-cost-strategy.md
+++ b/docs/adr/0022-prompt-cost-strategy.md
@@ -1,0 +1,55 @@
+# ADR 0022 — Prompt-cost strategy and offline compression eval
+
+## Status
+
+Accepted.
+
+## Context
+
+Operators want lower token cost for review runs and asked whether a custom tokenizer format or prompt-compression scheme would help. Shorthand and compression can shrink visible bytes, but:
+
+1. **Tokenization is provider- and model-specific.** Character counts and `characters/4` estimates are not billing tokens. An exact tokenizer dependency (e.g. tiktoken) only matches one family and adds install/native-build cost.
+2. **Prompt caching prefers stable prefixes.** Providers that cache system prompts reward long-lived, unchanged leading text. Aggressive rewrites of static contracts can _increase_ cost by busting the cache even when raw bytes drop.
+3. **Lossy compression removes review cues.** Severity labels, `submitReview` contract text, schema field names, and fixture evidence markers keep structured submission reliable. A compact format that strips them is a quality regression, not a win.
+4. **Learned compressors (LLMLingua and similar)** need task-specific regression checks and live model eval — out of scope for CI unit tests and for this spike.
+
+The repo already measures static prompt and tool surfaces in `test/promptCostBaselines.test.ts` via `test/helpers/promptCost.ts` (`characters/4` estimated tokens). That is the right foundation; what was missing is a **decision record** for cost strategy and an **offline harness** that compares candidate transforms without touching production prompts.
+
+## Decision
+
+1. **Preferred order of attack (do not skip ahead):**
+   1. **Measure** — keep and extend prompt/tool cost baselines (`promptCostBaselines` + this eval harness).
+   2. **Telemetry** — runtime usage metadata already records input bytes where providers expose them; expand carefully before inventing formats.
+   3. **Bounded dynamic tool outputs** — continue capping tool results (`toolOutputBudget`); dynamic tails dominate many runs.
+   4. **Deduplicate static prompt contracts** — shared blocks in `reviewPromptBlocks` already reduce drift; further dedupe beats private shorthand.
+   5. **Evaluated compression or custom formats** — only after 1–4, and only candidates that pass the offline invariant harness (and later, stronger live evals).
+
+2. **Offline eval harness (this PR).** Synthetic fixtures (correctness, security, false-positive trap, quality, tests, large/truncated) plus pure string candidate transforms live under `test/promptCostEval/`. The harness:
+   - builds baseline surfaces through existing prompt builders;
+   - applies baseline, compact-static, compact-tool-result, and test-only custom-shorthand transforms;
+   - measures bytes and `characters/4` estimated tokens;
+   - rejects candidates that drop structured submission markers, payload field names, severity labels, lens markers, or fixture `EVIDENCE:*` labels;
+   - needs no network, provider credentials, Postgres, or GitHub.
+
+3. **No production prompt change.** Compressed formats and the custom shorthand prototype stay test-only. Shipping a compressed production prompt requires a later decision backed by harness evidence (and preferably live quality eval).
+
+4. **No tokenizer dependency by default.** Estimates use the existing `measurePromptCost` character heuristic. Adding an exact tokenizer requires an explicit follow-up that documents compatibility with Nub/pnpm, keeps the package out of production request paths initially, and proves it is optional relative to the baseline estimate. If a candidate tokenizer needs native builds that conflict with the toolchain, stop and report rather than force it in.
+
+5. **Optional report script.** `scripts/prompt-cost-eval-report.mjs` may print a JSON comparison for local inspection (writes via `PROMPT_COST_EVAL_OUT` on the report-shape test); it is not required CI beyond the deterministic vitest suite.
+
+## Consequences
+
+- Contributors have a written order of operations: measurement and caching discipline before private formats.
+- CI gains a regression net against lossy “optimizations” that strip review contracts.
+- Future compression spikes have a fixture set and a machine-readable report shape (`surfaceName`, baseline/candidate bytes and estimated tokens, percent reduction, invariant pass/fail).
+- Production review behavior is unchanged by this ADR.
+
+## External guidance captured
+
+- **Stable prefixes → cache hits.** Keep long-lived system prompt prefixes stable across runs; put volatile PR-specific text in the user message / trusted context tail.
+- **Provider tokens ≠ estimates.** Treat `estimatedTokens` as a relative metric for diffs between candidates, not as a billing forecast.
+- **Task-specific regression.** Any learned or aggressive compressor must re-check structured submission and lens behavior; byte wins without invariant wins are rejected.
+
+## Reversal
+
+Delete `docs/adr/0022-prompt-cost-strategy.md`, `test/promptCostEval/`, `test/promptCostCompressionEval.test.ts`, and any optional report script. Baseline budget tests in `promptCostBaselines.test.ts` remain the sole cost guardrail.

--- a/scripts/prompt-cost-eval-report.mjs
+++ b/scripts/prompt-cost-eval-report.mjs
@@ -1,0 +1,66 @@
+/**
+ * Optional offline prompt-cost comparison report.
+ * Prints JSON to stdout. Not required CI — vitest is the gate.
+ *
+ * Usage (from repo root, after nub install):
+ *   node scripts/prompt-cost-eval-report.mjs
+ *
+ * Deterministic CI gate:
+ *   nub run test -- test/promptCostCompressionEval.test.ts
+ */
+
+import { spawnSync } from "node:child_process";
+import { readFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const outPath = join(tmpdir(), `prompt-cost-eval-report-${process.pid}.json`);
+
+const result = spawnSync(
+  "nub",
+  [
+    "run",
+    "test",
+    "--",
+    "test/promptCostCompressionEval.test.ts",
+    "-t",
+    "emits a machine-readable comparison report shape",
+    "--reporter=dot",
+  ],
+  {
+    cwd: root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      FORCE_COLOR: "0",
+      PROMPT_COST_EVAL_OUT: outPath,
+    },
+    maxBuffer: 20 * 1024 * 1024,
+  },
+);
+
+if (result.status !== 0) {
+  process.stderr.write(
+    (result.stderr || result.stdout || "prompt-cost-eval-report failed").slice(0, 2500) +
+      "\nHint: run `nub run test -- test/promptCostCompressionEval.test.ts` for the CI harness.\n",
+  );
+  process.exit(result.status ?? 1);
+}
+
+try {
+  const json = readFileSync(outPath, "utf8");
+  process.stdout.write(json.endsWith("\n") ? json : `${json}\n`);
+} catch (error) {
+  process.stderr.write(
+    `Failed to read report at ${outPath}: ${error instanceof Error ? error.message : String(error)}\n`,
+  );
+  process.exit(1);
+} finally {
+  try {
+    unlinkSync(outPath);
+  } catch {
+    // ignore
+  }
+}

--- a/test/promptCostCompressionEval.test.ts
+++ b/test/promptCostCompressionEval.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from "vitest";
+import { measurePromptCost } from "./helpers/promptCost.js";
+import { PROMPT_COST_EVAL_FIXTURES } from "./promptCostEval/fixtures.js";
+import {
+  buildEvalSurfaces,
+  compareCandidate,
+  formatReportJson,
+  runPromptCostEval,
+} from "./promptCostEval/harness.js";
+import {
+  buildFixtureEvidenceInvariants,
+  buildSystemPromptInvariants,
+  evaluateInvariants,
+} from "./promptCostEval/invariants.js";
+import {
+  baselineTransform,
+  compactStaticTransform,
+  compactToolResultTransform,
+  customShorthandTransform,
+  EVAL_CANDIDATE_TRANSFORMS,
+  lossyStripTransform,
+} from "./promptCostEval/transforms.js";
+
+describe("prompt cost compression eval harness", () => {
+  it("covers representative offline fixtures for every review lens", () => {
+    const lenses = new Set(PROMPT_COST_EVAL_FIXTURES.map((f) => f.lens));
+    expect(lenses.has("review")).toBe(true);
+    expect(lenses.has("review-security")).toBe(true);
+    expect(lenses.has("review-quality")).toBe(true);
+    expect(lenses.has("review-tests")).toBe(true);
+
+    const ids = PROMPT_COST_EVAL_FIXTURES.map((f) => f.id);
+    expect(ids).toContain("correctness-null-deref");
+    expect(ids).toContain("security-sql-interpolation");
+    expect(ids).toContain("false-positive-intentional-any");
+    expect(ids).toContain("quality-1k-line-growth");
+    expect(ids).toContain("tests-untested-error-path");
+    expect(ids).toContain("large-truncated-context");
+
+    for (const fixture of PROMPT_COST_EVAL_FIXTURES) {
+      expect(fixture.evidenceLabels.length).toBeGreaterThan(0);
+      expect(fixture.changedFiles.length).toBeGreaterThan(0);
+      expect(fixture.diffContent.length).toBeGreaterThan(0);
+      expect(fixture.diffContent).not.toMatch(/sk-[A-Za-z0-9]{10,}/);
+      expect(fixture.diffContent).not.toMatch(/BEGIN (RSA |OPENSSH )?PRIVATE KEY/);
+    }
+  });
+
+  it("builds baseline prompt surfaces through production prompt builders", () => {
+    const surfaces = buildEvalSurfaces();
+    const system = surfaces.filter((s) => s.kind === "system-prompt");
+    expect(new Set(system.map((s) => s.lens))).toEqual(
+      new Set(["review", "review-quality", "review-security", "review-tests"]),
+    );
+    for (const surface of system) {
+      expect(surface.content).toContain("submitReview exactly once");
+      expect(surface.content).toContain("ReviewPayload");
+      for (const severity of ["P0", "P1", "P2", "P3"] as const) {
+        expect(surface.content).toContain(severity);
+      }
+    }
+  });
+
+  it("compares baseline and candidate formats numerically", () => {
+    const { comparisons, report } = runPromptCostEval();
+    expect(comparisons.length).toBeGreaterThan(0);
+    expect(report.tokenizer).toBe("char/4-estimate");
+
+    for (const row of comparisons) {
+      expect(row.baselineBytes).toBeGreaterThan(0);
+      expect(row.baselineEstimatedTokens).toBeGreaterThan(0);
+      expect(row.candidateBytes).toBeGreaterThanOrEqual(0);
+      expect(row.candidateEstimatedTokens).toBeGreaterThanOrEqual(0);
+      expect(typeof row.percentReduction).toBe("number");
+      expect(Number.isFinite(row.percentReduction)).toBe(true);
+    }
+
+    const baselineRows = comparisons.filter((c) => c.candidateId === "baseline");
+    expect(baselineRows.length).toBeGreaterThan(0);
+    for (const row of baselineRows) {
+      expect(row.percentReduction).toBe(0);
+      expect(row.candidateBytes).toBe(row.baselineBytes);
+      expect(row.invariantsPassed).toBe(true);
+    }
+  });
+
+  it("keeps required contract markers under non-lossy candidates", () => {
+    const surfaces = buildEvalSurfaces().filter((s) => s.kind === "system-prompt");
+    const safeTransforms = [
+      baselineTransform,
+      compactStaticTransform,
+      compactToolResultTransform,
+      customShorthandTransform,
+    ];
+
+    for (const surface of surfaces) {
+      const baselineCost = measurePromptCost(surface.content);
+      for (const transform of safeTransforms) {
+        const row = compareCandidate({ surface, transform, baselineCost });
+        expect(
+          row.invariantsPassed,
+          `${surface.name}/${transform.id}: ${JSON.stringify(row.invariantFailures)}`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("rejects candidates that remove required fields, severity labels, or evidence", () => {
+    const surfaces = buildEvalSurfaces();
+    const system = surfaces.find((s) => s.name === "system:review");
+    expect(system).toBeDefined();
+    if (!system) return;
+
+    const baselineCost = measurePromptCost(system.content);
+    const lossy = compareCandidate({
+      surface: system,
+      transform: lossyStripTransform,
+      baselineCost,
+    });
+    expect(lossy.invariantsPassed).toBe(false);
+    const kinds = new Set(lossy.invariantFailures.map((f) => f.kind));
+    expect(kinds.has("structured-submission") || kinds.has("payload-field")).toBe(true);
+    expect(kinds.has("severity")).toBe(true);
+
+    const fixtureSurface = surfaces.find((s) => s.name === "fixture:correctness-null-deref");
+    expect(fixtureSurface).toBeDefined();
+    if (!fixtureSurface) return;
+    const fixtureBaseline = measurePromptCost(fixtureSurface.content);
+    const lossyFixture = compareCandidate({
+      surface: fixtureSurface,
+      transform: lossyStripTransform,
+      baselineCost: fixtureBaseline,
+    });
+    expect(lossyFixture.invariantsPassed).toBe(false);
+    expect(lossyFixture.invariantFailures.some((f) => f.kind === "fixture-evidence")).toBe(true);
+  });
+
+  it("preserves fixture evidence labels under compact transforms", () => {
+    for (const fixture of PROMPT_COST_EVAL_FIXTURES) {
+      const text = [fixture.supportingContext, fixture.diffContent].join("\n\n");
+      for (const transform of [
+        compactStaticTransform,
+        compactToolResultTransform,
+        customShorthandTransform,
+      ]) {
+        const out = transform.apply(text);
+        const inv = evaluateInvariants(out, buildFixtureEvidenceInvariants(fixture.evidenceLabels));
+        expect(
+          inv.allPassed,
+          `${fixture.id}/${transform.id}: ${JSON.stringify(inv.failures)}`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("emits a machine-readable comparison report shape", async () => {
+    const { report } = runPromptCostEval({
+      transforms: EVAL_CANDIDATE_TRANSFORMS,
+      surfaces: buildEvalSurfaces().filter((s) => s.kind === "system-prompt"),
+    });
+    const json = formatReportJson(report);
+    const parsed = JSON.parse(json) as {
+      tokenizer: string;
+      comparisons: Array<{
+        surfaceName: string;
+        candidateId: string;
+        baselineBytes: number;
+        baselineEstimatedTokens: number;
+        candidateBytes: number;
+        candidateEstimatedTokens: number;
+        percentReduction: number;
+        invariantsPassed: boolean;
+      }>;
+    };
+    expect(parsed.tokenizer).toBe("char/4-estimate");
+    expect(parsed.comparisons.length).toBeGreaterThan(0);
+    for (const row of parsed.comparisons) {
+      expect(row).toEqual(
+        expect.objectContaining({
+          surfaceName: expect.any(String),
+          candidateId: expect.any(String),
+          baselineBytes: expect.any(Number),
+          baselineEstimatedTokens: expect.any(Number),
+          candidateBytes: expect.any(Number),
+          candidateEstimatedTokens: expect.any(Number),
+          percentReduction: expect.any(Number),
+          invariantsPassed: expect.any(Boolean),
+        }),
+      );
+    }
+
+    if (process.env.PROMPT_COST_EVAL_OUT) {
+      const { writeFileSync } = await import("node:fs");
+      const full = runPromptCostEval();
+      writeFileSync(
+        process.env.PROMPT_COST_EVAL_OUT,
+        formatReportJson({
+          ...full.report,
+          generatedAt: new Date().toISOString(),
+        }),
+        "utf8",
+      );
+    }
+  });
+
+  it("keeps custom shorthand transforms test-only (not imported from src/)", async () => {
+    const srcImport = await import("../src/review/prompts/reviewSystemPrompt.js");
+    expect(srcImport).not.toHaveProperty("customShorthandPrototype");
+    expect(srcImport).not.toHaveProperty("compactStaticFormatting");
+
+    const checks = buildSystemPromptInvariants({ lens: "review" });
+    expect(checks.some((c) => c.kind === "structured-submission")).toBe(true);
+    expect(checks.some((c) => c.kind === "severity")).toBe(true);
+    expect(checks.some((c) => c.kind === "payload-field")).toBe(true);
+  });
+
+  it("uses the shared char/4 estimate and does not require a tokenizer dependency", () => {
+    const sample = "abcd".repeat(25);
+    const cost = measurePromptCost(sample);
+    expect(cost.characters).toBe(100);
+    expect(cost.estimatedTokens).toBe(25);
+    expect(EVAL_CANDIDATE_TRANSFORMS.every((t) => typeof t.apply === "function")).toBe(true);
+  });
+});

--- a/test/promptCostEval/fixtures.ts
+++ b/test/promptCostEval/fixtures.ts
@@ -1,0 +1,201 @@
+/** Synthetic offline fixtures for prompt-cost compression eval. */
+
+export type ReviewLens = "review" | "review-security" | "review-quality" | "review-tests";
+
+export type PromptCostEvalFixture = {
+  readonly id: string;
+  readonly lens: ReviewLens;
+  readonly title: string;
+  readonly changedFiles: readonly string[];
+  readonly diffContent: string;
+  readonly supportingContext: string;
+  readonly expectedFindingMechanisms: readonly string[];
+  readonly mustNotReportMechanisms: readonly string[];
+  readonly evidenceLabels: readonly string[];
+};
+
+export const PROMPT_COST_EVAL_FIXTURES: readonly PromptCostEvalFixture[] = [
+  {
+    id: "correctness-null-deref",
+    lens: "review",
+    title: "Null dereference after optional map lookup",
+    changedFiles: ["src/billing/retry.ts"],
+    diffContent: [
+      "diff --git a/src/billing/retry.ts b/src/billing/retry.ts",
+      "--- a/src/billing/retry.ts",
+      "+++ b/src/billing/retry.ts",
+      "@@ -10,6 +10,9 @@ export function nextAttempt(job: Job | undefined) {",
+      "-  return job.attempts + 1;",
+      "+  const found = jobs.find((j) => j.id === job?.id);",
+      "+  // EVIDENCE:null-deref — found may be undefined when job is missing",
+      "+  return found.attempts + 1;",
+    ].join("\n"),
+    supportingContext: [
+      "Changed files: src/billing/retry.ts",
+      "Path profile: application code",
+      "EVIDENCE:billing-retry-path",
+    ].join("\n"),
+    expectedFindingMechanisms: [
+      "optional map/find result used without null check",
+      "runtime TypeError when job is missing",
+    ],
+    mustNotReportMechanisms: ["rename variable for style", "prefer const over let without bug"],
+    evidenceLabels: ["EVIDENCE:null-deref", "EVIDENCE:billing-retry-path"],
+  },
+  {
+    id: "security-sql-interpolation",
+    lens: "review-security",
+    title: "SQL built with string concatenation from request id",
+    changedFiles: ["src/api/orders.ts"],
+    diffContent: [
+      "diff --git a/src/api/orders.ts b/src/api/orders.ts",
+      "--- a/src/api/orders.ts",
+      "+++ b/src/api/orders.ts",
+      "@@ -4,3 +4,6 @@ export async function getOrder(req: Request) {",
+      "+  // EVIDENCE:sql-injection — user-controlled orderId in query text",
+      '+  const sql = "SELECT * FROM orders WHERE id = \'" + req.params.orderId + "\'";',
+      "+  return db.query(sql);",
+    ].join("\n"),
+    supportingContext: [
+      "Changed files: src/api/orders.ts",
+      "Trust boundary: HTTP request params",
+      "EVIDENCE:trust-boundary-http",
+    ].join("\n"),
+    expectedFindingMechanisms: [
+      "sql-injection via string interpolation",
+      "user-controlled identifier reaches raw SQL",
+    ],
+    mustNotReportMechanisms: ["missing rate limit with no sensitive side effect claimed"],
+    evidenceLabels: ["EVIDENCE:sql-injection", "EVIDENCE:trust-boundary-http"],
+  },
+  {
+    id: "false-positive-intentional-any",
+    lens: "review",
+    title: "Intentional any at a documented interop boundary",
+    changedFiles: ["src/interop/legacy.ts"],
+    diffContent: [
+      "diff --git a/src/interop/legacy.ts b/src/interop/legacy.ts",
+      "--- a/src/interop/legacy.ts",
+      "+++ b/src/interop/legacy.ts",
+      "@@ -1,3 +1,6 @@",
+      "+// EVIDENCE:intentional-any — documented bridge to untyped vendor SDK",
+      "+// The vendor SDK has no types; cast is intentional and reviewed.",
+      "+export function bridge(input: unknown): any {",
+      "+  return input;",
+      "+}",
+    ].join("\n"),
+    supportingContext: [
+      "Changed files: src/interop/legacy.ts",
+      "EVIDENCE:documented-interop",
+      "Maintainer note: intentional untyped bridge; do not re-report style-only any usage.",
+    ].join("\n"),
+    expectedFindingMechanisms: [],
+    mustNotReportMechanisms: [
+      "forbid any without trigger path",
+      "style-only cast nit with no bug",
+      "cosmetic rename of bridge",
+    ],
+    evidenceLabels: ["EVIDENCE:intentional-any", "EVIDENCE:documented-interop"],
+  },
+  {
+    id: "quality-1k-line-growth",
+    lens: "review-quality",
+    title: "File crosses 1000 lines without decomposition",
+    changedFiles: ["src/handlers/mega.ts"],
+    diffContent: [
+      "diff --git a/src/handlers/mega.ts b/src/handlers/mega.ts",
+      "--- a/src/handlers/mega.ts",
+      "+++ b/src/handlers/mega.ts",
+      "@@ -990,3 +990,20 @@ export function handleMega(req: Request) {",
+      "+  // EVIDENCE:1k-line-growth — file moves past 1000 lines with new branch",
+      '+  if (req.query.mode === "special") {',
+      "+    return specialCasePath(req);",
+      "+  }",
+      "+  // ... many more lines pushing file over 1000 ...",
+    ].join("\n"),
+    supportingContext: [
+      "Changed files: src/handlers/mega.ts",
+      "File size before: 995 lines; after: 1020 lines",
+      "EVIDENCE:file-size-smell",
+    ].join("\n"),
+    expectedFindingMechanisms: [
+      "1k-line file-growth smell",
+      "prefer decomposition over growing mega handler",
+    ],
+    mustNotReportMechanisms: ["missing unit test for specialCasePath (wrong lens)"],
+    evidenceLabels: ["EVIDENCE:1k-line-growth", "EVIDENCE:file-size-smell"],
+  },
+  {
+    id: "tests-untested-error-path",
+    lens: "review-tests",
+    title: "New error branch without a test case",
+    changedFiles: ["src/payments/charge.ts", "test/payments/charge.test.ts"],
+    diffContent: [
+      "diff --git a/src/payments/charge.ts b/src/payments/charge.ts",
+      "--- a/src/payments/charge.ts",
+      "+++ b/src/payments/charge.ts",
+      "@@ -20,4 +20,8 @@ export async function charge(card: Card) {",
+      "+  // EVIDENCE:untested-error-path — new timeout branch, no test asserts it",
+      "+  if (card.networkTimedOut) {",
+      "+    throw new ChargeTimeoutError(card.id);",
+      "+  }",
+      "diff --git a/test/payments/charge.test.ts b/test/payments/charge.test.ts",
+      "--- a/test/payments/charge.test.ts",
+      "+++ b/test/payments/charge.test.ts",
+      "@@ -5,3 +5,6 @@",
+      "+// EVIDENCE:happy-path-only — still only covers successful charge",
+      '+it("charges a valid card", async () => { ... });',
+    ].join("\n"),
+    supportingContext: [
+      "Changed files: src/payments/charge.ts, test/payments/charge.test.ts",
+      "EVIDENCE:test-gap-timeout",
+    ].join("\n"),
+    expectedFindingMechanisms: [
+      "proposed test for ChargeTimeoutError path",
+      "untested error branch on busy payment path",
+    ],
+    mustNotReportMechanisms: ["sql-injection (wrong lens)", "file-size smell (wrong lens)"],
+    evidenceLabels: [
+      "EVIDENCE:untested-error-path",
+      "EVIDENCE:happy-path-only",
+      "EVIDENCE:test-gap-timeout",
+    ],
+  },
+  {
+    id: "large-truncated-context",
+    lens: "review",
+    title: "Large diff with truncated tool output marker",
+    changedFiles: ["src/bulk/transform.ts", "src/bulk/helpers.ts"],
+    diffContent: [
+      "diff --git a/src/bulk/transform.ts b/src/bulk/transform.ts",
+      "--- a/src/bulk/transform.ts",
+      "+++ b/src/bulk/transform.ts",
+      "@@ -1,3 +1,12 @@",
+      "+// EVIDENCE:off-by-one — loop uses <= length causing out-of-range read",
+      "+export function mapAll(items: Item[]) {",
+      "+  const out = [];",
+      "+  for (let i = 0; i <= items.length; i++) {",
+      "+    out.push(items[i].id);",
+      "+  }",
+      "+  return out;",
+      "+}",
+      '<!-- tool_result truncated="true" reason="response byte budget exceeded" -->',
+      "EVIDENCE:truncated-tool-result",
+    ].join("\n"),
+    supportingContext: [
+      "Changed files: src/bulk/transform.ts, src/bulk/helpers.ts",
+      "Size budget: large PR; tool outputs may be truncated",
+      "EVIDENCE:large-pr-budget",
+    ].join("\n"),
+    expectedFindingMechanisms: [
+      "off-by-one loop bound",
+      "out-of-range array access when i equals length",
+    ],
+    mustNotReportMechanisms: ["report every helper rename as P0"],
+    evidenceLabels: [
+      "EVIDENCE:off-by-one",
+      "EVIDENCE:truncated-tool-result",
+      "EVIDENCE:large-pr-budget",
+    ],
+  },
+];

--- a/test/promptCostEval/harness.ts
+++ b/test/promptCostEval/harness.ts
@@ -1,0 +1,220 @@
+/** Offline prompt-cost eval: pure string transforms, no network/LLM/Postgres. */
+
+import { automatedQualitySystemPrompt } from "../../src/agent/prompts/qualityPrompt.js";
+import { automatedReviewTestsSystemPrompt } from "../../src/agent/prompts/reviewTestsPrompt.js";
+import { automatedSecuritySystemPrompt } from "../../src/agent/prompts/securityPrompt.js";
+import { wrapTrustedContext } from "../../src/agent/prompts/promptBlocks.js";
+import { buildAutomatedSystemPrompt } from "../../src/review/prompts/reviewSystemPrompt.js";
+import { buildReviewRunUserContent } from "../../src/review/prompts/reviewUserMessage.js";
+import type { ReviewMode } from "../../src/review/reviewSchema.js";
+import { measurePromptCost, type PromptCost } from "../helpers/promptCost.js";
+import {
+  PROMPT_COST_EVAL_FIXTURES,
+  type PromptCostEvalFixture,
+  type ReviewLens,
+} from "./fixtures.js";
+import {
+  buildFixtureEvidenceInvariants,
+  buildSystemPromptInvariants,
+  evaluateInvariants,
+  type InvariantResult,
+} from "./invariants.js";
+import {
+  EVAL_CANDIDATE_TRANSFORMS,
+  type PromptCostCandidateId,
+  type PromptCostTransform,
+} from "./transforms.js";
+
+export type PromptSurfaceKind = "system-prompt" | "user-content" | "fixture-evidence";
+
+export type PromptSurface = {
+  readonly name: string;
+  readonly kind: PromptSurfaceKind;
+  readonly lens?: ReviewLens;
+  readonly fixtureId?: string;
+  readonly content: string;
+};
+
+export type CandidateComparison = {
+  readonly surfaceName: string;
+  readonly candidateId: PromptCostCandidateId;
+  readonly baselineBytes: number;
+  readonly baselineEstimatedTokens: number;
+  readonly candidateBytes: number;
+  readonly candidateEstimatedTokens: number;
+  /** Percent reduction vs baseline (positive = smaller). */
+  readonly percentReduction: number;
+  readonly invariantsPassed: boolean;
+  readonly invariantFailures: readonly InvariantResult[];
+};
+
+export type PromptCostEvalReport = {
+  readonly generatedAt: string;
+  readonly tokenizer: "char/4-estimate";
+  readonly note: string;
+  readonly comparisons: readonly CandidateComparison[];
+};
+
+function systemPromptForLens(lens: ReviewLens): string {
+  switch (lens) {
+    case "review":
+      return buildAutomatedSystemPrompt();
+    case "review-security":
+      return automatedSecuritySystemPrompt;
+    case "review-quality":
+      return automatedQualitySystemPrompt;
+    case "review-tests":
+      return automatedReviewTestsSystemPrompt;
+  }
+  const exhaustive: never = lens;
+  return exhaustive;
+}
+
+function fixtureUserContent(fixture: PromptCostEvalFixture): string {
+  const trusted = wrapTrustedContext([
+    fixture.supportingContext,
+    "",
+    "Diff excerpt:",
+    fixture.diffContent,
+  ]);
+  return buildReviewRunUserContent({
+    owner: "octo",
+    repo: "hello",
+    prNumber: 42,
+    headSha: "abc123def",
+    reviewMode: fixture.lens as ReviewMode,
+    userSupplement: `Fixture ${fixture.id}: ${fixture.title}`,
+    trustedContext: trusted,
+  });
+}
+
+/** Build the prompt surfaces the offline eval compares. */
+export function buildEvalSurfaces(): PromptSurface[] {
+  const surfaces: PromptSurface[] = [];
+
+  const lenses: ReviewLens[] = ["review", "review-security", "review-quality", "review-tests"];
+  for (const lens of lenses) {
+    surfaces.push({
+      name: `system:${lens}`,
+      kind: "system-prompt",
+      lens,
+      content: systemPromptForLens(lens),
+    });
+  }
+
+  for (const fixture of PROMPT_COST_EVAL_FIXTURES) {
+    const userContent = fixtureUserContent(fixture);
+    surfaces.push({
+      name: `user:${fixture.id}`,
+      kind: "user-content",
+      lens: fixture.lens,
+      fixtureId: fixture.id,
+      content: userContent,
+    });
+    // Fixture evidence surface: diff + supporting context only (what compression
+    // must not strip of EVIDENCE:* labels).
+    surfaces.push({
+      name: `fixture:${fixture.id}`,
+      kind: "fixture-evidence",
+      lens: fixture.lens,
+      fixtureId: fixture.id,
+      content: [fixture.supportingContext, fixture.diffContent].join("\n\n"),
+    });
+  }
+
+  return surfaces;
+}
+
+function invariantsForSurface(
+  surface: PromptSurface,
+): ReturnType<typeof buildSystemPromptInvariants> {
+  if (surface.kind === "system-prompt") {
+    return buildSystemPromptInvariants({ lens: surface.lens });
+  }
+  if (surface.kind === "fixture-evidence" && surface.fixtureId) {
+    const fixture = PROMPT_COST_EVAL_FIXTURES.find((f) => f.id === surface.fixtureId);
+    if (fixture) {
+      return buildFixtureEvidenceInvariants(fixture.evidenceLabels);
+    }
+  }
+  if (surface.kind === "user-content" && surface.fixtureId) {
+    const fixture = PROMPT_COST_EVAL_FIXTURES.find((f) => f.id === surface.fixtureId);
+    if (fixture) {
+      return [
+        ...buildFixtureEvidenceInvariants(fixture.evidenceLabels),
+        {
+          kind: "structured-submission" as const,
+          label: "structured:submitReview exactly once",
+          required: "submitReview exactly once",
+        },
+      ];
+    }
+  }
+  return [];
+}
+
+export function compareCandidate(params: {
+  readonly surface: PromptSurface;
+  readonly transform: PromptCostTransform;
+  readonly baselineCost: PromptCost;
+}): CandidateComparison {
+  const transformed = params.transform.apply(params.surface.content);
+  const cost = measurePromptCost(transformed);
+  const checks = invariantsForSurface(params.surface);
+  const inv = evaluateInvariants(transformed, checks);
+  const baselineBytes = params.baselineCost.bytes;
+  const percentReduction =
+    baselineBytes === 0 ? 0 : ((baselineBytes - cost.bytes) / baselineBytes) * 100;
+
+  return {
+    surfaceName: params.surface.name,
+    candidateId: params.transform.id,
+    baselineBytes,
+    baselineEstimatedTokens: params.baselineCost.estimatedTokens,
+    candidateBytes: cost.bytes,
+    candidateEstimatedTokens: cost.estimatedTokens,
+    percentReduction: Math.round(percentReduction * 100) / 100,
+    invariantsPassed: inv.allPassed,
+    invariantFailures: inv.failures,
+  };
+}
+
+export function runPromptCostEval(params?: {
+  readonly transforms?: readonly PromptCostTransform[];
+  readonly surfaces?: readonly PromptSurface[];
+}): {
+  readonly report: PromptCostEvalReport;
+  readonly comparisons: readonly CandidateComparison[];
+} {
+  const transforms = params?.transforms ?? EVAL_CANDIDATE_TRANSFORMS;
+  const surfaces = params?.surfaces ?? buildEvalSurfaces();
+  const comparisons: CandidateComparison[] = [];
+
+  for (const surface of surfaces) {
+    const baselineCost = measurePromptCost(surface.content);
+    for (const transform of transforms) {
+      comparisons.push(
+        compareCandidate({
+          surface,
+          transform,
+          baselineCost,
+        }),
+      );
+    }
+  }
+
+  const report: PromptCostEvalReport = {
+    generatedAt: new Date(0).toISOString(),
+    tokenizer: "char/4-estimate",
+    note:
+      "Estimated tokens use characters/4 (model-agnostic). Not a provider tokenizer. " +
+      "Custom shorthand is test-only and must not ship in production prompts.",
+    comparisons,
+  };
+
+  return { report, comparisons };
+}
+
+export function formatReportJson(report: PromptCostEvalReport): string {
+  return `${JSON.stringify(report, null, 2)}\n`;
+}

--- a/test/promptCostEval/invariants.ts
+++ b/test/promptCostEval/invariants.ts
@@ -1,0 +1,115 @@
+/** Invariant checks for prompt-cost compression candidates (string presence only). */
+
+export type InvariantKind =
+  | "structured-submission"
+  | "payload-field"
+  | "severity"
+  | "lens-marker"
+  | "fixture-evidence";
+
+export type InvariantCheck = {
+  readonly kind: InvariantKind;
+  readonly label: string;
+  readonly required: string;
+};
+
+export type InvariantResult = {
+  readonly kind: InvariantKind;
+  readonly label: string;
+  readonly required: string;
+  readonly passed: boolean;
+};
+
+/** Required structured submission markers on every review system prompt. */
+export const STRUCTURED_SUBMISSION_MARKERS = [
+  "submitReview exactly once",
+  "ReviewPayload",
+] as const;
+
+/** Top-level ReviewPayload field names that must remain visible. */
+export const REVIEW_PAYLOAD_FIELD_MARKERS = [
+  "prCharacter",
+  "findings",
+  "estimatedEffort",
+  "relevantTests",
+  "securityConcerns",
+  "followUps",
+] as const;
+
+/** Severity labels that must remain visible. */
+export const SEVERITY_MARKERS = ["P0", "P1", "P2", "P3"] as const;
+
+/** Lens-specific phrases that must survive transforms of that lens's system prompt. */
+export const LENS_MARKERS: Readonly<Record<string, readonly string[]>> = {
+  review: ["high-confidence, actionable bugs", "submitReview exactly once"],
+  "review-security": ["security researcher", "sql-injection", "submitReview exactly once"],
+  "review-quality": ["Structural simplification", "1k-line", "submitReview exactly once"],
+  "review-tests": ["proposed test case", "submitReview exactly once"],
+};
+
+export function buildSystemPromptInvariants(params: { readonly lens?: string }): InvariantCheck[] {
+  const checks: InvariantCheck[] = [];
+  for (const marker of STRUCTURED_SUBMISSION_MARKERS) {
+    checks.push({
+      kind: "structured-submission",
+      label: `structured:${marker}`,
+      required: marker,
+    });
+  }
+  for (const field of REVIEW_PAYLOAD_FIELD_MARKERS) {
+    checks.push({
+      kind: "payload-field",
+      label: `field:${field}`,
+      required: field,
+    });
+  }
+  for (const severity of SEVERITY_MARKERS) {
+    checks.push({
+      kind: "severity",
+      label: `severity:${severity}`,
+      required: severity,
+    });
+  }
+  if (params.lens && LENS_MARKERS[params.lens]) {
+    for (const marker of LENS_MARKERS[params.lens]) {
+      checks.push({
+        kind: "lens-marker",
+        label: `lens:${params.lens}:${marker}`,
+        required: marker,
+      });
+    }
+  }
+  return checks;
+}
+
+export function buildFixtureEvidenceInvariants(
+  evidenceLabels: readonly string[],
+): InvariantCheck[] {
+  return evidenceLabels.map((label) => ({
+    kind: "fixture-evidence" as const,
+    label: `evidence:${label}`,
+    required: label,
+  }));
+}
+
+export function evaluateInvariants(
+  content: string,
+  checks: readonly InvariantCheck[],
+): {
+  readonly results: readonly InvariantResult[];
+  readonly allPassed: boolean;
+  readonly failures: readonly InvariantResult[];
+} {
+  const results = checks.map((check) => ({
+    kind: check.kind,
+    label: check.label,
+    required: check.required,
+    passed: content.includes(check.required),
+  }));
+  const failures = results.filter((r) => !r.passed);
+  return {
+    results,
+    allPassed: failures.length === 0,
+    failures,
+  };
+}

--- a/test/promptCostEval/transforms.ts
+++ b/test/promptCostEval/transforms.ts
@@ -1,0 +1,136 @@
+/** Test-only pure string transforms — do not import from production paths. */
+
+export type PromptCostCandidateId =
+  | "baseline"
+  | "compact-static"
+  | "compact-tool-result"
+  | "custom-shorthand";
+
+export type PromptCostTransform = {
+  readonly id: PromptCostCandidateId;
+  readonly description: string;
+  readonly apply: (text: string) => string;
+};
+
+/** Identity: production prompt surface as built today. */
+export const baselineTransform: PromptCostTransform = {
+  id: "baseline",
+  description: "Unmodified production prompt surface",
+  apply: (text) => text,
+};
+
+/** Collapse excess blank lines and trailing whitespace only. */
+export function compactStaticFormatting(text: string): string {
+  return text
+    .replace(/[ \t]+$/gm, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trimEnd();
+}
+
+export const compactStaticTransform: PromptCostTransform = {
+  id: "compact-static",
+  description: "Collapse excess blank lines and trailing whitespace",
+  apply: compactStaticFormatting,
+};
+
+/** Shorten truncated-tool markers and multi-space padding; keep field names. */
+export function compactToolResultFormatting(text: string): string {
+  let out = compactStaticFormatting(text);
+  out = out.replace(
+    /<!--\s*tool_result\s+truncated="true"\s+reason="response byte budget exceeded"\s*-->/g,
+    "<!--tool_result truncated=true reason=byte_budget-->",
+  );
+  out = out.replace(
+    /"truncationReason"\s*:\s*"response byte budget exceeded"/g,
+    '"truncationReason":"byte_budget"',
+  );
+  out = out.replace(/ {2,}/g, " ");
+  return out;
+}
+
+export const compactToolResultTransform: PromptCostTransform = {
+  id: "compact-tool-result",
+  description: "Shorten truncated-tool markers and multi-space padding",
+  apply: compactToolResultFormatting,
+};
+
+/**
+ * Test-only shorthand: compress non-contract headers/phrases only.
+ * Required markers stay intact; lossyStripTransform is the negative control.
+ */
+const SHORTHAND_REPLACEMENTS: readonly (readonly [RegExp, string])[] = [
+  [/## High-signal bug patterns/g, "## HSBP"],
+  [/## Evidence bar and anti-slop discipline/g, "## Anti-slop"],
+  [/## High-stakes \/ trivial-change trap/g, "## HST"],
+  [/## Security tripwires/g, "## SecTrip"],
+  [/## Prose contracts/g, "## Prose"],
+  [/## Prior inline review feedback/g, "## PriorFB"],
+  [/## Single-pass review contract/g, "## 1pass"],
+  [/## Structured delivery \(submitReview\)/g, "## SD(submitReview)"],
+  [/## Public output contract/g, "## POC"],
+  [/## Path and size guidance/g, "## PathSize"],
+  [/## Investigation protocol \(local workspace tools\)/g, "## InvProto"],
+  [/## Code-quality mission/g, "## CQ"],
+  [/## Test-drafting mission/g, "## TDM"],
+  [/## Known vulnerability categories/g, "## VulnCats"],
+  [/## Rule out mitigations before flagging/g, "## MitigateFirst"],
+  [/## Subtle auth-bypass patterns/g, "## AuthBypass"],
+  [/## Out-of-scope files/g, "## OOS"],
+  [/## Severity classification \(security findings only\)/g, "## Sev(sec)"],
+  [/## Severity classification \(test-gap findings only\)/g, "## Sev(tests)"],
+  [/## What to review/g, "## Scope"],
+  [/## Prove it before you flag it/g, "## Prove"],
+  [/## Reporting gate/g, "## Gate"],
+  [/## What earns a finding/g, "## Earns"],
+  [/## Preferred remedies \(carry these in fixPrompt\)/g, "## Remedies"],
+  [/## What to look for/g, "## LookFor"],
+  [/\bDo not report\b/g, "DNR"],
+  [/\bNever report\b/g, "NR"],
+  [/\bStatic analysis only\b/g, "SAO"],
+  [/\bresponse byte budget exceeded\b/g, "byte budget exceeded"],
+];
+
+export function customShorthandPrototype(text: string): string {
+  let out = compactStaticFormatting(text);
+  for (const [pattern, replacement] of SHORTHAND_REPLACEMENTS) {
+    out = out.replace(pattern, replacement);
+  }
+  return out;
+}
+
+export const customShorthandTransform: PromptCostTransform = {
+  id: "custom-shorthand",
+  description: "Test-only header/prose shorthand (experimental, not for production)",
+  apply: customShorthandPrototype,
+};
+
+/** Negative-control transform that strips contract markers and evidence labels. */
+export function lossyStripContractMarkers(text: string): string {
+  return text
+    .replace(/submitReview exactly once/g, "")
+    .replace(/\bP0\b/g, "")
+    .replace(/\bP1\b/g, "")
+    .replace(/\bP2\b/g, "")
+    .replace(/\bP3\b/g, "")
+    .replace(/\bprCharacter\b/g, "")
+    .replace(/\bfindings\b/g, "")
+    .replace(/\bestimatedEffort\b/g, "")
+    .replace(/\brelevantTests\b/g, "")
+    .replace(/\bsecurityConcerns\b/g, "")
+    .replace(/\bfollowUps\b/g, "")
+    .replace(/\bReviewPayload\b/g, "")
+    .replace(/EVIDENCE:[A-Za-z0-9_-]+/g, "");
+}
+
+export const lossyStripTransform: PromptCostTransform = {
+  id: "custom-shorthand",
+  description: "Lossy strip of contract markers (negative control for harness)",
+  apply: lossyStripContractMarkers,
+};
+
+export const EVAL_CANDIDATE_TRANSFORMS: readonly PromptCostTransform[] = [
+  baselineTransform,
+  compactStaticTransform,
+  compactToolResultTransform,
+  customShorthandTransform,
+];


### PR DESCRIPTION
Closes #150.

## Summary
Adds an offline, deterministic prompt-cost evaluation harness and ADR 0022 so compression ideas can be compared safely without changing production review prompts.

## Changes
- **ADR 0022** documents preferred cost order: measure → telemetry → tool-output caps → prompt dedupe → evaluated compression. Notes stable-prefix caching, provider-specific tokenization, and no default tokenizer dependency.
- **`test/promptCostEval/`** fixtures (correctness, security, false-positive trap, quality, tests, large/truncated), pure string candidate transforms (baseline, compact-static, compact-tool-result, test-only custom shorthand), invariant checks, and harness that builds surfaces via existing prompt builders.
- **`test/promptCostCompressionEval.test.ts`** asserts byte/token deltas, preserves contract markers under non-lossy candidates, rejects lossy strips of fields/severities/EVIDENCE labels, and emits machine-readable report shape.
- **`scripts/prompt-cost-eval-report.mjs`** optional JSON report via the report-shape test (`PROMPT_COST_EVAL_OUT`); not required CI.

## Out of scope (per issue)
No production prompt compression, no LLMLingua/runtime tokenizer, no live model eval, no schema/publish/topology changes.

___

## PR Agent Description

### PR Type

Documentation, Enhancement, Tests

### Description

- Add ADR 0022 documenting prompt-cost strategy and preferred order of attack
- Build offline eval harness with synthetic fixtures for every review lens
- Implement test-only string transforms (compact-static, compact-tool-result, custom-shorthand)
- Add invariant checks that reject lossy transforms stripping contract markers
- Include optional report script for local JSON comparison output

### Changes Diagram

```mermaid
flowchart LR
  A["ADR 0022: Cost strategy"] --> B["Offline eval harness"]
  B --> C["Synthetic fixtures (6 lenses)"]
  B --> D["String-only transforms"]
  D --> E["baseline / compact-static / compact-tool-result / custom-shorthand"]
  B --> F["Invariant checks"]
  F --> G["Reject lossy transforms"]
  B --> H["Vitest CI gate + optional report script"]
```

### File Walkthrough

<details>
<summary>Documentation (1 file)</summary>

<details>
<summary>ADR 0022 for prompt-cost strategy</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/171/files#diff-0982e52fae21bdc9076ea605d96886fa23d1e06c87cb3c799d2fa3977c46b00a"><code>docs/adr/0022-prompt-cost-strategy.md</code></a>

- Documents order of attack: measure → telemetry → tool budgets → dedupe → evaluate compression
- Defines offline harness as prerequisite before any production prompt change
- Captures caching discipline and tokenizer policy

</details>

</details>

<details>
<summary>Tests (5 files)</summary>

<details>
<summary>Synthetic fixtures for all review lenses</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/171/files#diff-4f449251530a4527a03cf6a0b435ba926145bb5e97df1b7b85bbb6de25850f34"><code>test/promptCostEval/fixtures.ts</code></a>

- 6 fixtures across correctness, security, false-positive, quality, tests, and large/truncated
- Each includes diffContent, evidenceLabels, and structured invariants metadata

</details>

<details>
<summary>Harness building surfaces and comparing candidates</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/171/files#diff-5f548bf9ebfc560765274f4531b3fbe7164e87d3f5e1b6d7038ea91a2b2c0335"><code>test/promptCostEval/harness.ts</code></a>

- Builds system-prompt, user-content, and fixture-evidence surfaces from production builders
- Runs candidate transforms, measures bytes/tokens, evaluates invariants
- Produces machine-readable JSON report shape

</details>

<details>
<summary>Invariant checks for contract and evidence markers</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/171/files#diff-162f9f27888d06622a3cbe9e92e186732396d6b7cf8bb3520a160af67d8e83cb"><code>test/promptCostEval/invariants.ts</code></a>

- Checks for structured-submission, payload-field, severity, lens-marker, and fixture-evidence kinds
- evaluateInvariants returns pass/fail per check for transform validation

</details>

<details>
<summary>Test-only pure string transforms</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/171/files#diff-a768552de89b543f6ad4da9c5de9ada15630d55523aa461a988272be438b76f3"><code>test/promptCostEval/transforms.ts</code></a>

- Baseline (identity), compact-static, compact-tool-result, and custom-shorthand transforms
- Negative-control lossyStripTransform used to verify harness rejects broken candidates
- All transforms are test-only and not exported from src/

</details>

<details>
<summary>Vitest suite for the offline eval harness</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/171/files#diff-dd7e5f605b10a0cad58fe79f260e9f8c40ebaab59a9d1a8909d43e137c824155"><code>test/promptCostCompressionEval.test.ts</code></a>

- 8 tests covering fixture coverage, surface building, numerical comparisons, invariant enforcement
- Verifies lossy candidates are rejected and compact transforms preserve evidence labels
- Emits machine-readable JSON report via PROMPT_COST_EVAL_OUT env var

</details>

</details>

<details>
<summary>Other (1 file)</summary>

<details>
<summary>Optional report script for local inspection</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/171/files#diff-3d26646b1a21cbfdc8129905108a18e3224a1d7bf8a0be83d1801839c885b1b0"><code>scripts/prompt-cost-eval-report.mjs</code></a>

- Spawns vitest with PROMPT_COST_EVAL_OUT env var and prints the report JSON to stdout
- Not required by CI; the vitest suite is the gate

</details>

</details>