### PR TITLE
Enforce triage commit body bullet limit

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -298,6 +298,7 @@ An orchestrated review computes its hard return deadline from the pg-boss job st
 | `TRIAGE_SKIP_REASON_MAX_CHARS`       | 300                                                 |
 | `TRIAGE_COMMIT_SUBJECT_MAX_CHARS`    | 50                                                  |
 | `TRIAGE_COMMIT_TYPES`                | feat, fix, refactor, docs, test, chore, style, perf |
+| `TRIAGE_COMMIT_BODY_MAX_BULLETS`     | 5                                                   |
 | `TRIAGE_COMMIT_MAX_FILES`            | 20                                                  |
 | `TRIAGE_MAX_COMMIT_DIFF_LINES`       | 200                                                 |
 | `TRIAGE_NEW_FILE_MAX_BYTES`          | 32768                                               |

--- a/src/agent/triage/triagePrompt.ts
+++ b/src/agent/triage/triagePrompt.ts
@@ -24,7 +24,9 @@ export const triageSystemPrompt = [
   "Tests-focused findings may propose missing test cases. When still valid you may add test files, wire Vitest, and mock dependencies, using the test commit type. Respect the fix budget and the commitFix file/diff limits; skip with a reason when the test setup is too large for one commit.",
   "",
   "## Commit contract",
-  "- Subject: conventional, no scope, lowercase description, max 50 chars.",
-  "- Allowed types: feat, fix, refactor, docs, test, chore, style, perf.",
-  "- Body bullets are optional; each starts with '- ', capitalized first word, no trailing period.",
+  "- Prove every subject and body line from the committed fix diff only; no ticket, review, session, or branch language.",
+  "- Subject: `type: description` — no scope; lowercase imperative except names/terms; max 50 chars; no trailing period.",
+  "- Types: feat, fix, refactor, docs, test, chore, style, perf. Match most changed lines; use chore only when nothing else fits.",
+  "- Optional body: 1–5 `- ` bullets; capitalize each; no blank lines or trailing periods; only material details absent from the subject.",
+  "- Prefer concrete verbs the diff proves; avoid vague update/change/address/improve wording when a specific action is available.",
 ].join("\n");

--- a/src/agent/triage/triageWorkspaceTools.ts
+++ b/src/agent/triage/triageWorkspaceTools.ts
@@ -10,6 +10,7 @@ import type { WritablePrCheckout } from "../../prWorkspace/writablePrCheckout.js
 import { assertWorkspacePath } from "../../prWorkspace/localPrWorkspace.js";
 import {
   SENSITIVE_PATH_PATTERNS,
+  TRIAGE_COMMIT_BODY_MAX_BULLETS,
   TRIAGE_NEW_FILE_MAX_BYTES,
   LOCAL_WORKSPACE_FETCH_TIMEOUT_MS,
   LOCAL_WORKSPACE_MAX_FILE_BYTES,
@@ -201,12 +202,12 @@ export function buildTriageWorkspaceTools(params: {
   });
 
   const commitFix = defineLocalTool({
-    description: "Commit the staged minimal fix for one finding. One call per threadRootCommentId.",
+    description: "Commit the minimal fix for one finding. One call per threadRootCommentId.",
     schema: z.object({
       threadRootCommentId: z.number().int().positive(),
       files: z.array(z.string().min(1)).min(1),
       subject: z.string().min(1),
-      body: z.array(z.string().min(1)).optional(),
+      body: z.array(z.string().min(1)).max(TRIAGE_COMMIT_BODY_MAX_BULLETS).optional(),
     }),
     run: async ({ threadRootCommentId, files, subject, body }) => {
       if (!inventoryIds.has(threadRootCommentId)) {

--- a/src/prWorkspace/writablePrCheckout.ts
+++ b/src/prWorkspace/writablePrCheckout.ts
@@ -7,6 +7,7 @@ import type { BotIdentity } from "../github/appAuth.js";
 import { AppError } from "../errors/appError.js";
 import {
   SENSITIVE_PATH_PATTERNS,
+  TRIAGE_COMMIT_BODY_MAX_BULLETS,
   TRIAGE_COMMIT_MAX_FILES,
   TRIAGE_COMMIT_SUBJECT_MAX_CHARS,
   TRIAGE_COMMIT_TYPES,
@@ -130,6 +131,13 @@ function validateSubject(subject: string): void {
 
 function validateBody(body: readonly string[] | undefined): string | undefined {
   if (!body || body.length === 0) return undefined;
+  if (body.length > TRIAGE_COMMIT_BODY_MAX_BULLETS) {
+    throw new AppError({
+      code: "pr_workspace.commit_body_too_many_bullets",
+      message: `Commit body accepts at most ${TRIAGE_COMMIT_BODY_MAX_BULLETS} bullets`,
+      context: { maxBullets: TRIAGE_COMMIT_BODY_MAX_BULLETS },
+    });
+  }
   for (const line of body) {
     if (!line.startsWith("- ")) {
       throw new AppError({

--- a/src/settings/triageConstants.ts
+++ b/src/settings/triageConstants.ts
@@ -43,6 +43,7 @@ export const TRIAGE_COMMIT_TYPES = [
   "style",
   "perf",
 ] as const;
+export const TRIAGE_COMMIT_BODY_MAX_BULLETS = 5;
 export const TRIAGE_COMMIT_MAX_FILES = 20;
 /** Staged-diff size cap per commitFix call (added + removed lines). */
 export const TRIAGE_MAX_COMMIT_DIFF_LINES = 200;

--- a/test/writablePrCheckout.test.ts
+++ b/test/writablePrCheckout.test.ts
@@ -80,8 +80,29 @@ describe("writable PR checkout", () => {
     TEST_TIMEOUT_MS,
   );
 
-  it("rejects bad subjects, sensitive paths, path escape, and uses -n", () => {
+  it("rejects bad subjects, oversized bodies, and uses -n", () => {
     expect(() => buildCommitCommandArgs({ files: ["x"], subject: "fix(scope): nope" })).toThrow();
+    expect(() =>
+      buildCommitCommandArgs({
+        files: ["x"],
+        subject: "fix: guard null user",
+        body: [
+          "- One",
+          "- Two",
+          "- Three",
+          "- Four",
+          "- Five",
+          "- Six",
+        ],
+      }),
+    ).toThrow(/at most 5 bullets/);
+    expect(
+      buildCommitCommandArgs({
+        files: ["x"],
+        subject: "fix: guard null user",
+        body: ["- Cover null user path"],
+      }),
+    ).toEqual(["commit", "-n", "-m", "fix: guard null user", "-m", "- Cover null user path"]);
     expect(buildCommitCommandArgs({ files: ["x"], subject: "fix: guard null user" })).toContain(
       "-n",
     );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Expand the triage Commit contract with clean-room, imperative subject, type-picking, and concrete-verb rules
- Cap optional commit body bullets at `TRIAGE_COMMIT_BODY_MAX_BULLETS` (5) in validation and the `commitFix` schema
- Document the new constant and cover the body limit plus `-m` shape in tests

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8118adb1-ab53-4c33-8987-e8f3e0e687b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8118adb1-ab53-4c33-8987-e8f3e0e687b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

___

## PR Agent Description

### PR Type

Enhancement, Tests

### Description

- Add `TRIAGE_COMMIT_BODY_MAX_BULLETS` constant (5) and enforce in commit body validation
- Refine triage prompt's commit contract with stricter subject and body prose rules
- Validate body bullet count in `validateBody` with a new `commit_body_too_many_bullets` error
- Document the new constant in configuration reference and add test coverage

### File Walkthrough

<details>
<summary>Enhancement (4 files)</summary>

<details>
<summary>New constant for max commit body bullets</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/330/files#diff-93b4de36c9ea8d0712d90951d708e19d49edb3eaa05f6de2864d6a29d471eb06"><code>src/settings/triageConstants.ts</code></a>

- Export `TRIAGE_COMMIT_BODY_MAX_BULLETS = 5`

</details>

<details>
<summary>Enforce bullet limit in commit body validation</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/330/files#diff-827d6d463c5fd63731ebf38d8dbe9eb3d37b4e27b72cb0feaf93401b6c5c0941"><code>src/prWorkspace/writablePrCheckout.ts</code></a>

- Import `TRIAGE_COMMIT_BODY_MAX_BULLETS`
- Throw `commit_body_too_many_bullets` error when body exceeds the limit

</details>

<details>
<summary>Apply bullet limit to commitFix tool schema</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/330/files#diff-460b47420d68c6ffe56009dffc7df032b5e1ae3bc2bb8fc2f186f2f115bd2e4d"><code>src/agent/triage/triageWorkspaceTools.ts</code></a>

- Import `TRIAGE_COMMIT_BODY_MAX_BULLETS`
- Add `.max()` constraint to the `body` array in commitFix schema

</details>

<details>
<summary>Tighten commit contract prose in triage prompt</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/330/files#diff-daa1980a9006e1e4928501cec1f6f8bf330f8e53cbdf37224104ecb0128fce0a"><code>src/agent/triage/triagePrompt.ts</code></a>

- Require every subject/body line to be provable from the diff
- Restrict body to 1–5 bullets with capitalization and no trailing periods
- Prefer concrete verbs over vague wording

</details>

</details>

<details>
<summary>Tests (1 file)</summary>

<details>
<summary>Test oversized body rejection and valid body paths</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/330/files#diff-97900ff53f2426a083558ec32b1d2e92e07d80121e28131cc27207f624e89141"><code>test/writablePrCheckout.test.ts</code></a>

- Add test case rejecting 6 bullets with expected error message
- Add test case confirming a valid 1-bullet body produces correct args

</details>

</details>

<details>
<summary>Documentation (1 file)</summary>

<details>
<summary>Document TRIAGE_COMMIT_BODY_MAX_BULLETS</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/330/files#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180"><code>docs/configuration.md</code></a>

- Add config entry with default value of 5

</details>

</details>