### PR TITLE
Rewrite AGENTS.md as a progressive-disclosure index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ Skip doc updates when none of the above apply.
 ### Gotchas
 
 - **Install Nub once** — `npm install -g --ignore-scripts=false @nubjs/nub`, then `nub install` in the repo. Node 22.22.0 is pinned in [`.node-version`](.node-version); Nub provisions it on demand.
+- **`PATH` before global npm** — if `/exec-daemon` (or another Node) precedes the nvm Node on `PATH`, `npm install -g` may target `/usr/lib/node_modules` and fail with `EACCES`. Put the pinned Node first (`export PATH="$HOME/.nvm/versions/node/$(cat .node-version)/bin:$PATH"` after `nvm install`/`nvm use`), then install Nub.
 - **`GITHUB_APP_PRIVATE_KEY` must be a valid PEM key** — `loadConfig()` calls `crypto.createPrivateKey()` and throws on placeholders. For local-only dev, generate a throwaway key: `openssl genrsa 2048 > key.pem` and set the `.env` value to the escaped content.
 - **Docker in cloud VMs** — needs `fuse-overlayfs` storage driver and `iptables-legacy`. The update script handles Docker installation; start `dockerd` manually if needed: `sudo dockerd &>/tmp/dockerd.log &`.
 - **Tests (`nub run test`)** are pure unit/integration tests and do not need Postgres or any running service. Use `nub run --node test` if Vitest shows augmentation-related flakiness.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,38 +1,40 @@
-# Agent maintenance index
+# AGENTS.md
 
-**pr-agent** is a GitHub PR agent: automated reviews on `pull_request` events plus `/review`, `/describe`, `/ask`, and `/triage` slash commands. It runs as two roles over Postgres + pg-boss: **web** (webhook intake, durable dedupe, job enqueue) and **worker** (ack, review, ask, description, triage, retention queues).
+Indexer for agents working on **pr-agent**. Open the linked source; do not treat this file as the rulebook.
 
-## Always apply
+## What this is
 
-- Use the domain vocabulary from [CONTEXT.md](CONTEXT.md); it is the canonical product language — do not invent synonyms.
-- No magic numbers or env defaults in feature modules; everything goes through `src/settings/`. Follow the knob-change checklist in [docs/configuration.md](docs/configuration.md).
-- Long prompt prose lives in prompt modules, not settings; see [docs/development.md](docs/development.md).
-- Import concrete modules, not removed barrel `index.ts` files; run `nubx knip` after refactors (details in [docs/development.md](docs/development.md)).
-- If a change alters runtime topology, update the [README.md](README.md) "How It Works" Mermaid diagram in the same PR (rubric in [docs/development.md](docs/development.md)).
-- Docs are part of the change: if your change is critical (see Keep the docs true), update the matching doc in the same PR.
+- **Navigation only** — pointers to product language, design, and deeper docs.
+- **Progressive disclosure** — read the entry you need; leave the rest closed.
+- If a rule already lives elsewhere, **link it; do not restate it**.
 
-## Where to look
+## Product (always)
 
-| Read                                                             | When                                                                     |
-| ---------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| [CONTEXT.md](CONTEXT.md)                                         | Domain language — always read before naming things                       |
-| [README.md](README.md) "How It Works"                            | Runtime topology (web vs worker, Postgres, pg-boss queues)               |
-| [docs/configuration.md](docs/configuration.md)                   | Any tunable, env var, or code constant change                            |
-| [docs/development.md](docs/development.md)                       | Module layout, import rules, Cursor Cloud setup, topology-diagram rubric |
-| [docs/operations.md](docs/operations.md)                         | Behaviour, deployment, developer scripts                                 |
-| [docs/agent-work-ops.md](docs/agent-work-ops.md)                 | Queue health, retry and recovery                                         |
-| [docs/adr/](docs/adr/)                                           | Architecture rationale (ADRs numbered 0001-0018)                         |
-| [test/settingsInventory.test.ts](test/settingsInventory.test.ts) | CI gate for env/config alignment                                         |
+**pr-agent** — GitHub PR agent: automated reviews on `pull_request` events plus `/review`, `/describe`, `/ask`, and `/triage`. Roles: **web** (webhook intake) and **worker** (queues). Topology: [README.md](README.md) "How It Works".
 
-## Keep the docs true
+**Language / design:** [CONTEXT.md](CONTEXT.md) is the canonical domain vocabulary. Use those terms; do not invent synonyms.
 
-| If you change                                                       | Update in the same PR                                                             |
-| ------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| Domain vocabulary or a product concept                              | [CONTEXT.md](CONTEXT.md)                                                          |
-| Env var, default, or code constant                                  | [docs/configuration.md](docs/configuration.md) (follow its knob-change checklist) |
-| Module layout, public entry points, or import rules                 | [docs/development.md](docs/development.md)                                        |
-| Runtime topology (roles, queues, webhook route, executor ownership) | [README.md](README.md) "How It Works" Mermaid diagram                             |
-| User-facing behaviour, deployment, or scripts                       | [docs/operations.md](docs/operations.md)                                          |
-| A significant architecture decision                                 | new ADR in [docs/adr/](docs/adr/) (next number)                                   |
+## Open when
 
-If none apply, no doc update is needed; do not update docs speculatively.
+| Need | Source |
+| ---- | ------ |
+| Naming, product concepts | [CONTEXT.md](CONTEXT.md) |
+| Runtime topology | [README.md](README.md) "How It Works" |
+| Env, constants, knob checklist | [docs/configuration.md](docs/configuration.md) · CI: [`test/settingsInventory.test.ts`](test/settingsInventory.test.ts) |
+| Modules, imports, prompts, Cloud setup, topology rubric | [docs/development.md](docs/development.md) |
+| Behaviour, deploy, scripts | [docs/operations.md](docs/operations.md) |
+| Queue health / recovery | [docs/agent-work-ops.md](docs/agent-work-ops.md) |
+| Architecture decisions | [docs/adr/](docs/adr/) |
+
+## Same-PR doc updates
+
+| Change | Update |
+| ------ | ------ |
+| Domain vocabulary or product concept | [CONTEXT.md](CONTEXT.md) |
+| Env, default, or code constant | [docs/configuration.md](docs/configuration.md) |
+| Module layout, entry points, or import rules | [docs/development.md](docs/development.md) |
+| Runtime topology | [README.md](README.md) "How It Works" |
+| Behaviour, deploy, or scripts | [docs/operations.md](docs/operations.md) |
+| Significant architecture decision | new ADR under [docs/adr/](docs/adr/) |
+
+Skip doc updates when none of the above apply.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,10 +21,11 @@ Indexer for agents working on **pr-agent**. Open the linked source; do not treat
 | Naming, product concepts | [CONTEXT.md](CONTEXT.md) |
 | Runtime topology | [README.md](README.md) "How It Works" |
 | Env, constants, knob checklist | [docs/configuration.md](docs/configuration.md) · CI: [`test/settingsInventory.test.ts`](test/settingsInventory.test.ts) |
-| Modules, imports, prompts, Cloud setup, topology rubric | [docs/development.md](docs/development.md) |
+| Modules, imports, prompts, topology rubric | [docs/development.md](docs/development.md) |
 | Behaviour, deploy, scripts | [docs/operations.md](docs/operations.md) |
 | Queue health / recovery | [docs/agent-work-ops.md](docs/agent-work-ops.md) |
 | Architecture decisions | [docs/adr/](docs/adr/) |
+| Cursor Cloud services / gotchas | [Cursor Cloud specific instructions](#cursor-cloud-specific-instructions) (this file) |
 
 ## Same-PR doc updates
 
@@ -36,5 +37,26 @@ Indexer for agents working on **pr-agent**. Open the linked source; do not treat
 | Runtime topology | [README.md](README.md) "How It Works" |
 | Behaviour, deploy, or scripts | [docs/operations.md](docs/operations.md) |
 | Significant architecture decision | new ADR under [docs/adr/](docs/adr/) |
+| Cursor Cloud setup | this file |
 
 Skip doc updates when none of the above apply.
+
+## Cursor Cloud specific instructions
+
+### Services overview
+
+| Service              | How to run                                                                                                                                               | Notes                                                        |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| Postgres 16          | `docker run -d --name pr-agent-postgres -e POSTGRES_DB=pr_agent -e POSTGRES_USER=pr_agent -e POSTGRES_PASSWORD=pr_agent -p 5432:5432 postgres:16-alpine` | Required for both web and worker roles                       |
+| Web (webhook intake) | `ROLE=web nub src/index.ts`                                                                                                                              | Listens on `PORT` (default 7224); `GET /health` returns `ok` |
+| Worker (agent work)  | `ROLE=worker nub src/index.ts`                                                                                                                           | Processes reviews, descriptions, asks, and triage            |
+
+### Gotchas
+
+- **Install Nub once** — `npm install -g --ignore-scripts=false @nubjs/nub`, then `nub install` in the repo. Node 22.22.0 is pinned in [`.node-version`](.node-version); Nub provisions it on demand.
+- **`GITHUB_APP_PRIVATE_KEY` must be a valid PEM key** — `loadConfig()` calls `crypto.createPrivateKey()` and throws on placeholders. For local-only dev, generate a throwaway key: `openssl genrsa 2048 > key.pem` and set the `.env` value to the escaped content.
+- **Docker in cloud VMs** — needs `fuse-overlayfs` storage driver and `iptables-legacy`. The update script handles Docker installation; start `dockerd` manually if needed: `sudo dockerd &>/tmp/dockerd.log &`.
+- **Tests (`nub run test`)** are pure unit/integration tests and do not need Postgres or any running service. Use `nub run --node test` if Vitest shows augmentation-related flakiness.
+- **Lint/fmt commands**: `nub run lint` (oxlint, type-aware), `nub run typecheck` (tsc), `nub run fmt:check` (oxfmt). Combined: `nub run check:code`.
+- **Ignored build scripts warning** from Nub is expected for some transitive deps (`esbuild`, `protobufjs`). **`sqlite3` is approved** in `package.json` (`pnpm.onlyBuiltDependencies`) because `@cursor/sdk` needs its native binding when `PI_PROVIDER=cursor`. The Docker image compiles `sqlite3` in the `deps` stage (with `python3`/`make`/`g++`) and copies `node_modules` into runtime — do not run a fresh `nub prune --prod` in the final stage without build tools.
+- **Vercel site deploys** remain on pnpm via [`site/vercel.json`](site/vercel.json); all other surfaces use Nub in pnpm incumbent mode.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,4 +2,4 @@
 
 @AGENTS.md
 
-All agent instructions live in AGENTS.md; follow its pointers for deeper context.
+Start at AGENTS.md; follow its pointers for deeper context.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 Single place to find tunables for **pr-agent**. Code defaults live in [`src/settings/`](../src/settings/); env vars are loaded in [`src/config.ts`](../src/config.ts).
 
-For behaviour, deployment, and developer scripts see [operations.md](operations.md). Maintenance rules: [AGENTS.md](../AGENTS.md).
+For behaviour, deployment, and developer scripts see [operations.md](operations.md). Agent index: [AGENTS.md](../AGENTS.md).
 
 ## How to change something
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,6 +1,6 @@
 # Development guide
 
-Module layout, import rules, Cursor Cloud setup, and the runtime topology diagram rubric for **pr-agent**. Agent index: [AGENTS.md](../AGENTS.md).
+Module layout, import rules, and the runtime topology diagram rubric for **pr-agent**. Agent index (including Cursor Cloud setup): [AGENTS.md](../AGENTS.md).
 
 ## Module layout (production)
 
@@ -29,23 +29,3 @@ When a change alters **runtime topology**, update the Mermaid diagram in [README
 **Counts as topology change:** web vs worker responsibilities, Postgres or pg-boss role, webhook route, pg-boss queue lanes, or which executor owns a work type.
 
 **Does not require diagram updates:** prompt tweaks, tool implementation details, publish formatting, or other changes that do not change the diagram's boxes or arrows.
-
-## Cursor Cloud specific instructions
-
-### Services overview
-
-| Service              | How to run                                                                                                                                               | Notes                                                        |
-| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| Postgres 16          | `docker run -d --name pr-agent-postgres -e POSTGRES_DB=pr_agent -e POSTGRES_USER=pr_agent -e POSTGRES_PASSWORD=pr_agent -p 5432:5432 postgres:16-alpine` | Required for both web and worker roles                       |
-| Web (webhook intake) | `ROLE=web nub src/index.ts`                                                                                                                              | Listens on `PORT` (default 7224); `GET /health` returns `ok` |
-| Worker (agent work)  | `ROLE=worker nub src/index.ts`                                                                                                                           | Processes reviews, descriptions, asks, and triage            |
-
-### Gotchas
-
-- **Install Nub once** — `npm install -g --ignore-scripts=false @nubjs/nub`, then `nub install` in the repo. Node 22.22.0 is pinned in [`.node-version`](../.node-version); Nub provisions it on demand.
-- **`GITHUB_APP_PRIVATE_KEY` must be a valid PEM key** — `loadConfig()` calls `crypto.createPrivateKey()` and throws on placeholders. For local-only dev, generate a throwaway key: `openssl genrsa 2048 > key.pem` and set the `.env` value to the escaped content.
-- **Docker in cloud VMs** — needs `fuse-overlayfs` storage driver and `iptables-legacy`. The update script handles Docker installation; start `dockerd` manually if needed: `sudo dockerd &>/tmp/dockerd.log &`.
-- **Tests (`nub run test`)** are pure unit/integration tests and do not need Postgres or any running service. Use `nub run --node test` if Vitest shows augmentation-related flakiness.
-- **Lint/fmt commands**: `nub run lint` (oxlint, type-aware), `nub run typecheck` (tsc), `nub run fmt:check` (oxfmt). Combined: `nub run check:code`.
-- **Ignored build scripts warning** from Nub is expected for some transitive deps (`esbuild`, `protobufjs`). **`sqlite3` is approved** in `package.json` (`pnpm.onlyBuiltDependencies`) because `@cursor/sdk` needs its native binding when `PI_PROVIDER=cursor`. The Docker image compiles `sqlite3` in the `deps` stage (with `python3`/`make`/`g++`) and copies `node_modules` into runtime — do not run a fresh `nub prune --prod` in the final stage without build tools.
-- **Vercel site deploys** remain on pnpm via [`site/vercel.json`](../site/vercel.json); all other surfaces use Nub in pnpm incumbent mode.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,6 +1,6 @@
 # Development guide
 
-Module layout, import rules, Cursor Cloud setup, and the runtime topology diagram rubric for **pr-agent**. Index and always-apply rules: [AGENTS.md](../AGENTS.md).
+Module layout, import rules, Cursor Cloud setup, and the runtime topology diagram rubric for **pr-agent**. Agent index: [AGENTS.md](../AGENTS.md).
 
 ## Module layout (production)
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -118,7 +118,7 @@ Type-aware lint requires `oxlint-tsgolint` (dev dependency). [`pnpm-workspace.ya
 
 `nub run test` runs this gate before Vitest (`pretest`).
 
-Maintainer rules: [AGENTS.md](../AGENTS.md).
+Agent index: [AGENTS.md](../AGENTS.md).
 
 ## Security
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@types/pg": "^8.20.0",
     "oxfmt": "^0.53.0",
     "oxlint": "^1.68.0",
-    "oxlint-tsgolint": "^0.23.0",
+    "oxlint-tsgolint": "^0.24.0",
     "typescript": "^7.0.1-rc",
     "vitest": "^4.1.8"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,10 +100,10 @@ importers:
         version: 0.53.0
       oxlint:
         specifier: ^1.68.0
-        version: 1.72.0(oxlint-tsgolint@0.23.0)
+        version: 1.72.0(oxlint-tsgolint@0.24.0)
       oxlint-tsgolint:
-        specifier: ^0.23.0
-        version: 0.23.0
+        specifier: ^0.24.0
+        version: 0.24.0
       typescript:
         specifier: ^7.0.1-rc
         version: 7.0.2
@@ -1038,33 +1038,33 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxlint-tsgolint/darwin-arm64@0.23.0':
-    resolution: {integrity: sha512-gOs9PVr2wEg4ox9z0aJo+RKhhImW86YL5N6yav8BK/rgPsIrwN/igSZ+pbRr723NFvUNKde9fgMhRA6JrXAOZw==}
+  '@oxlint-tsgolint/darwin-arm64@0.24.0':
+    resolution: {integrity: sha512-C2uMmwK5Bc4ri4ysZ6sA8Rcu+A5zBQTp6ml2u0CLLbRZp4kMFPV3yWk8B5DK9Aw7y9bbjogIm75tUwGLFzlsYQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint-tsgolint/darwin-x64@0.23.0':
-    resolution: {integrity: sha512-kjJ8B+7n4tB9VJdxS5A9GdJt6/bYpzbu4lXp2uO1S3sRmCB5gDEABlGoiePNApRWaW+xqL4b4xgiE727jSLhuA==}
+  '@oxlint-tsgolint/darwin-x64@0.24.0':
+    resolution: {integrity: sha512-Wgvt/1lRbDxmoNqWQKKcL+UIiqLmdJ+EWLpQa1qzoNVAfNB0PJpa82/8dH1twT/3rSs4zrP5TXPWl4juB71WuQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint-tsgolint/linux-arm64@0.23.0':
-    resolution: {integrity: sha512-6dCZuKNu135seMXilkRk9SpCx6i1XgmiipYGalLij5WVRX6ZYS8c4xI7preN/zv9fCXhsQclTIMDu2Y/cytTjw==}
+  '@oxlint-tsgolint/linux-arm64@0.24.0':
+    resolution: {integrity: sha512-PB1rxII7KV83+ASY4sSkXtqvpij6ME66+QCRL49uksi/ofs2Rf/UVboYr095n0Rkbl2wgvlsHGl6DHC361jQUQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@oxlint-tsgolint/linux-x64@0.23.0':
-    resolution: {integrity: sha512-3bdilnyA7kmSTjK27rvjIjSxL5SIg3wt7vwNiRkouWB83ytssyKnuGvxSYJxgMEmFpSutzaBzcCUM2jDtPGcgA==}
+  '@oxlint-tsgolint/linux-x64@0.24.0':
+    resolution: {integrity: sha512-xcz3CxKmjTQLREtE/UShh+ruWmm9nAb7UM9zKcD65BStiuYgOakAKkPHl4YS5DztpVcDrE0+HqbOolTlRKYWmw==}
     cpu: [x64]
     os: [linux]
 
-  '@oxlint-tsgolint/win32-arm64@0.23.0':
-    resolution: {integrity: sha512-j+OEp44SVYiQ+ZD+uttsX7u6L9SvmbbQ77SO1pSFCcJlsVMeCk8qZsjhKfGKuT/jIA+ipOJMVs/+pqUfObBWNw==}
+  '@oxlint-tsgolint/win32-arm64@0.24.0':
+    resolution: {integrity: sha512-A2i6ZGBec3i20S7RaxkgHc6r3HYtD5Mn7j/mb22NkTz14u0JuudvTu6JggAnbGMcv8+dBKQI//EasxSPJLD8pw==}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint-tsgolint/win32-x64@0.23.0':
-    resolution: {integrity: sha512-5MyjFuqf+g8OUPJBSGWHJtmoWnzFJYyOg4To9WMQshZYEWig/vtu7JtJ03VWnzHv9LJkAUeApY0gVCOywFR/iQ==}
+  '@oxlint-tsgolint/win32-x64@0.24.0':
+    resolution: {integrity: sha512-0ZbGd9qRB6zs82moekaKdEvncRANq49EAwfNX62JpTS46feXUhKAuoyVDvZMj6Rywejylrmmu79Wo6faYCo4Ew==}
     cpu: [x64]
     os: [win32]
 
@@ -2730,8 +2730,8 @@ packages:
       vite-plus:
         optional: true
 
-  oxlint-tsgolint@0.23.0:
-    resolution: {integrity: sha512-3mBv3CoPbh8dFbzfDGIWa2ytZjn2v+3EX4aKRXjIhsoGFzG8GCjfRirz3rwZf1wYbZzsNLTSgpw8VjQuWdp/jA==}
+  oxlint-tsgolint@0.24.0:
+    resolution: {integrity: sha512-giCk5sEvG02d5tzPmFMX3hem8ndzEEu1xvGYS5OwNfO2WGl6ZVxt5LjE0yiMDoz94INI7XkXwgFAQiydPvVHDw==}
     hasBin: true
 
   oxlint@1.72.0:
@@ -4363,22 +4363,22 @@ snapshots:
   '@oxfmt/binding-win32-x64-msvc@0.53.0':
     optional: true
 
-  '@oxlint-tsgolint/darwin-arm64@0.23.0':
+  '@oxlint-tsgolint/darwin-arm64@0.24.0':
     optional: true
 
-  '@oxlint-tsgolint/darwin-x64@0.23.0':
+  '@oxlint-tsgolint/darwin-x64@0.24.0':
     optional: true
 
-  '@oxlint-tsgolint/linux-arm64@0.23.0':
+  '@oxlint-tsgolint/linux-arm64@0.24.0':
     optional: true
 
-  '@oxlint-tsgolint/linux-x64@0.23.0':
+  '@oxlint-tsgolint/linux-x64@0.24.0':
     optional: true
 
-  '@oxlint-tsgolint/win32-arm64@0.23.0':
+  '@oxlint-tsgolint/win32-arm64@0.24.0':
     optional: true
 
-  '@oxlint-tsgolint/win32-x64@0.23.0':
+  '@oxlint-tsgolint/win32-x64@0.24.0':
     optional: true
 
   '@oxlint/binding-android-arm-eabi@1.72.0':
@@ -5785,18 +5785,18 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.53.0
       '@oxfmt/binding-win32-x64-msvc': 0.53.0
 
-  oxlint-tsgolint@0.23.0:
+  oxlint-tsgolint@0.24.0:
     optionalDependencies:
-      '@oxlint-tsgolint/darwin-arm64': 0.23.0
-      '@oxlint-tsgolint/darwin-x64': 0.23.0
-      '@oxlint-tsgolint/linux-arm64': 0.23.0
-      '@oxlint-tsgolint/linux-x64': 0.23.0
-      '@oxlint-tsgolint/win32-arm64': 0.23.0
-      '@oxlint-tsgolint/win32-x64': 0.23.0
+      '@oxlint-tsgolint/darwin-arm64': 0.24.0
+      '@oxlint-tsgolint/darwin-x64': 0.24.0
+      '@oxlint-tsgolint/linux-arm64': 0.24.0
+      '@oxlint-tsgolint/linux-x64': 0.24.0
+      '@oxlint-tsgolint/win32-arm64': 0.24.0
+      '@oxlint-tsgolint/win32-x64': 0.24.0
 
-  oxlint@1.72.0(oxlint-tsgolint@0.23.0):
+  oxlint@1.72.0(oxlint-tsgolint@0.24.0):
     dependencies:
-      oxlint-tsgolint: 0.23.0
+      oxlint-tsgolint: 0.24.0
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.72.0
       '@oxlint/binding-android-arm64': 1.72.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rewrites `AGENTS.md` from a rule dump into a navigation-only indexer: product language points at `CONTEXT.md`, detail lives behind open-when and same-PR doc tables, and restated always-apply bullets are removed in favor of links.

Moves Cursor Cloud services overview and gotchas from `docs/development.md` into `AGENTS.md`, and updates open-when / same-PR pointers accordingly.

Bumps `oxlint-tsgolint` to `^0.24.0` so `npm install` / Cloud update scripts no longer fail on oxlint's `peerOptional >=0.24.0`, and documents the `/exec-daemon` PATH ordering gotcha for global Nub installs.

Aligns `CLAUDE.md` and the development/configuration/operations cross-refs to call it the agent index.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99754a15-e411-48d3-8b62-a89f91b7488b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99754a15-e411-48d3-8b62-a89f91b7488b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

___

## PR Agent Description

### PR Type

Documentation

### Description

- Rewrite AGENTS.md as concise navigation index with progressive disclosure
- Replace detailed rulebook content with linked references to source docs
- Update doc cross-references to label AGENTS.md as "Agent index"

### File Walkthrough

<details>
<summary>Documentation (5 files)</summary>

<details>
<summary>Rewrite as navigation index with progressive disclosure</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/285/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9"><code>AGENTS.md</code></a>

- Shift from rulebook to pointer-based structure
- Add "What this is" and "Open when" sections
- Link to sources instead of restating rules

</details>

<details>
<summary>Simplify reference to AGENTS.md entry point</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/285/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7"><code>CLAUDE.md</code></a>

- Shorten instruction to start at AGENTS.md

</details>

<details>
<summary>Update AGENTS.md reference label</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/285/files#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180"><code>docs/configuration.md</code></a>

- Change "Maintenance rules" to "Agent index"

</details>

<details>
<summary>Update AGENTS.md reference label</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/285/files#diff-97db29a7915320e63d41d38a0440360a87055ee8ed03757aa263116dbbb4aabe"><code>docs/development.md</code></a>

- Change "Index and always-apply rules" to "Agent index"

</details>

<details>
<summary>Update AGENTS.md reference label</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/285/files#diff-ad74991b96593fdee570962fc5b1e319080abd55e16614f556f74b7de8fd02d1"><code>docs/operations.md</code></a>

- Change "Maintainer rules" to "Agent index"

</details>

</details>