### PR TITLE
Close low-severity site, test, and config backlog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,28 +16,28 @@ Indexer for agents working on **pr-agent**. Open the linked source; do not treat
 
 ## Open when
 
-| Need | Source |
-| ---- | ------ |
-| Naming, product concepts | [CONTEXT.md](CONTEXT.md) |
-| Runtime topology | [README.md](README.md) "How It Works" |
-| Env, constants, knob checklist | [docs/configuration.md](docs/configuration.md) · CI: [`test/settingsInventory.test.ts`](test/settingsInventory.test.ts) |
-| Modules, imports, prompts, topology rubric | [docs/development.md](docs/development.md) |
-| Behaviour, deploy, scripts | [docs/operations.md](docs/operations.md) |
-| Queue health / recovery | [docs/agent-work-ops.md](docs/agent-work-ops.md) |
-| Architecture decisions | [docs/adr/](docs/adr/) |
-| Cursor Cloud services / gotchas | [Cursor Cloud specific instructions](#cursor-cloud-specific-instructions) (this file) |
+| Need                                       | Source                                                                                                                  |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| Naming, product concepts                   | [CONTEXT.md](CONTEXT.md)                                                                                                |
+| Runtime topology                           | [README.md](README.md) "How It Works"                                                                                   |
+| Env, constants, knob checklist             | [docs/configuration.md](docs/configuration.md) · CI: [`test/settingsInventory.test.ts`](test/settingsInventory.test.ts) |
+| Modules, imports, prompts, topology rubric | [docs/development.md](docs/development.md)                                                                              |
+| Behaviour, deploy, scripts                 | [docs/operations.md](docs/operations.md)                                                                                |
+| Queue health / recovery                    | [docs/agent-work-ops.md](docs/agent-work-ops.md)                                                                        |
+| Architecture decisions                     | [docs/adr/](docs/adr/)                                                                                                  |
+| Cursor Cloud services / gotchas            | [Cursor Cloud specific instructions](#cursor-cloud-specific-instructions) (this file)                                   |
 
 ## Same-PR doc updates
 
-| Change | Update |
-| ------ | ------ |
-| Domain vocabulary or product concept | [CONTEXT.md](CONTEXT.md) |
-| Env, default, or code constant | [docs/configuration.md](docs/configuration.md) |
-| Module layout, entry points, or import rules | [docs/development.md](docs/development.md) |
-| Runtime topology | [README.md](README.md) "How It Works" |
-| Behaviour, deploy, or scripts | [docs/operations.md](docs/operations.md) |
-| Significant architecture decision | new ADR under [docs/adr/](docs/adr/) |
-| Cursor Cloud setup | this file |
+| Change                                       | Update                                         |
+| -------------------------------------------- | ---------------------------------------------- |
+| Domain vocabulary or product concept         | [CONTEXT.md](CONTEXT.md)                       |
+| Env, default, or code constant               | [docs/configuration.md](docs/configuration.md) |
+| Module layout, entry points, or import rules | [docs/development.md](docs/development.md)     |
+| Runtime topology                             | [README.md](README.md) "How It Works"          |
+| Behaviour, deploy, or scripts                | [docs/operations.md](docs/operations.md)       |
+| Significant architecture decision            | new ADR under [docs/adr/](docs/adr/)           |
+| Cursor Cloud setup                           | this file                                      |
 
 Skip doc updates when none of the above apply.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ USER node
 
 EXPOSE 7224
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
   CMD node -e "fetch('http://127.0.0.1:'+process.env.PORT+'/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 
 CMD ["node", "dist/index.js"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,19 +2,6 @@
 # Usage: docker compose -f docker-compose.yml -f docker-compose.prod.yml up
 services:
   postgres:
-    shm_size: 128mb
-    command:
-      - postgres
-      - -c
-      - shared_buffers=${POSTGRES_SHARED_BUFFERS:-256MB}
-      - -c
-      - effective_cache_size=${POSTGRES_EFFECTIVE_CACHE_SIZE:-768MB}
-      - -c
-      - maintenance_work_mem=${POSTGRES_MAINTENANCE_WORK_MEM:-128MB}
-      - -c
-      - wal_compression=${POSTGRES_WAL_COMPRESSION:-on}
-      - -c
-      - random_page_cost=${POSTGRES_RANDOM_PAGE_COST:-1.1}
     environment:
       POSTGRES_DB: ${POSTGRES_DB:?set POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER:?set POSTGRES_USER}

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -63,7 +63,7 @@ Compose sets `environment.PORT=7224` and **`7224:7224`** publishing. For a host 
 
 **Requires Docker Engine with Compose v2.** `env_file` defaults to **`.env`**; use host env **`PR_AGENT_ENV_FILE`** for an alternate path.
 
-The Compose `postgres` service sets `shm_size: 128mb` and conservative server tuning flags (`shared_buffers`, `effective_cache_size`, `maintenance_work_mem`, `wal_compression`, `random_page_cost`). Override them with the `POSTGRES_SHARED_BUFFERS`, `POSTGRES_EFFECTIVE_CACHE_SIZE`, `POSTGRES_MAINTENANCE_WORK_MEM`, `POSTGRES_WAL_COMPRESSION`, and `POSTGRES_RANDOM_PAGE_COST` Compose env vars; the production override mirrors the same flags.
+The Compose `postgres` service sets `shm_size: 128mb` and conservative server tuning flags (`shared_buffers`, `effective_cache_size`, `maintenance_work_mem`, `wal_compression`, `random_page_cost`). Override them with the `POSTGRES_SHARED_BUFFERS`, `POSTGRES_EFFECTIVE_CACHE_SIZE`, `POSTGRES_MAINTENANCE_WORK_MEM`, `POSTGRES_WAL_COMPRESSION`, and `POSTGRES_RANDOM_PAGE_COST` Compose env vars. The base Compose file owns `shm_size` and those tuning flags; the production overlay only requires credentials via `:?` env vars.
 
 ```bash
 PR_AGENT_ENV_FILE=/abs/path/to/.env docker compose up

--- a/site/app/__root.tsx
+++ b/site/app/__root.tsx
@@ -121,6 +121,9 @@ function RootLayout() {
         <script defer src="/_vercel/insights/script.js" />
       </head>
       <body className="bg-navy text-ink min-h-screen overflow-x-hidden">
+        <a href="#main-content" className="skip-link">
+          Skip to content
+        </a>
         <Outlet />
         <Scripts />
       </body>

--- a/site/app/__root.tsx
+++ b/site/app/__root.tsx
@@ -41,6 +41,10 @@ export const Route = createRootRoute({
         content: "website",
       },
       {
+        property: "og:url",
+        content: SITE_ORIGIN,
+      },
+      {
         property: "og:site_name",
         content: PRODUCT_NAME,
       },
@@ -85,6 +89,10 @@ export const Route = createRootRoute({
       {
         rel: "stylesheet",
         href: appCss,
+      },
+      {
+        rel: "canonical",
+        href: SITE_ORIGIN,
       },
       {
         rel: "icon",

--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -45,6 +45,24 @@
     scroll-behavior: smooth;
   }
 
+  .skip-link {
+    position: absolute;
+    left: 1rem;
+    top: 1rem;
+    z-index: 100;
+    padding: 0.5rem 0.75rem;
+    background: var(--color-navy-raised);
+    color: var(--color-ink);
+    border: 1px solid var(--color-edge-strong);
+    border-radius: 0.25rem;
+    transform: translateY(-200%);
+    transition: transform 0.15s ease;
+  }
+
+  .skip-link:focus {
+    transform: translateY(0);
+  }
+
   @media (prefers-reduced-motion: reduce) {
     html {
       scroll-behavior: auto;

--- a/site/app/index.tsx
+++ b/site/app/index.tsx
@@ -20,8 +20,8 @@ function Home() {
   return (
     <>
       <JsonLd />
+      <Header />
       <main id="main-content" className="overflow-x-hidden">
-        <Header />
         <Hero />
         <Features />
         <Capabilities />
@@ -31,8 +31,8 @@ function Home() {
         <Alternatives />
         <Faq />
         <Quickstart />
-        <Footer />
       </main>
+      <Footer />
     </>
   );
 }

--- a/site/components/capabilities.tsx
+++ b/site/components/capabilities.tsx
@@ -22,7 +22,7 @@ export function Capabilities() {
           </h2>
           <p className="mt-4 text-sm leading-relaxed text-ink-mute">
             Trigger a pass from a pull request comment, or let the automatic path run when a PR
-            opens or updates.
+            opens.
           </p>
         </div>
 

--- a/site/lib/content.ts
+++ b/site/lib/content.ts
@@ -19,10 +19,10 @@ export const FEATURES: FeatureItem[] = [
     summary: "Self-hosted GitHub App",
   },
   {
-    title: "A pull request opens or updates",
+    title: "A pull request opens",
     detail:
       "GitHub delivers a signed webhook. PR Agent records it, reacts with eyes so the team knows work started, and queues a review for that head.",
-    cue: "pull_request opened / synchronize",
+    cue: "pull_request opened",
     summary: "Automated AI pull request reviews",
   },
   {
@@ -57,7 +57,7 @@ export type CapabilityItem = {
 export const CAPABILITIES: CapabilityItem[] = [
   {
     title: "Catch review basics before a human opens the diff",
-    trigger: "Runs when a PR opens or updates, or when you comment /review",
+    trigger: "Runs when a PR opens, or when you comment /review",
     detail: "Inline comments appear on the Files changed tab.",
   },
   {

--- a/site/lib/seo.ts
+++ b/site/lib/seo.ts
@@ -39,7 +39,7 @@ export function softwareApplicationJsonLd() {
     applicationSubCategory: "AI Code Review",
     operatingSystem: "Linux, Docker",
     description: SEO_DESCRIPTION,
-    url: REPO_URL,
+    url: SITE_ORIGIN,
     downloadUrl: REPO_URL,
     softwareVersion: "0.1.0",
     license: "https://opensource.org/licenses/MIT",
@@ -65,7 +65,7 @@ export function webSiteJsonLd() {
     "@type": "WebSite",
     name: PRODUCT_NAME,
     description: SEO_DESCRIPTION,
-    url: REPO_URL,
+    url: SITE_ORIGIN,
   };
 }
 

--- a/src/commands/parseAskQuestion.ts
+++ b/src/commands/parseAskQuestion.ts
@@ -57,14 +57,3 @@ export function parseAskQuestionForReplyTarget(
   if (question.length > MAX_ASK_QUESTION_CHARS) return { kind: "too_long" };
   return { kind: "ok", question };
 }
-
-export function parseAskQuestion(body: string): string | null {
-  const result = parseAskQuestionResult(body);
-  return result.kind === "ok" ? result.question : null;
-}
-
-export function askQuestionParseFailure(body: string): "missing" | "too_long" | null {
-  const result = parseAskQuestionResult(body);
-  if (result.kind === "missing" || result.kind === "too_long") return result.kind;
-  return null;
-}

--- a/src/review/repoPolicy.ts
+++ b/src/review/repoPolicy.ts
@@ -58,6 +58,10 @@ function sanitizeRenderedPolicyText(value: string): string {
   return value.split(/\r?\n/).join(" ").trim();
 }
 
+function escapeYamlDoubleQuoted(value: string): string {
+  return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+}
+
 export async function loadRepoPolicy(
   agentCwd: string,
   maxBytes: number,
@@ -155,13 +159,14 @@ export function renderPolicySuggestionForDismissed(params: {
   readonly filePath: string;
   readonly dismissalEvidence: string;
 }): string {
-  const path = sanitizeRenderedPolicyText(params.filePath).slice(
-    0,
-    MAX_REPO_POLICY_PATH_PATTERN_CHARS,
+  const path = escapeYamlDoubleQuoted(
+    sanitizeRenderedPolicyText(params.filePath).slice(0, MAX_REPO_POLICY_PATH_PATTERN_CHARS),
   );
-  const instruction = sanitizeRenderedPolicyText(params.dismissalEvidence).slice(
-    0,
-    MAX_REPO_POLICY_INSTRUCTION_CHARS,
+  const instruction = escapeYamlDoubleQuoted(
+    sanitizeRenderedPolicyText(params.dismissalEvidence).slice(
+      0,
+      MAX_REPO_POLICY_INSTRUCTION_CHARS,
+    ),
   );
   return [
     "```yaml",

--- a/test/parseAskQuestion.test.ts
+++ b/test/parseAskQuestion.test.ts
@@ -3,55 +3,65 @@ import { MAX_ASK_QUESTION_CHARS } from "../src/agent/ask/askSafety.js";
 import { ASK_USAGE_HINT } from "../src/settings/index.js";
 import {
   ASK_QUESTION_TOO_LONG_HINT,
-  askQuestionParseFailure,
-  parseAskQuestion,
   parseAskQuestionForReplyTarget,
   parseAskQuestionResult,
 } from "../src/commands/parseAskQuestion.js";
 
-describe("parseAskQuestion", () => {
+describe("parseAskQuestionResult", () => {
   it("extracts unquoted question from first line", () => {
-    expect(parseAskQuestion("/ask what is this for?")).toBe("what is this for?");
+    expect(parseAskQuestionResult("/ask what is this for?")).toEqual({
+      kind: "ok",
+      question: "what is this for?",
+    });
   });
 
   it("extracts double-quoted question", () => {
-    expect(parseAskQuestion('/ask "what is useHydrationSafeDistance?"')).toBe(
-      "what is useHydrationSafeDistance?",
-    );
+    expect(parseAskQuestionResult('/ask "what is useHydrationSafeDistance?"')).toEqual({
+      kind: "ok",
+      question: "what is useHydrationSafeDistance?",
+    });
   });
 
   it("extracts single-quoted question", () => {
-    expect(parseAskQuestion("/ask 'why this change?'")).toBe("why this change?");
+    expect(parseAskQuestionResult("/ask 'why this change?'")).toEqual({
+      kind: "ok",
+      question: "why this change?",
+    });
   });
 
-  it("returns null for bare /ask", () => {
-    expect(parseAskQuestion("/ask")).toBe(null);
-    expect(parseAskQuestion("/ask   ")).toBe(null);
+  it("returns missing for bare /ask", () => {
+    expect(parseAskQuestionResult("/ask")).toEqual({ kind: "missing" });
+    expect(parseAskQuestionResult("/ask   ")).toEqual({ kind: "missing" });
   });
 
-  it("returns null when not an ask command", () => {
-    expect(parseAskQuestion("/review")).toBe(null);
-    expect(parseAskQuestion("hello")).toBe(null);
+  it("returns not_ask when not an ask command", () => {
+    expect(parseAskQuestionResult("/review")).toEqual({ kind: "not_ask" });
+    expect(parseAskQuestionResult("hello")).toEqual({ kind: "not_ask" });
   });
 
   it("uses first non-empty line only", () => {
-    expect(parseAskQuestion(" \n/ask what is this?")).toBe("what is this?");
-    expect(parseAskQuestion(" \r\n/ask what is this?\n/ask ignored")).toBe("what is this?");
-    expect(parseAskQuestion("hello\n/ask ignored")).toBe(null);
+    expect(parseAskQuestionResult(" \n/ask what is this?")).toEqual({
+      kind: "ok",
+      question: "what is this?",
+    });
+    expect(parseAskQuestionResult(" \r\n/ask what is this?\n/ask ignored")).toEqual({
+      kind: "ok",
+      question: "what is this?",
+    });
+    expect(parseAskQuestionResult("hello\n/ask ignored")).toEqual({ kind: "not_ask" });
   });
 
   it("is case-sensitive on /ask token", () => {
-    expect(parseAskQuestion("/Ask what?")).toBe(null);
+    expect(parseAskQuestionResult("/Ask what?")).toEqual({ kind: "not_ask" });
   });
 
   it("exports usage hint", () => {
     expect(ASK_USAGE_HINT).toContain("/ask");
   });
 
-  it("returns null when question is too long", () => {
+  it("returns too_long when question is too long", () => {
     const long = "a".repeat(MAX_ASK_QUESTION_CHARS + 1);
-    expect(parseAskQuestion(`/ask ${long}`)).toBe(null);
-    expect(askQuestionParseFailure(`/ask ${long}`)).toBe("too_long");
+    expect(parseAskQuestionResult(`/ask ${long}`)).toEqual({ kind: "too_long" });
   });
 
   it("exports too-long hint", () => {

--- a/test/providerErrors.test.ts
+++ b/test/providerErrors.test.ts
@@ -10,6 +10,18 @@ describe("classifyProviderError", () => {
     expect(classifyProviderError(new Error("429 rate limit exceeded"))).toBe("rate_limit");
   });
 
+  it("classifies quota failures", () => {
+    expect(classifyProviderError(new Error("quota exceeded"))).toBe("quota");
+  });
+
+  it("classifies billing failures", () => {
+    expect(classifyProviderError(new Error("payment required"))).toBe("billing");
+  });
+
+  it("classifies timeouts", () => {
+    expect(classifyProviderError(new Error("request timed out"))).toBe("timeout");
+  });
+
   it("returns unknown for unclassified errors", () => {
     expect(classifyProviderError(new Error("something else"))).toBe("unknown");
   });

--- a/test/refreshableGithubTools.test.ts
+++ b/test/refreshableGithubTools.test.ts
@@ -34,24 +34,30 @@ describe("createRefreshableToolExecutors", () => {
     expect(build).toHaveBeenLastCalledWith("fresh-token", freshExpiresAtTs);
   });
 
-  it("keeps static tool parameter schemas identical across token rebuilds", () => {
+  it("keeps static tool parameter schemas identical across token rebuilds", async () => {
     const sharedSchema = { type: "object", properties: {} };
-    const build = () => ({
+    const refresh = vi.fn(async () => ({
+      token: "fresh-token",
+      expiresAtTs: Date.now() + 3_600_000,
+    }));
+    const build = vi.fn(() => ({
       piTools: [{ name: "getPullRequest", description: "d", parameters: sharedSchema }],
       executors: { getPullRequest: vi.fn() },
-    });
+    }));
     const refreshable = createRefreshableToolExecutors({
       initialToken: "old-token",
-      tokenExpiresAtTs: Date.now() + 3_600_000,
+      tokenExpiresAtTs: Date.now() + TOKEN_FRESHNESS_BUFFER_MS - 1_000,
       tokenTtlMs: 3_600_000,
+      refreshInstallationToken: refresh,
       build,
       githubToolNames: new Set(["getPullRequest"]),
     });
 
     const first = refreshable.bundle.piTools[0]?.parameters;
-    refreshable.refreshBeforeTool("getPullRequest");
+    await refreshable.refreshBeforeTool("getPullRequest");
     const second = refreshable.bundle.piTools[0]?.parameters;
 
+    expect(build).toHaveBeenCalledTimes(2);
     expect(second).toBe(first);
   });
 });

--- a/test/repoPolicy.test.ts
+++ b/test/repoPolicy.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from "vitest";
+import {
+  MAX_REPO_POLICY_INSTRUCTION_CHARS,
+  MAX_REPO_POLICY_PATH_PATTERN_CHARS,
+} from "../src/settings/reviewConstants.js";
 import { renderPolicySuggestionForDismissed } from "../src/review/repoPolicy.js";
+
+function quotedScalar(result: string, key: "path" | "instructions"): string {
+  const match = result.match(new RegExp(`${key}: "((?:\\\\.|[^"\\\\])*)"`));
+  expect(match).not.toBeNull();
+  return match?.[1] ?? "";
+}
 
 describe("renderPolicySuggestionForDismissed", () => {
   it("renders a paste-ready yaml snippet with file path and dismissal evidence", () => {
@@ -36,10 +46,23 @@ describe("renderPolicySuggestionForDismissed", () => {
       dismissalEvidence: longEvidence,
     });
 
-    expect(result).toContain('path: "');
-    expect(result).toContain('instructions: "');
-    // The yaml block should still be well-formed
+    const path = quotedScalar(result, "path");
+    const instructions = quotedScalar(result, "instructions");
+    expect(path.length).toBe(MAX_REPO_POLICY_PATH_PATTERN_CHARS);
+    expect(instructions.length).toBe(MAX_REPO_POLICY_INSTRUCTION_CHARS);
     expect(result).toContain("```yaml");
     expect(result).toContain("```");
+  });
+
+  it("escapes embedded double quotes in path and instructions", () => {
+    const result = renderPolicySuggestionForDismissed({
+      filePath: 'src/"weird".ts',
+      dismissalEvidence: 'contains "quotes"',
+    });
+
+    expect(result).toContain('path: "src/\\"weird\\".ts"');
+    expect(result).toContain('instructions: "contains \\"quotes\\""');
+    expect(quotedScalar(result, "path")).toBe('src/\\"weird\\".ts');
+    expect(quotedScalar(result, "instructions")).toBe('contains \\"quotes\\"');
   });
 });

--- a/test/reviewSizeBudget.test.ts
+++ b/test/reviewSizeBudget.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
+  REVIEW_SIZE_TIER_LARGE_MIN_CHANGES,
+  REVIEW_SIZE_TIER_MEDIUM_MAX_FILES,
+  REVIEW_SIZE_TIER_SMALL_MAX_FILES,
+} from "../src/settings/reviewConstants.js";
+import {
   buildReviewSizeBudget,
   classifyReviewBudgetTier,
+  formatReviewSizeBudgetBlock,
 } from "../src/review/run/reviewSizeBudget.js";
 
 describe("classifyReviewBudgetTier", () => {
@@ -15,10 +21,27 @@ describe("classifyReviewBudgetTier", () => {
     ).toBe("small");
   });
 
+  it("classifies medium PRs by file count", () => {
+    expect(
+      classifyReviewBudgetTier({
+        fileCount: REVIEW_SIZE_TIER_SMALL_MAX_FILES + 1,
+        totalChanges: 100,
+        truncated: false,
+      }),
+    ).toBe("medium");
+    expect(
+      classifyReviewBudgetTier({
+        fileCount: REVIEW_SIZE_TIER_MEDIUM_MAX_FILES,
+        totalChanges: 100,
+        truncated: false,
+      }),
+    ).toBe("medium");
+  });
+
   it("classifies large PRs by file count or total changes", () => {
     expect(
       classifyReviewBudgetTier({
-        fileCount: 80,
+        fileCount: REVIEW_SIZE_TIER_MEDIUM_MAX_FILES + 1,
         totalChanges: 100,
         truncated: false,
       }),
@@ -26,7 +49,7 @@ describe("classifyReviewBudgetTier", () => {
     expect(
       classifyReviewBudgetTier({
         fileCount: 5,
-        totalChanges: 2500,
+        totalChanges: REVIEW_SIZE_TIER_LARGE_MIN_CHANGES,
         truncated: false,
       }),
     ).toBe("large");
@@ -41,5 +64,36 @@ describe("buildReviewSizeBudget", () => {
       truncated: true,
     });
     expect(budget.truncated).toBe(true);
+  });
+});
+
+describe("formatReviewSizeBudgetBlock", () => {
+  it("includes tier and change counts", () => {
+    const block = formatReviewSizeBudgetBlock({
+      tier: "medium",
+      truncated: false,
+      fileCount: 25,
+      totalChanges: 100,
+    });
+    expect(block).toContain("Trusted context (review budget tier):");
+    expect(block).toContain("- Tier: medium");
+    expect(block).toContain("- Changed files: 25");
+    expect(block).toContain("- Total line changes (additions + deletions): 100");
+    expect(block).not.toContain("Change set truncated");
+    expect(block).not.toContain("Large PR:");
+  });
+
+  it("notes truncation and large-PR guidance when applicable", () => {
+    const block = formatReviewSizeBudgetBlock({
+      tier: "large",
+      truncated: true,
+      fileCount: 80,
+      totalChanges: 2500,
+    });
+    expect(block).toContain("- Tier: large");
+    expect(block).toContain(
+      "- Change set truncated: treat coverage as partial and note limits in prCharacter.",
+    );
+    expect(block).toContain("- Large PR:");
   });
 });

--- a/test/userSupplementPromptContract.test.ts
+++ b/test/userSupplementPromptContract.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { descriptionSystemPrompt } from "../src/agent/description/descriptionSystemPrompt.js";
 import { automatedQualitySystemPrompt } from "../src/agent/prompts/qualityPrompt.js";
+import { automatedReviewTestsSystemPrompt } from "../src/agent/prompts/reviewTestsPrompt.js";
 import { automatedSecuritySystemPrompt } from "../src/agent/prompts/securityPrompt.js";
 import { buildAutomatedSystemPrompt } from "../src/review/prompts/reviewSystemPrompt.js";
 
@@ -15,6 +16,7 @@ describe("user supplement prompt contracts", () => {
     expect(buildAutomatedSystemPrompt()).toContain(reviewSupplementContract);
     expect(automatedSecuritySystemPrompt).toContain(reviewSupplementContract);
     expect(automatedQualitySystemPrompt).toContain(reviewSupplementContract);
+    expect(automatedReviewTestsSystemPrompt).toContain(reviewSupplementContract);
   });
 
   it("documents user supplements as untrusted in the description prompt", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "noEmit": true
   },
-  "include": ["src/**/*.ts", "test/**/*.ts", "vitest.config.ts"],
+  "include": ["src/**/*.ts", "test/**/*.ts", "vitest*.config.ts"],
   "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Clears the remaining open `severity:low` backlog in one PR across nine commits.

- Align landing-page copy with opened-only auto-review defaults
- Point JSON-LD, `og:url`, and canonical tags at `SITE_ORIGIN`
- Move header/footer outside `<main>` and add a skip-to-content link
- Strengthen unit coverage for prompt contracts, provider errors, token rebuilds, and review size budgets
- Escape quotes in policy dismissal YAML snippets and assert truncation lengths
- Align vitest typecheck include, Dockerfile healthcheck `start_period`, and prod Compose inheritance (ops doc updated)
- Remove unused `parseAskQuestion` / `askQuestionParseFailure` wrappers
- Format `AGENTS.md` so `oxfmt --check` passes

## Verification

- `nub run typecheck`
- `nub run test` (951 passed)
- `nub run site:build`
- `nub run fmt:check`
- Merged compose config checked with dummy required env vars
- Skip-link / landmark structure verified statically in source (control-ui browser pass not run in this environment)

Closes #249
Closes #250
Closes #251
Closes #252
Closes #253
Closes #255
Closes #256
Closes #257
Closes #258
Closes #259
Closes #261
Closes #262
Closes #263

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-488579aa-b79d-4c74-970b-bf7bd41646a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-488579aa-b79d-4c74-970b-bf7bd41646a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

___

## PR Agent Description

### PR Type

Enhancement, Bug fix, Tests

### Description

- Increase Docker health check start period and simplify Postgres prod overlay configuration
- Add YAML double-quote escaping for repo policy suggestion rendering to prevent injection
- Refactor ask question parsing to use discriminated union result type with updated tests
- Improve site SEO with canonical links, og:url, skip-to-content accessibility, and semantic HTML

### File Walkthrough

<details>
<summary>Enhancement (7 files)</summary>

<details>
<summary>Increase health check start period</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/286/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557"><code>Dockerfile</code></a>

- Raise start-period from 10s to 15s for slower cold starts

</details>

<details>
<summary>Remove Postgres tuning from production overlay</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/286/files#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3"><code>docker-compose.prod.yml</code></a>

- Move shared_buffers and related flags to base compose file
- Production overlay only requires credential env vars

</details>

<details>
<summary>Remove legacy ask question helpers</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/286/files#diff-02517bc0f3cbafd743eb6da7b0a493acbb48514d1279395c7071ab4ceadfd465"><code>src/commands/parseAskQuestion.ts</code></a>

- Deleted parseAskQuestion and askQuestionParseFailure
- Callers should use parseAskQuestionResult directly

</details>

<details>
<summary>Use SITE_ORIGIN for JSON-LD URLs</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/286/files#diff-cf47298f05a6a287d7f2e9f5f6094545cab650a2a8eda73c13a7ffbb2af63ed7"><code>site/lib/seo.ts</code></a>

- SoftwareApplication and WebSite url fields use SITE_ORIGIN
- Ensures consistent canonical URL in structured data

</details>

<details>
<summary>Add canonical link and skip-to-content</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/286/files#diff-a7dfa7fa7c6b482c553cda51f28c7a2c7fcefaf84fec30db7606bf9405f886f6"><code>site/app/__root.tsx</code></a>

- Added og:url meta property and rel=canonical link
- Skip link improves keyboard navigation accessibility

</details>

<details>
<summary>Style skip-link for accessibility</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/286/files#diff-894b451aed1c6f2b457ebe4eb1d80aa78dda0560ca1a22b0a90ab2295fae7296"><code>site/app/globals.css</code></a>

- Hidden by default, visible on focus with smooth transition
- Positioned at top-left with proper z-index

</details>

<details>
<summary>Move Header and Footer outside main</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/286/files#diff-290a69b1f09a3a131775e89ebd6eda1d2b5da05d5a316e78e0242c2bd24d0753"><code>site/app/index.tsx</code></a>

- Semantic improvement: nav/footer not inside main content
- Maintains visual order while improving document structure

</details>

</details>

<details>
<summary>Documentation (3 files)</summary>

<details>
<summary>Update operations docs for compose changes</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/286/files#diff-ad74991b96593fdee570962fc5b1e319080abd55e16614f556f74b7de8fd02d1"><code>docs/operations.md</code></a>

- Reflect that tuning flags live in base compose file
- Production overlay handles credentials only

</details>

<details>
<summary>Simplify feature trigger descriptions</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/286/files#diff-6052707d80a009093c54269815b18a93a53bc8ad09dbe5ceced9eb6643fb922b"><code>site/lib/content.ts</code></a>

- Remove synchronize references from pull request triggers
- Capabilities section reflects opens-only behavior

</details>

<details>
<summary>Update capabilities trigger text</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/286/files#diff-367be2d37fd932f9d54e54ceebebd97978cbc6db0c709ecb82090ed014293fa8"><code>site/components/capabilities.tsx</code></a>

- Change opens or updates to opens only
- Matches simplified feature descriptions

</details>

</details>

<details>
<summary>Bug fix (1 file)</summary>

<details>
<summary>Add YAML escaping for policy suggestions</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/286/files#diff-de0a603b8ca9c069efc587851f89f5fdbc79460484c76e9ff23cbe6819f17316"><code>src/review/repoPolicy.ts</code></a>

- New escapeYamlDoubleQuoted helper prevents injection
- Applied to filePath and dismissalEvidence fields

</details>

</details>

<details>
<summary>Tests (3 files)</summary>

<details>
<summary>Update tests for discriminated union results</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/286/files#diff-04db1fb54a0499d3f0d6580c8862425ccb7e2fdc61cbbb12a4ae40cedb19eb18"><code>test/parseAskQuestion.test.ts</code></a>

- All tests now use parseAskQuestionResult return values
- Covers ok, missing, not_ask, and too_long cases

</details>

<details>
<summary>Add provider error classification tests</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/286/files#diff-24eea44aa7e80f8cce3b03e30fb525a4ead3a26473421c290fa69a6cfb57dbee"><code>test/providerErrors.test.ts</code></a>

- Tests for quota, billing, and timeout error types
- Expands coverage beyond rate_limit and unknown

</details>

<details>
<summary>Fix async refresh test expectations</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/286/files#diff-905597641f64b15e967b788a9541c3e8ffe5581cf9fad44cfdce8e9394e9b76b"><code>test/refreshableGithubTools.test.ts</code></a>

- Test now awaits refreshBeforeTool call properly
- Verifies build called twice with identical schemas

</details>

</details>

<details>
<summary>Other (1 file)</summary>

<details>
<summary>Include all vitest config files</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/286/files#diff-b55cdbef4907b7045f32cc5360d48d262cca5f94062e353089f189f4460039e0"><code>tsconfig.json</code></a>

- Pattern changed from vitest.config.ts to vitest*.config.ts
- Captures variant config filenames

</details>

</details>