### PR TITLE
Clear knip findings and codebase smell cleanup

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -282,7 +282,6 @@ An orchestrated review computes its hard return deadline from the pg-boss job st
 | `TRIAGE_SUMMARY_SENTINEL`            | `## PR Agent Triage`                                |
 | `TRIAGE_ALREADY_IN_PROGRESS`         | duplicate `/triage` ack text                        |
 | `TRIAGE_FAILURE_MESSAGE`             | terminal failure PR comment                         |
-| `TRIAGE_NO_PRIOR_FINDINGS`           | legacy empty inventory text (deprecated alias)      |
 | `TRIAGE_NO_ELIGIBLE_FINDINGS`        | no triage-eligible unresolved findings report text  |
 | `TRIAGE_THREAD_NOT_ELIGIBLE`         | scoped thread not in inventory ack/report text      |
 | `TRIAGE_FULL_RUN_IN_PROGRESS`        | thread `/triage` while full-PR triage active ack    |
@@ -305,15 +304,14 @@ An orchestrated review computes its hard return deadline from the pg-boss job st
 
 ### Ask safety
 
-| Symbol                                                     | Default                                                                            |
-| ---------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| `MAX_ASK_QUESTION_CHARS`                                   | 8192                                                                               |
-| `MAX_ASK_THREAD_TRANSCRIPT_CHARS`                          | 24000                                                                              |
-| `ASK_META_REFUSAL`                                         | meta-probe reply                                                                   |
-| `BOT_META_PATTERNS`                                        | regex set                                                                          |
-| `BOT_SECRET_PATTERNS`                                      | outbound redaction for auth headers, provider keys, JWTs, and secret-shaped tokens |
-| `SENSITIVE_PATH_PATTERNS`                                  | ask path gate for env files, key material, and credential stores                   |
-| `ASK_TOOLS_WITH_OWNER_REPO` / `ASK_TOOLS_WITH_PULL_NUMBER` | tool scope sets                                                                    |
+| Symbol                            | Default                                                                            |
+| --------------------------------- | ---------------------------------------------------------------------------------- |
+| `MAX_ASK_QUESTION_CHARS`          | 8192                                                                               |
+| `MAX_ASK_THREAD_TRANSCRIPT_CHARS` | 24000                                                                              |
+| `ASK_META_REFUSAL`                | meta-probe reply                                                                   |
+| `BOT_META_PATTERNS`               | regex set                                                                          |
+| `BOT_SECRET_PATTERNS`             | outbound redaction for auth headers, provider keys, JWTs, and secret-shaped tokens |
+| `SENSITIVE_PATH_PATTERNS`         | ask path gate for env files, key material, and credential stores                   |
 
 ### GitHub API
 
@@ -321,7 +319,6 @@ An orchestrated review computes its hard return deadline from the pg-boss job st
 | ----------------------------------------- | ------- |
 | `TOKEN_FRESHNESS_BUFFER_MS`               | 60000   |
 | `INSTALLATION_TOKEN_FALLBACK_TTL_MS`      | 1h      |
-| `DEFAULT_COOLDOWN_SECONDS`                | 60      |
 | `PRIMARY_RATE_LIMIT_MAX_RETRIES`          | 2       |
 | `SECONDARY_RATE_LIMIT_MAX_RETRIES`        | 3       |
 | `GITHUB_PULL_REQUEST_FILES_API_MAX_FILES` | 3000    |

--- a/docs/superpowers/plans/2026-07-22-codebase-cleanup-spec.md
+++ b/docs/superpowers/plans/2026-07-22-codebase-cleanup-spec.md
@@ -1,0 +1,22 @@
+# Spec: entire-codebase cleanup
+
+## Goal
+
+Review and clean the entire production and test surface so the tree is free of AI slop, useless one-caller helpers, and over-engineering.
+
+## Requirements
+
+1. Apply Fowler smell baseline across `src/`, `test/`, and `site/` (not only a PR diff).
+2. Remove or inline useless single-use functions and Middle Man wrappers when inlining lowers reader load.
+3. Delete Speculative Generality: unused abstractions, unused params, speculative hooks, dead re-exports.
+4. Remove AI slop: narrating comments, redundant JSDoc that restates the signature, chatbot phrasing in comments.
+5. Fix hard violations of `docs/development.md` (no bare `Error` from `src/`, no forbidden barrel imports, AppError rules).
+6. Prefer deletion and inlining over new shared abstractions unless duplication is already real and painful.
+7. Keep behavior unchanged. Pin with `nub run test`, `nubx knip`, and `nub run check:code`.
+8. Ship fixes on `pd/chore/knip-deslop-15a1` (PR #331).
+
+## Non-goals
+
+- Do not invent new product features.
+- Do not rewrite prompt product-copy strings solely to remove em dashes.
+- Do not extract new shared helpers for one-off sleep/escape clones unless a clear third caller already exists.

--- a/docs/superpowers/plans/2026-07-22-inline-single-use.md
+++ b/docs/superpowers/plans/2026-07-22-inline-single-use.md
@@ -1,0 +1,18 @@
+# Plan: inline single-use helpers
+
+## Goal
+
+Collapse Speculative Generality / Middle Man helpers that have exactly one caller, following a codebase-wide hunt. Example target: `isRecord` in test helpers.
+
+## Requirements
+
+1. Hunt across `src/`, `test/helpers/`, and `site/` with parallel agents.
+2. Inline only one-caller helpers whose bodies are small enough that inlining lowers reader load.
+3. Keep helpers with 2+ callers (for example `isRecord` in `publishRecordRepository.ts`).
+4. No behavior change. Pin with the existing unit suite.
+5. Ship on a follow-up branch from the knip cleanup tip.
+
+## Non-goals
+
+- Do not inline large one-caller functions (>~8 lines of real logic).
+- Do not remove type predicates that mark a parse boundary when they earn their name and have multiple uses.

--- a/docs/superpowers/plans/2026-07-22-knip-deslop.md
+++ b/docs/superpowers/plans/2026-07-22-knip-deslop.md
@@ -1,0 +1,27 @@
+# Plan: knip cleanup and AI slop removal
+
+## Goal
+
+Run `nubx knip`, clear every finding, remove AI slop traces, leave knip green and tests unchanged.
+
+## Requirements
+
+1. Knip reports zero issues with a committed `knip.json` that includes root and `site` workspaces.
+2. Delete or unexport unused symbols; remove unused `@octokit/request-error`.
+3. Wire `IGNORED_*` slash constants into webhook intake instead of string literals.
+4. Update `docs/configuration.md` for deleted settings symbols.
+5. Remove narrating or redundant comments found in the slop scan.
+6. Pin: existing unit suite stays green (`nub run test`).
+
+## Steps
+
+1. Add workspace-aware `knip.json` so the landing site is not false-positive unused.
+2. Subtract dead exports, dead prompt blocks, unused deps; unexport file-local APIs.
+3. Use queue ignore constants at the webhook gate.
+4. Deslop high-confidence comment noise.
+5. Verify with `nubx knip`, `nub run check:code`, `nub run test`.
+
+## Non-goals
+
+- No behavior changes to review, ask, triage, or publish paths.
+- No rewrite of established product-copy em dashes in prompts or GitHub status strings.

--- a/knip.json
+++ b/knip.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://unpkg.com/knip@6/schema.json",
+  "workspaces": {
+    ".": {
+      "entry": ["test/**/*.{ts,tsx}!", "scripts/**/*.{js,mjs,ts}!"],
+      "project": ["src/**/*.{ts,tsx}", "test/**/*.{ts,tsx}", "scripts/**/*.{js,mjs,ts}"]
+    },
+    "site": {
+      "entry": ["router.tsx!", "app/**/*.{ts,tsx}!", "scripts/**/*.{js,mjs}!", "routeTree.gen.ts!"],
+      "project": ["**/*.{ts,tsx,css}"]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@octokit/core": "^7.0.6",
     "@octokit/plugin-retry": "^8.1.0",
     "@octokit/plugin-throttling": "^11.0.3",
-    "@octokit/request-error": "^7.1.0",
     "@octokit/rest": "^22.0.1",
     "@octokit/types": "^16.0.0",
     "effect": "3.22.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,9 +58,6 @@ importers:
       '@octokit/plugin-throttling':
         specifier: ^11.0.3
         version: 11.0.3(@octokit/core@7.0.6)
-      '@octokit/request-error':
-        specifier: ^7.1.0
-        version: 7.1.0
       '@octokit/rest':
         specifier: ^22.0.1
         version: 22.0.1

--- a/site/app/sitemap[.]xml.ts
+++ b/site/app/sitemap[.]xml.ts
@@ -5,17 +5,8 @@ export const Route = createFileRoute("/sitemap.xml")({
   server: {
     handlers: {
       GET: () =>
-        new Response(sitemapXml(), {
-          headers: {
-            "Content-Type": "application/xml; charset=utf-8",
-          },
-        }),
-    },
-  },
-});
-
-function sitemapXml() {
-  return `<?xml version="1.0" encoding="UTF-8"?>
+        new Response(
+          `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>${SITE_ORIGIN}</loc>
@@ -24,5 +15,13 @@ function sitemapXml() {
     <priority>1.0</priority>
   </url>
 </urlset>
-`;
-}
+`,
+          {
+            headers: {
+              "Content-Type": "application/xml; charset=utf-8",
+            },
+          },
+        ),
+    },
+  },
+});

--- a/site/components/capabilities.tsx
+++ b/site/components/capabilities.tsx
@@ -1,11 +1,6 @@
 import { Section } from "@/components/section";
 import { CAPABILITIES } from "@/lib/content";
 
-function commandHint(trigger: string): string | null {
-  const match = trigger.match(/\/[a-z-]+/);
-  return match?.[0] ?? null;
-}
-
 export function Capabilities() {
   return (
     <Section id="capabilities" labelledBy="capabilities-heading" raised>
@@ -23,7 +18,7 @@ export function Capabilities() {
 
       <ul className="mt-12 grid gap-x-12 gap-y-9 md:grid-cols-2">
         {CAPABILITIES.map((cap) => {
-          const command = commandHint(cap.trigger);
+          const command = cap.trigger.match(/\/[a-z-]+/)?.[0] ?? null;
           return (
             <li key={cap.title} className="min-w-0">
               {command ? (

--- a/site/components/features.tsx
+++ b/site/components/features.tsx
@@ -1,10 +1,6 @@
 import { Section } from "@/components/section";
 import { FEATURES } from "@/lib/content";
 
-/**
- * How a review runs - full-width walkthrough, readable at every breakpoint.
- * No side-by-side sticky intro (that cramped the steps on tablet).
- */
 export function Features() {
   return (
     <Section id="features" labelledBy="features-heading">

--- a/site/components/gallery.tsx
+++ b/site/components/gallery.tsx
@@ -31,20 +31,6 @@ const EXAMPLES: readonly OutputExample[] = [
     detail: "Question and answer on the PR conversation.",
     kind: "ask",
   },
-  {
-    command: "/review-security",
-    label: "Security review",
-    detail: "Same summary shape under ## PR Agent Security Review.",
-    kind: "review",
-    lens: "review-security",
-  },
-  {
-    command: "/review-quality",
-    label: "Quality review",
-    detail: "Same summary shape under ## PR Agent Quality Review.",
-    kind: "review",
-    lens: "review-quality",
-  },
 ];
 
 function ExampleBody({ example }: { readonly example: OutputExample }) {
@@ -62,10 +48,6 @@ function ExampleBody({ example }: { readonly example: OutputExample }) {
   }
 }
 
-/**
- * Desktop/tablet zig-zag moves the WHOLE block (caption + mock), not a
- * caption|mock split that leaves a dead column beside a tall card.
- */
 export function Gallery() {
   return (
     <Section id="examples" labelledBy="examples-heading">

--- a/site/components/hero.tsx
+++ b/site/components/hero.tsx
@@ -39,16 +39,15 @@ function HeroCta({ align = "start" }: { readonly align?: "start" | "end" }) {
 }
 
 /**
- * Explicitly scoped layouts — do not merge these into one class fight:
- * - < lg : mobile + iPad (in-flow, no min-h 100svh)
- * - lg+  : restored desktop fold (absolute artifact, two-column band)
+ * Keep mobile and desktop layouts separate.
+ * Below lg: in-flow, no min-h 100svh.
+ * lg+: absolute artifact, two-column fold.
  */
 export function Hero() {
   return (
     <section aria-labelledby="hero-heading" className="grain relative overflow-x-hidden">
       <DiffField />
 
-      {/* Mobile + tablet (< lg) */}
       <div className="relative z-10 mx-auto w-full max-w-6xl px-4 pb-10 pt-28 sm:px-6 sm:pb-12 sm:pt-32 md:pb-14 lg:hidden">
         <div className="grid min-w-0 items-start gap-6 md:grid-cols-[minmax(0,1fr)_minmax(16rem,22rem)] md:gap-8">
           <p className="min-w-0 font-display text-[clamp(3.25rem,14vw,5.5rem)] leading-[0.85] tracking-[-0.03em] text-ink md:text-[clamp(3.5rem,7vw,5.5rem)]">
@@ -67,7 +66,6 @@ export function Hero() {
           </div>
         </div>
 
-        {/* md+ (iPad): headline | CTA like desktop. Mobile stays stacked. */}
         <div className="mt-8 border-t border-edge pt-7 md:mt-10 md:grid md:grid-cols-[minmax(0,1.4fr)_auto] md:items-end md:gap-8 md:pt-8">
           <div className="min-w-0">
             <HeroCopy headingId="hero-heading" />
@@ -78,7 +76,6 @@ export function Hero() {
         </div>
       </div>
 
-      {/* Desktop (lg+) — previous fold composition */}
       <div className="relative z-10 mx-auto hidden min-h-[100svh] w-full max-w-6xl flex-col px-6 pb-16 pt-32 lg:flex">
         <div className="relative min-h-[22rem] flex-1">
           <p className="relative z-20 max-w-[10ch] font-display text-[clamp(4.5rem,10vw,9rem)] leading-[0.85] tracking-[-0.03em] text-ink">

--- a/site/components/hero.tsx
+++ b/site/components/hero.tsx
@@ -38,11 +38,6 @@ function HeroCta({ align = "start" }: { readonly align?: "start" | "end" }) {
   );
 }
 
-/**
- * Keep mobile and desktop layouts separate.
- * Below lg: in-flow, no min-h 100svh.
- * lg+: absolute artifact, two-column fold.
- */
 export function Hero() {
   return (
     <section aria-labelledby="hero-heading" className="grain relative overflow-x-hidden">

--- a/site/components/icons.tsx
+++ b/site/components/icons.tsx
@@ -2,7 +2,6 @@ type IconProps = {
   readonly className?: string;
 };
 
-/** Diagonal outbound arrow — house mark for CTAs, not the stock right chevron. */
 export function OutboundArrow({ className }: IconProps) {
   return (
     <svg

--- a/site/components/quickstart.tsx
+++ b/site/components/quickstart.tsx
@@ -20,11 +20,10 @@ const APP_FIELDS = [
 ] as const;
 
 const SLASH_COMMANDS = [
-  { cmd: "/review", tip: "General bug-and-correctness pass on the diff" },
+  { cmd: "/review", tip: "Orchestrated review on the diff" },
   { cmd: "/describe", tip: "Write a readable summary into the PR body" },
-  { cmd: "/review-security", tip: "Security lens when the change touches risk" },
-  { cmd: "/review-quality", tip: "Maintainability notes before you merge" },
   { cmd: "/ask …", tip: "Ask a question about the code in that thread" },
+  { cmd: "/triage", tip: "Verify prior findings and fix valid ones" },
 ] as const;
 
 const COMPOSE_SNIPPET = `cp .env.example .env
@@ -141,8 +140,8 @@ export function Quickstart() {
               Open a PR and talk to it
             </h3>
             <p className="mt-2 text-[0.98rem] leading-relaxed text-ink-mute sm:text-base">
-              Install the app on a repo, open a pull request, and wait for the automatic pass - or
-              type a slash command in the conversation when you want a specific lens.
+              Install the app on a repo, open a pull request, and wait for the automatic pass — or
+              type a slash command in the conversation when you want more.
             </p>
             <ul className="surface-inset edge-self mt-5 divide-y divide-edge rounded-md">
               {SLASH_COMMANDS.map((item) => (

--- a/site/components/review-artifact.tsx
+++ b/site/components/review-artifact.tsx
@@ -1,9 +1,5 @@
 import { GhCode } from "@/components/github-output/primitives";
 
-/**
- * Compact hero signature — a PR conversation snippet, not the full summary card.
- * Kept deliberately smaller than the gallery mocks.
- */
 export function ReviewArtifact() {
   return (
     <div className="relative w-full origin-bottom-right" aria-hidden="true">

--- a/site/lib/content.ts
+++ b/site/lib/content.ts
@@ -1,15 +1,10 @@
-export type FeatureItem = {
+type FeatureItem = {
   title: string;
   detail: string;
-  /** Short phrase shown under the step (command, event, or outcome). */
   cue: string;
-  /** Short phrase for schema.org SoftwareApplication.featureList */
   summary: string;
 };
 
-/**
- * Walkthrough of what happens after deploy - instructional, not a feature laundry list.
- */
 export const FEATURES: FeatureItem[] = [
   {
     title: "Deploy once on infrastructure you control",
@@ -35,8 +30,8 @@ export const FEATURES: FeatureItem[] = [
   {
     title: "Results land in the pull request",
     detail:
-      "Inline threads show up on Files changed. A review summary lands in the conversation. Need more? Comment /describe, /review-security, /review-quality, /ask, or @-mention the bot - answers stay in the same thread.",
-    cue: "/review · /describe · /ask · @bot",
+      "Inline threads show up on Files changed. A review summary lands in the conversation. Need more? Comment /describe, /ask, /triage, or @-mention the bot - answers stay in the same thread.",
+    cue: "/review · /describe · /ask · /triage · @bot",
     summary: "Reviews and replies posted in the pull request",
   },
   {
@@ -48,7 +43,7 @@ export const FEATURES: FeatureItem[] = [
   },
 ];
 
-export type CapabilityItem = {
+type CapabilityItem = {
   title: string;
   trigger: string;
   detail: string;
@@ -66,19 +61,14 @@ export const CAPABILITIES: CapabilityItem[] = [
     detail: "Summary bullets and an optional diagram go into the PR body.",
   },
   {
-    title: "Ask for a security pass when the change touches risk",
-    trigger: "Comment /review-security on the PR",
-    detail: "Security notes are posted as a separate summary.",
-  },
-  {
-    title: "Ask for a quality pass before merge",
-    trigger: "Comment /review-quality on the PR",
-    detail: "Maintainability notes land in the PR conversation.",
-  },
-  {
     title: "Ask code questions without leaving GitHub",
     trigger: "Comment /ask … or @-mention the bot with your question",
     detail: "Get an answer in the same thread, right where the code lives.",
+  },
+  {
+    title: "Triage prior findings on the pull request",
+    trigger: "Comment /triage on the PR or an inline finding thread",
+    detail: "Verifies open findings and can push fixes for valid same-repo issues.",
   },
   {
     title: "Skip AI review when the PR is only docs",
@@ -87,7 +77,7 @@ export const CAPABILITIES: CapabilityItem[] = [
   },
 ];
 
-export type PricingPlan = {
+type PricingPlan = {
   title: string;
   price: string;
   detail: string;
@@ -113,7 +103,7 @@ export const PRICING_PLANS: PricingPlan[] = [
   },
 ];
 
-export type ProviderItem = {
+type ProviderItem = {
   name: string;
   detail: string;
 };
@@ -130,7 +120,7 @@ export const PROVIDERS: ProviderItem[] = [
   },
 ];
 
-export type FaqItem = {
+type FaqItem = {
   question: string;
   answer: string;
 };
@@ -139,7 +129,7 @@ export const FAQ_ITEMS: FaqItem[] = [
   {
     question: "What is PR Agent?",
     answer:
-      "PR Agent reviews GitHub pull requests on your servers. You deploy webhook intake, a Postgres job queue, background workers, and AI agents. It posts reviews, PR descriptions, security notes, quality notes, and Q&A replies back to GitHub.",
+      "PR Agent reviews GitHub pull requests on your servers. You deploy webhook intake, a Postgres job queue, background workers, and AI agents. It posts reviews, PR descriptions, and Q&A replies back to GitHub.",
   },
   {
     question: "Is PR Agent a self-hosted alternative to CodeRabbit?",
@@ -178,7 +168,7 @@ export const FAQ_ITEMS: FaqItem[] = [
   },
 ];
 
-export type AlternativeRow = {
+type AlternativeRow = {
   name: string;
   deployment: string;
   differentiator: string;

--- a/site/lib/seo.ts
+++ b/site/lib/seo.ts
@@ -59,25 +59,6 @@ function softwareApplicationJsonLd() {
   };
 }
 
-function webSiteJsonLd() {
-  return {
-    "@context": "https://schema.org",
-    "@type": "WebSite",
-    name: PRODUCT_NAME,
-    description: SEO_DESCRIPTION,
-    url: SITE_ORIGIN,
-  };
-}
-
-function organizationJsonLd() {
-  return {
-    "@context": "https://schema.org",
-    "@type": "Organization",
-    name: "prathamdby",
-    url: "https://github.com/prathamdby",
-  };
-}
-
 function faqPageJsonLd() {
   return {
     "@context": "https://schema.org",
@@ -111,8 +92,19 @@ function itemListJsonLd() {
 
 export const JSON_LD_GRAPHS = [
   softwareApplicationJsonLd(),
-  webSiteJsonLd(),
-  organizationJsonLd(),
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: PRODUCT_NAME,
+    description: SEO_DESCRIPTION,
+    url: SITE_ORIGIN,
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: "prathamdby",
+    url: "https://github.com/prathamdby",
+  },
   faqPageJsonLd(),
   itemListJsonLd(),
 ];

--- a/site/lib/seo.ts
+++ b/site/lib/seo.ts
@@ -30,7 +30,7 @@ export const SEO_KEYWORDS = [
   "Docker code review",
 ];
 
-export function softwareApplicationJsonLd() {
+function softwareApplicationJsonLd() {
   return {
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
@@ -59,7 +59,7 @@ export function softwareApplicationJsonLd() {
   };
 }
 
-export function webSiteJsonLd() {
+function webSiteJsonLd() {
   return {
     "@context": "https://schema.org",
     "@type": "WebSite",
@@ -69,7 +69,7 @@ export function webSiteJsonLd() {
   };
 }
 
-export function organizationJsonLd() {
+function organizationJsonLd() {
   return {
     "@context": "https://schema.org",
     "@type": "Organization",
@@ -78,7 +78,7 @@ export function organizationJsonLd() {
   };
 }
 
-export function faqPageJsonLd() {
+function faqPageJsonLd() {
   return {
     "@context": "https://schema.org",
     "@type": "FAQPage",
@@ -93,7 +93,7 @@ export function faqPageJsonLd() {
   };
 }
 
-export function itemListJsonLd() {
+function itemListJsonLd() {
   return {
     "@context": "https://schema.org",
     "@type": "ItemList",

--- a/src/agent/ask/askRun.ts
+++ b/src/agent/ask/askRun.ts
@@ -1,7 +1,7 @@
 import { logInfo } from "../../evlog.js";
 import { AppError } from "../../errors/appError.js";
 import { buildAskSystemPrompt } from "./askPrompt.js";
-import { formatAskFailureReply, formatAskReply } from "./formatAskReply.js";
+import { formatAskReply } from "./formatAskReply.js";
 import { buildContext7Tools } from "../tools/context7Tools.js";
 import {
   ASK_FAILURE_MESSAGE,
@@ -89,14 +89,11 @@ export async function runAskRun(params: AskRunParams): Promise<AskRunResult> {
       }
     }
 
-    const answerText =
-      lastText.length > 0
-        ? formatAskReply({ question, answer: lastText, replyTarget })
-        : formatAskFailureReply({
-            question,
-            message: ASK_FAILURE_MESSAGE,
-            replyTarget,
-          });
+    const answerText = formatAskReply({
+      question,
+      answer: lastText.length > 0 ? lastText : ASK_FAILURE_MESSAGE,
+      replyTarget,
+    });
 
     logInfo("ask_run_completed", {
       provider: cfg.agentProvider,

--- a/src/agent/ask/formatAskReply.ts
+++ b/src/agent/ask/formatAskReply.ts
@@ -21,15 +21,3 @@ export function formatAskReply(params: {
   }
   return [`**Question:** ${params.question.trim()}`, "", "**Answer:**", "", answer].join("\n");
 }
-
-export function formatAskFailureReply(params: {
-  question: string;
-  message: string;
-  replyTarget: ReplyTarget;
-}): string {
-  return formatAskReply({
-    question: params.question,
-    answer: params.message,
-    replyTarget: params.replyTarget,
-  });
-}

--- a/src/agent/prompts/promptBlocks.ts
+++ b/src/agent/prompts/promptBlocks.ts
@@ -1,10 +1,9 @@
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 function neutralizeUntrustedBlockTags(label: string, text: string): string {
   const tagGap = "[\\s\\p{Cf}\\p{Cc}]*";
-  const labelPattern = label.split("").map(escapeRegExp).join(tagGap);
+  const labelPattern = label
+    .split("")
+    .map((value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+    .join(tagGap);
   const tagPattern = new RegExp(
     `<${tagGap}/?${tagGap}${labelPattern}(?=[\\s>/\\p{Cf}\\p{Cc}])[^>]*>`,
     "giu",

--- a/src/agent/providers/cursor/mcpBridge.ts
+++ b/src/agent/providers/cursor/mcpBridge.ts
@@ -304,9 +304,10 @@ export async function createMcpBridge(options: McpBridgeOptions): Promise<McpBri
     startTimeoutId = setTimeout(
       () =>
         reject(
-          new Error(
-            `MCP bridge HTTP server did not start within ${CURSOR_MCP_SERVER_START_TIMEOUT_MS}ms`,
-          ),
+          new AppError({
+            code: "cursor.mcp_start_timeout",
+            message: `MCP bridge HTTP server did not start within ${CURSOR_MCP_SERVER_START_TIMEOUT_MS}ms`,
+          }),
         ),
       CURSOR_MCP_SERVER_START_TIMEOUT_MS,
     );

--- a/src/agent/providers/cursor/ripgrepBoot.ts
+++ b/src/agent/providers/cursor/ripgrepBoot.ts
@@ -2,6 +2,7 @@ import { accessSync, constants } from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { AppError } from "../../../errors/appError.js";
 import { DEFAULT_CURSOR_RIPGREP_PATH, ENV } from "../../../settings/index.js";
 import { captureCursorWorkerEvent, captureCursorWorkerFailure } from "./cursorAnalytics.js";
 
@@ -50,9 +51,11 @@ export function assertCursorRipgrepConfigured(): string {
     return configured;
   }
 
-  const error = new Error(
-    "Ripgrep path not configured for Cursor local agent. Call configureCursorRipgrepPath() at worker boot.",
-  );
+  const error = new AppError({
+    code: "cursor.ripgrep_boot_failed",
+    message:
+      "Ripgrep path not configured for Cursor local agent. Call configureCursorRipgrepPath() at worker boot.",
+  });
   captureCursorWorkerFailure("ripgrep_required", error);
   throw error;
 }

--- a/src/agent/providers/interface.ts
+++ b/src/agent/providers/interface.ts
@@ -1,12 +1,8 @@
 import type { Tool as PiTool } from "@earendil-works/pi-ai";
 import type { Config } from "../../config.js";
-import type {
-  AgentRunnerPromptMetadata,
-  AgentRunnerTurn,
-  AgentRunnerUsageMetadata,
-} from "./usageMetadata.js";
+import type { AgentRunnerTurn } from "./usageMetadata.js";
 
-export type { AgentRunnerPromptMetadata, AgentRunnerTurn, AgentRunnerUsageMetadata };
+export type { AgentRunnerTurn };
 
 export type AgentRunnerToolExecutor = (args: Record<string, unknown>) => Promise<unknown>;
 

--- a/src/agent/providers/pi/index.ts
+++ b/src/agent/providers/pi/index.ts
@@ -210,7 +210,10 @@ export const piAgentRunnerProvider: AgentRunnerProvider = {
             idleRejected = true;
             void session.abort();
             rejectOnIdle?.(
-              new Error(`Provider prompt timeout: no activity for ${idleTimeoutMs}ms`),
+              new AppError({
+                code: "pi.prompt_idle_timeout",
+                message: `Provider prompt timeout: no activity for ${idleTimeoutMs}ms`,
+              }),
             );
           };
           const startIdleTimer = () => {

--- a/src/agent/providers/providerErrors.ts
+++ b/src/agent/providers/providerErrors.ts
@@ -1,15 +1,11 @@
 export type ProviderErrorKind = "auth" | "quota" | "billing" | "rate_limit" | "timeout" | "unknown";
 
-function errorText(error: unknown): string {
-  if (error instanceof Error) {
-    return `${error.name} ${error.message}`.toLowerCase();
-  }
-  return String(error).toLowerCase();
-}
-
 /** Logs-only classification for worker/provider failures. */
 export function classifyProviderError(error: unknown): ProviderErrorKind {
-  const text = errorText(error);
+  const text =
+    error instanceof Error
+      ? `${error.name} ${error.message}`.toLowerCase()
+      : String(error).toLowerCase();
   if (
     /\b401\b|\b403\b|unauthorized|forbidden|invalid api key|authentication|bad credentials/.test(
       text,

--- a/src/agent/tools/localWorkspaceTools.ts
+++ b/src/agent/tools/localWorkspaceTools.ts
@@ -39,10 +39,6 @@ const DEFAULT_LOCAL_WORKSPACE_TOOL_LIMITS: LocalWorkspaceToolLimits = {
 
 const BINARY_SAMPLE_BYTES = 8192;
 
-function looksBinary(sample: Buffer): boolean {
-  return sample.includes(0);
-}
-
 function primePathGate(
   workspace: LocalPrWorkspace,
   pathGate: AskPathGate,
@@ -137,7 +133,7 @@ export function buildLocalWorkspaceTools(
       }
       const safePath = assertWorkspacePath(workspace.agentCwd, normalized);
       const buf = await readFile(safePath);
-      if (looksBinary(buf.subarray(0, Math.min(buf.length, BINARY_SAMPLE_BYTES)))) {
+      if (buf.subarray(0, Math.min(buf.length, BINARY_SAMPLE_BYTES)).includes(0)) {
         return {
           path: normalized,
           refused: true,

--- a/src/agent/triage/publishTriage.ts
+++ b/src/agent/triage/publishTriage.ts
@@ -109,16 +109,12 @@ export function parseStoredTriagePushDetail(detail: unknown): StoredTriagePushDe
   };
 }
 
-function shortSha(sha: string): string {
-  return sha.slice(0, 7);
-}
-
 function replyBody(
   verdict: Extract<TriageVerdict, { verdict: "fixed" | "already-resolved" }>,
 ): string {
   if (verdict.verdict === "fixed") {
     return redactReviewText(
-      `**Triage**: Fixed in ${shortSha(verdict.commitSha)} - ${verdict.evidence}`,
+      `**Triage**: Fixed in ${verdict.commitSha.slice(0, 7)} - ${verdict.evidence}`,
     );
   }
   return redactReviewText(`**Triage**: Already resolved - ${verdict.evidence}`);

--- a/src/agent/verification/publishVerification.ts
+++ b/src/agent/verification/publishVerification.ts
@@ -43,10 +43,6 @@ function withStubMarker(body: string): string {
   return `${VERIFICATION_STUB_MARKER}\n${body}`;
 }
 
-function skippedReplyBody(verdict: Extract<VerificationVerdict, { verdict: "skipped" }>): string {
-  return withStubMarker(redactReviewText(`**Verification**: Still open - ${verdict.reason}`));
-}
-
 function terminalSuccessStubBody(
   verdict: Extract<VerificationVerdict, { verdict: "fixed" | "already-resolved" }>,
 ): string {
@@ -230,7 +226,9 @@ export async function publishVerification(
       }
       case "skipped": {
         if (!changedFiles.has(thread.path)) break;
-        const body = skippedReplyBody(verdict);
+        const body = withStubMarker(
+          redactReviewText(`**Verification**: Still open - ${verdict.reason}`),
+        );
         const stubCommentId = await upsertStubComment({
           token: params.token,
           tokenExpiresAtTs: params.tokenExpiresAtTs,

--- a/src/agentRun/sessionHelpers.ts
+++ b/src/agentRun/sessionHelpers.ts
@@ -4,20 +4,12 @@ import type { Config } from "../config.js";
 import type { AgentRunnerSession, AgentRunnerTurn } from "../agent/providers/interface.js";
 import { CURSOR_API, CURSOR_PROVIDER } from "../agent/providers/cursor/models.js";
 
-function sessionAssistantApi(runProvider: string, piApi: string): Api {
-  return runProvider === CURSOR_PROVIDER ? CURSOR_API : (piApi as Api);
-}
-
-function sessionAssistantProvider(runProvider: string, piProvider: string): ProviderId {
-  return runProvider === CURSOR_PROVIDER ? CURSOR_PROVIDER : piProvider;
-}
-
 export function assistantFromText(cfg: Config, text: string, provider: string): AssistantMessage {
   return {
     role: "assistant",
     content: text ? [{ type: "text", text }] : [],
-    api: sessionAssistantApi(provider, cfg.piApi),
-    provider: sessionAssistantProvider(provider, cfg.piProvider),
+    api: provider === CURSOR_PROVIDER ? CURSOR_API : (cfg.piApi as Api),
+    provider: (provider === CURSOR_PROVIDER ? CURSOR_PROVIDER : cfg.piProvider) as ProviderId,
     model: cfg.piModel,
     usage: {
       input: 0,

--- a/src/agentWork/boss.ts
+++ b/src/agentWork/boss.ts
@@ -52,17 +52,15 @@ export async function createStartedBoss(cfg: BossConfig): Promise<PgBoss> {
   return boss;
 }
 
-const deadLetterQueueOptions = (cfg: QueueConfig): QueueOptions => ({
-  retryLimit: 0,
-  retryDelay: 0,
-  retryBackoff: false,
-  deleteAfterSeconds: cfg.queueDeleteAfterSeconds,
-  retentionSeconds: cfg.queueRetentionSeconds,
-});
-
 export async function ensureAgentQueues(boss: PgBoss, cfg: QueueConfig): Promise<void> {
   const defaults = queueDefaults(cfg);
-  const dlq = deadLetterQueueOptions(cfg);
+  const dlq: QueueOptions = {
+    retryLimit: 0,
+    retryDelay: 0,
+    retryBackoff: false,
+    deleteAfterSeconds: cfg.queueDeleteAfterSeconds,
+    retentionSeconds: cfg.queueRetentionSeconds,
+  };
   // DLQ rows are archival only; no workers subscribe to these queue names.
   const deadLetterQueues = [
     ACK_DEAD_LETTER_QUEUE,

--- a/src/agentWork/durableJob.ts
+++ b/src/agentWork/durableJob.ts
@@ -11,7 +11,6 @@ import {
   type BotIdentity,
   type InstallationToken,
 } from "../github/appAuth.js";
-import { INSTALLATION_TOKEN_FALLBACK_TTL_MS } from "../github/installationTokenExpiry.js";
 import { sanitizeLogMessage } from "../security/sanitizeLogMessage.js";
 import { classifyProviderError } from "../agent/providers/providerErrors.js";
 import type { PullRequestForFileList } from "../github/listPullRequestFiles.js";
@@ -19,6 +18,7 @@ import {
   DEFERRED_HEAD_SHA,
   GITHUB_REACTION_MINUS_ONE,
   GITHUB_REACTION_PLUS_ONE,
+  INSTALLATION_TOKEN_FALLBACK_TTL_MS,
   TOKEN_FRESHNESS_BUFFER_MS,
   type GithubReactionContent,
 } from "../settings/index.js";
@@ -38,7 +38,6 @@ import {
   updateRunningWorkHeadSha,
 } from "./repository.js";
 import { getPullRequestHead, reactOnAckTargets } from "./githubPrSurface.js";
-import { isTerminalPgBossAttempt } from "./pgBossJob.js";
 import { reactionTargetsForWorkItem } from "./reactionTargets.js";
 import { cancelOrphanedStaleHeadReplacementOnTerminalFailure } from "./reviewReschedule.js";
 import type { AgentWorkItem, AgentWorkItemCore, WorkType } from "./types.js";
@@ -493,7 +492,7 @@ export async function runDurableWorkItem<T extends WorkType>(
   async function handleDurableExecutionError(error: unknown): Promise<void> {
     if (await recheckSkippableAndCancel("skipped_after_error")) return;
     const message = error instanceof Error ? error.message : String(error);
-    if (!isTerminalPgBossAttempt(spec.job)) {
+    if (!(spec.job.retryCount >= spec.job.retryLimit)) {
       await markRetryingOrCancel(error, message);
       return;
     }

--- a/src/agentWork/durableJob.ts
+++ b/src/agentWork/durableJob.ts
@@ -54,10 +54,6 @@ type DurableExecutionContext = {
 const installationTokenCache = new Map<number, InstallationToken | Promise<InstallationToken>>();
 let botIdentityCache: Promise<BotIdentity> | undefined;
 
-function tokenIsFresh(token: InstallationToken): boolean {
-  return token.expiresAtTs - Date.now() > TOKEN_FRESHNESS_BUFFER_MS;
-}
-
 export function clearDurableAuthCachesForTest(): void {
   if (process.env.NODE_ENV === "test") {
     installationTokenCache.clear();
@@ -122,7 +118,7 @@ export async function mintInstallationToken(
   const cached = installationTokenCache.get(installationId);
   if (cached) {
     const token = await cached;
-    if (tokenIsFresh(token)) return token;
+    if (token.expiresAtTs - Date.now() > TOKEN_FRESHNESS_BUFFER_MS) return token;
   }
 
   const pending = (async () => {
@@ -251,10 +247,6 @@ function enterExecutingPhase(state: WorkItemPhaseState): void {
   state.phase = "executing";
 }
 
-function enterCompletingPhase(state: WorkItemPhaseState): void {
-  state.phase = "completing";
-}
-
 function isSkipCheckSuppressed(state: WorkItemPhaseState): boolean {
   return state.phase === "executing";
 }
@@ -348,7 +340,7 @@ export async function runDurableWorkItem<T extends WorkType>(
   };
 
   const recheckSkippableAndCancel = async (reason: string, notifyHook = true) => {
-    enterCompletingPhase(phaseState);
+    phaseState.phase = "completing";
     return cancelIfSkippable(reason, notifyHook);
   };
 

--- a/src/agentWork/executors/ackExecutor.ts
+++ b/src/agentWork/executors/ackExecutor.ts
@@ -1,7 +1,7 @@
 import type { Pool } from "pg";
 import type { Config } from "../../config.js";
 import { logWarn } from "../../evlog.js";
-import { reviewSummarySentinelForMode } from "../../review/reviewSchema.js";
+import { REVIEW_SUMMARY_SENTINEL } from "../../review/reviewSchema.js";
 import { upsertSummaryCommentWithCreationClaim } from "../../review/publish/publishReview.js";
 import {
   DEFERRED_HEAD_SHA,
@@ -77,7 +77,7 @@ export async function executeAckJob(cfg: Config, pool: Pool, data: AckJobData): 
       progressWorkItemId: data.workItemId,
     });
     const resourceKey = `${data.owner}/${data.repo}#${data.prNumber}`;
-    const sentinel = reviewSummarySentinelForMode(data.progress.lens);
+    const sentinel = REVIEW_SUMMARY_SENTINEL;
     await upsertSummaryCommentWithCreationClaim({
       pool,
       workItemId: data.workItemId,

--- a/src/agentWork/executors/askExecutor.ts
+++ b/src/agentWork/executors/askExecutor.ts
@@ -4,7 +4,7 @@ import type { Config } from "../../config.js";
 import { captureEvent } from "../../analytics/index.js";
 import { runAskRun } from "../../agent/ask/askRun.js";
 import { loadAskThreadTranscript } from "../../agent/ask/askThreadContext.js";
-import { formatAskFailureReply, sanitizeAskAnswerText } from "../../agent/ask/formatAskReply.js";
+import { formatAskReply, sanitizeAskAnswerText } from "../../agent/ask/formatAskReply.js";
 import { installationOctokit } from "../../github/appAuth.js";
 import { logWarn } from "../../evlog.js";
 import { ASK_PUBLISH_LENS } from "../../settings/index.js";
@@ -163,9 +163,9 @@ export async function executeAskJob(
         installation.token,
         installation.expiresAtTs,
         item,
-        formatAskFailureReply({
+        formatAskReply({
           question: payload.question,
-          message: "PR Agent could not complete this ask after retries. Please try again later.",
+          answer: "PR Agent could not complete this ask after retries. Please try again later.",
           replyTarget: payload.replyTarget,
         }),
         true,

--- a/src/agentWork/executors/reviewExecutor.ts
+++ b/src/agentWork/executors/reviewExecutor.ts
@@ -26,7 +26,7 @@ import {
   fetchPriorInlineFeedbackBlockForReview,
 } from "../../review/prompts/reviewTrustedContext.js";
 import { buildReviewPreflightMetadataFromPullRequestFiles } from "../../review/placement/reviewPreflightFiles.js";
-import { reviewSummarySentinelForMode, type ReviewMode } from "../../review/reviewSchema.js";
+import { REVIEW_SUMMARY_SENTINEL, type ReviewMode } from "../../review/reviewSchema.js";
 import {
   initReviewRunMetrics,
   logReviewRunCompleted,
@@ -82,18 +82,6 @@ type Result<T> =
   | { readonly ok: false; readonly error: unknown };
 
 type SettledPriorInlineFeedback = Result<string | undefined>;
-
-async function tryCatchAsync<T>(
-  fn: () => Promise<T>,
-  onError?: (error: unknown) => void,
-): Promise<Result<T>> {
-  try {
-    return { ok: true, value: await fn() };
-  } catch (error: unknown) {
-    onError?.(error);
-    return { ok: false, error };
-  }
-}
 
 /** Load a discriminated result and render the ok branch into a trusted-context block. */
 async function loadAndRenderTrustedBlock<TResult extends { readonly kind: string }>(params: {
@@ -306,7 +294,7 @@ async function runLightweightCompletionOrSkip(args: {
   return { done: true, result: { degraded: false } };
 }
 
-function buildPriorInlineFeedbackPromise(args: {
+async function buildPriorInlineFeedbackPromise(args: {
   readonly cfg: Config;
   readonly item: ReviewWorkItem;
   readonly reviewLens: ReviewMode;
@@ -322,17 +310,23 @@ function buildPriorInlineFeedbackPromise(args: {
       message: error instanceof Error ? error.message : String(error),
     });
   };
-  return tryCatchAsync(async () => {
+  try {
     const bot = await getAppBotIdentity(cfg);
-    return fetchPriorInlineFeedbackBlockForReview({
-      token: tokenState.installation.token,
-      owner: item.owner,
-      repo: item.repo,
-      prNumber: item.prNumber,
-      botUserId: bot.userId,
-      onPriorFeedbackError: logPriorFeedbackError,
-    });
-  }, logPriorFeedbackError);
+    return {
+      ok: true,
+      value: await fetchPriorInlineFeedbackBlockForReview({
+        token: tokenState.installation.token,
+        owner: item.owner,
+        repo: item.repo,
+        prNumber: item.prNumber,
+        botUserId: bot.userId,
+        onPriorFeedbackError: logPriorFeedbackError,
+      }),
+    };
+  } catch (error: unknown) {
+    logPriorFeedbackError(error);
+    return { ok: false, error };
+  }
 }
 
 async function handleReviewPublishResult(args: {
@@ -722,7 +716,7 @@ export async function executeReviewJob(
           mode: reviewLens,
           retryCommand: "/review",
         }),
-        reviewSummarySentinelForMode(reviewLens),
+        REVIEW_SUMMARY_SENTINEL,
         undefined,
         installation.expiresAtTs,
       );

--- a/src/agentWork/executors/triageExecutor.ts
+++ b/src/agentWork/executors/triageExecutor.ts
@@ -423,7 +423,10 @@ async function tryResumeStoredPush(params: {
 
   const parsed = parseStoredTriagePushDetail(storedPushDetail);
   if (!parsed) {
-    const error = new Error("Stored triage_push detail is invalid");
+    const error = new AppError({
+      code: "triage.invalid_stored_push",
+      message: "Stored triage_push detail is invalid",
+    });
     captureTriageFailure(params.analytics, "parse_stored_push", error);
     throw error;
   }
@@ -506,7 +509,10 @@ async function runFreshTriageAgent(params: {
         scope: params.scope,
       });
       if (!result.submitted || !result.payload) {
-        const error = new Error("Triage run ended without submitTriage");
+        const error = new AppError({
+          code: "triage.missing_submit",
+          message: "Triage run ended without submitTriage",
+        });
         captureTriageFailure(params.analytics, "agent_run", error, {
           submitted: result.submitted,
         });

--- a/src/agentWork/intake/applier.ts
+++ b/src/agentWork/intake/applier.ts
@@ -1,14 +1,10 @@
 import type { Pool, PoolClient } from "pg";
 import type { PgBoss } from "pg-boss";
 import type { Config } from "../../config.js";
-import { inTransaction } from "../../db/postgres.js";
+import { inTransaction, pgBossDb } from "../../db/postgres.js";
 import { DESCRIPTION_QUEUE, REVIEW_QUEUE, VERIFICATION_QUEUE } from "../../settings/index.js";
 import { replaceAutoWorkItem, type AutoWorkSupersedeTarget } from "../autoWorkEnqueue.js";
-import {
-  releaseSingletonSlot,
-  reviewSingletonSlotDb,
-  type SingletonSlotDb,
-} from "../singletonQueue.js";
+import { releaseSingletonSlot, type SingletonSlotDb } from "../singletonQueue.js";
 import type { RequestLogger } from "../../evlog.js";
 import { recordEvent } from "../../evlog.js";
 import {
@@ -129,7 +125,7 @@ async function applyPlannedAutomatedPullRequestIntake(
   }
   const correlation = jobCorrelation(event.id, headers);
   const resourceKey = prResourceKey(ref.owner, ref.repo, ref.prNumber);
-  const slotDb = reviewSingletonSlotDb(client);
+  const slotDb = pgBossDb(client);
 
   if (plan.kinds.includes("review")) {
     const ackTargets: AckTarget[] = [{ kind: "pr", prNumber: ref.prNumber }];

--- a/src/agentWork/intake/webhookEvents.ts
+++ b/src/agentWork/intake/webhookEvents.ts
@@ -14,15 +14,11 @@ type EventRecord =
       readonly dedupeKey: string;
     };
 
-function bodySha(rawBody: Buffer): string {
-  return crypto.createHash("sha256").update(rawBody).digest("hex");
-}
-
 function webhookEventKeys(headers: WebhookHeaders): {
   readonly dedupeKey: string;
   readonly bodySha256: string;
 } {
-  const bodySha256 = bodySha(headers.rawBody);
+  const bodySha256 = crypto.createHash("sha256").update(headers.rawBody).digest("hex");
   return {
     dedupeKey: headers.delivery ? `delivery:${headers.delivery}` : `body:${bodySha256}`,
     bodySha256,

--- a/src/agentWork/pgBossJob.ts
+++ b/src/agentWork/pgBossJob.ts
@@ -1,5 +1,0 @@
-import type { JobWithMetadata } from "pg-boss";
-
-export function isTerminalPgBossAttempt(job: JobWithMetadata<unknown>): boolean {
-  return job.retryCount >= job.retryLimit;
-}

--- a/src/agentWork/retention.ts
+++ b/src/agentWork/retention.ts
@@ -11,14 +11,8 @@ export type RetentionResult = {
 };
 
 /**
- * Delete terminal agent work items and aged webhook events. Work items go first so
- * their `webhook_event_id` references clear before the webhook rows are removed
- * (the FK is ON DELETE SET NULL, so either order is safe).
- *
- * Each table is drained in fixed-size batches (`RETENTION_DELETE_BATCH_SIZE`); every
- * batch is its own implicit transaction (`pool.query`) so a large backlog never holds
- * one long open transaction. The two tables run concurrently via `Promise.all`. A
- * batch that deletes fewer rows than the batch size means the table is drained.
+ * Delete aged terminal work items then webhook events, in batches, so a large
+ * backlog never holds one long transaction.
  */
 export async function runRetention(
   pool: Pool,

--- a/src/agentWork/reviewCheckRun.ts
+++ b/src/agentWork/reviewCheckRun.ts
@@ -22,10 +22,6 @@ import {
   reserveReviewCheckRun,
 } from "./repository.js";
 
-function sleepMs(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 /** P0–P2 findings fail the check; empty or P3-only payloads pass. */
 export function reviewCheckRunOutcome(findings: readonly Pick<ReviewFinding, "severity">[]): {
   conclusion: ReviewCheckRunConclusion;
@@ -50,7 +46,7 @@ export async function waitForReviewCheckRunGithubId(
   while (Date.now() < deadline) {
     const id = await getReviewCheckRunGithubId(pool, workItemId, reviewLens);
     if (id != null) return id;
-    await sleepMs(pollMs);
+    await new Promise<void>((resolve) => setTimeout(resolve, pollMs));
   }
   return getReviewCheckRunGithubId(pool, workItemId, reviewLens);
 }

--- a/src/agentWork/reviewCheckRun.ts
+++ b/src/agentWork/reviewCheckRun.ts
@@ -1,5 +1,6 @@
 import type { Pool } from "pg";
 import { logWarn } from "../evlog.js";
+import { isMissingActionsPermissionError } from "../github/actionsLogs.js";
 import { httpStatus } from "../github/httpStatus.js";
 import {
   createReviewCheckRun,
@@ -51,30 +52,19 @@ export async function waitForReviewCheckRunGithubId(
   return getReviewCheckRunGithubId(pool, workItemId, reviewLens);
 }
 
-function isMissingChecksPermissionError(error: unknown): boolean {
-  const status = httpStatus(error);
-  if (status !== 403 && status !== 404) return false;
-  const message = error instanceof Error ? error.message : String(error);
-  return (
-    message.includes("Resource not accessible by integration") ||
-    message.includes("Not Found") ||
-    status === 404
-  );
-}
-
 function logCheckRunWarning(
   event: string,
   error: unknown,
   fields: Record<string, string | number | undefined>,
 ): void {
-  if (isMissingChecksPermissionError(error)) return;
+  if (isMissingActionsPermissionError(error)) return;
   logWarn(event, {
     ...fields,
     message: error instanceof Error ? error.message : String(error),
   });
 }
 
-export function reviewCheckRunName(_mode: AnyReviewLens): string {
+export function reviewCheckRunName(): string {
   return "PR Agent Review";
 }
 
@@ -320,7 +310,7 @@ export async function ensureReviewCheckRunStarted(
   const existing = await getReviewCheckRunGithubId(pool, params.workItemId, params.reviewLens);
   if (existing != null) return existing;
 
-  const name = reviewCheckRunName(params.reviewLens);
+  const name = reviewCheckRunName();
   const reservation = await reserveReviewCheckRunSlot(pool, params, name);
   if (reservation.kind === "existing") return reservation.githubId;
   if (reservation.kind === "resolved") return reservation.githubId;
@@ -355,7 +345,7 @@ export async function completeReviewCheckRun(
   if (checkRunId == null) return false;
 
   const completedAt = new Date().toISOString();
-  const name = reviewCheckRunName(params.reviewLens);
+  const name = reviewCheckRunName();
   try {
     await updateReviewCheckRun(
       params.token,

--- a/src/agentWork/reviewLightweightCompletion.ts
+++ b/src/agentWork/reviewLightweightCompletion.ts
@@ -4,7 +4,7 @@ import type { ReviewPreflightMetadata } from "../review/placement/reviewPrefligh
 import { renderLightweightReviewCompletion } from "../review/run/reviewRender.js";
 import { resolveReviewWallClockMs } from "../review/run/reviewRunFooter.js";
 import { snapshotReviewRunMetrics } from "../review/run/reviewRunMetrics.js";
-import { reviewSummarySentinelForMode, type ReviewMode } from "../review/reviewSchema.js";
+import { REVIEW_SUMMARY_SENTINEL, type ReviewMode } from "../review/reviewSchema.js";
 import {
   resolveVerifiedSummaryCommentRef,
   upsertReviewSummaryComment,
@@ -60,7 +60,7 @@ export async function tryLightweightAutoReviewCompletion(
     params.item.resourceKey,
     params.reviewLens,
   );
-  const body = renderLightweightReviewCompletion(params.reviewLens, {
+  const body = renderLightweightReviewCompletion({
     headSha: params.item.headSha,
     durationMs: resolveReviewWallClockMs({
       stubPostedAtMs,
@@ -69,7 +69,7 @@ export async function tryLightweightAutoReviewCompletion(
     }),
     model: params.model,
   });
-  const sentinel = reviewSummarySentinelForMode(params.reviewLens);
+  const sentinel = REVIEW_SUMMARY_SENTINEL;
   const storedId = await getSummaryCommentGithubId(
     pool,
     params.item.resourceKey,

--- a/src/agentWork/singletonQueue.ts
+++ b/src/agentWork/singletonQueue.ts
@@ -1,5 +1,4 @@
 import type { PgBoss } from "pg-boss";
-import type { PoolClient } from "pg";
 import { pgBossDb } from "../db/postgres.js";
 import { REVIEW_QUEUE } from "../settings/index.js";
 import { reviewSingletonKey } from "./types.js";
@@ -46,8 +45,4 @@ export async function releaseReviewSingletonSlot(
     skipJobId: opts?.skipJobId,
     skipWorkItemId: opts?.skipWorkItemId,
   });
-}
-
-export function reviewSingletonSlotDb(client: PoolClient): SingletonSlotDb {
-  return pgBossDb(client);
 }

--- a/src/agentWork/verificationThreadLedger.ts
+++ b/src/agentWork/verificationThreadLedger.ts
@@ -2,7 +2,7 @@ import type { Pool } from "pg";
 import { VERIFICATION_PUBLISH_LENS } from "../settings/index.js";
 import { recordPublishStep } from "./repository.js";
 
-export type VerificationThreadVerdict = "skipped" | "dismissed" | "fixed" | "already-resolved";
+type VerificationThreadVerdict = "skipped" | "dismissed" | "fixed" | "already-resolved";
 
 export type VerificationThreadState = {
   readonly stubCommentId?: number;

--- a/src/agentWork/workItemPayloadSchema.ts
+++ b/src/agentWork/workItemPayloadSchema.ts
@@ -115,19 +115,16 @@ export class WorkItemPayloadValidationError extends AppError {
   }
 }
 
-function formatZodError(error: z.ZodError): string {
-  const issue = error.issues[0];
-  if (!issue) return "invalid payload";
-  const path = issue.path.length > 0 ? issue.path.join(".") : "(root)";
-  return `${path}: ${issue.message}`;
-}
-
 function parseWithSchema<T>(workType: WorkType, schema: z.ZodType<T>, raw: unknown): T {
   const result = schema.safeParse(raw);
   if (!result.success) {
+    const issue = result.error.issues[0];
+    const detail = !issue
+      ? "invalid payload"
+      : `${issue.path.length > 0 ? issue.path.join(".") : "(root)"}: ${issue.message}`;
     throw new WorkItemPayloadValidationError(
       workType,
-      `Invalid ${workType} work item payload: ${formatZodError(result.error)}`,
+      `Invalid ${workType} work item payload: ${detail}`,
     );
   }
   return result.data;

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -4,7 +4,6 @@ import type { AnalyticsSink, CaptureEventInput } from "./types.js";
 let sink: AnalyticsSink = noopAnalyticsSink;
 let enabled = false;
 
-/** Enable PostHog only when projectToken is non-empty; otherwise keep the no-op sink. */
 export async function initAnalytics(opts: {
   readonly projectToken: string;
   readonly host: string;
@@ -21,7 +20,6 @@ export async function initAnalytics(opts: {
   enabled = true;
 }
 
-/** Explicit no-op sink for tests that exercise capture call sites without boot. */
 export function initNoOpAnalytics(): void {
   sink = noopAnalyticsSink;
   enabled = false;

--- a/src/analytics/posthogSink.ts
+++ b/src/analytics/posthogSink.ts
@@ -2,10 +2,6 @@ import { PostHog, type EventMessage } from "posthog-node";
 import { sanitizePostHogEvent } from "../security/sanitizePostHogEvent.js";
 import type { AnalyticsSink } from "./types.js";
 
-function beforeSend(event: EventMessage | null): EventMessage | null {
-  return sanitizePostHogEvent(event) as EventMessage | null;
-}
-
 export function createPostHogSink(opts: {
   readonly projectToken: string;
   readonly host: string;
@@ -13,7 +9,7 @@ export function createPostHogSink(opts: {
   const client = new PostHog(opts.projectToken, {
     ...(opts.host ? { host: opts.host } : {}),
     enableExceptionAutocapture: true,
-    before_send: beforeSend,
+    before_send: (event) => sanitizePostHogEvent(event) as EventMessage | null,
   });
 
   return {

--- a/src/commands/parseBotMention.ts
+++ b/src/commands/parseBotMention.ts
@@ -3,10 +3,6 @@
  * Logins look like `pr-agent[bot]`; also accept the slug without the `[bot]` suffix.
  */
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 /** Login forms that count as tagging this bot (full login + optional slug without `[bot]`). */
 export function botMentionLogins(botLogin: string): readonly string[] {
   const trimmed = botLogin.trim();
@@ -22,7 +18,7 @@ export function botMentionLogins(botLogin: string): readonly string[] {
 
 function mentionPattern(botLogin: string): RegExp {
   const alternation = botMentionLogins(botLogin)
-    .map((login) => escapeRegExp(login))
+    .map((login) => login.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
     .join("|");
   // Word-ish boundary: avoid matching `@pr-agent-extra` when login is `pr-agent`.
   return new RegExp(`(^|[^A-Za-z0-9_-])@(${alternation})(?![A-Za-z0-9_-])`, "gi");

--- a/src/commands/parseSlashCommand.ts
+++ b/src/commands/parseSlashCommand.ts
@@ -1,8 +1,5 @@
 import { firstNonEmptyLine } from "./firstNonEmptyLine.js";
 
-/**
- * First meaningful line must start with `/command` (plan: case-sensitive token).
- */
 const SLASH_COMMAND_RE = /^\/([a-z0-9-]+)(?:\s|$)/;
 
 export function parseSlashCommand(body: string): string | null {

--- a/src/effect/server.ts
+++ b/src/effect/server.ts
@@ -15,10 +15,6 @@ function singleHeader(v: string | string[] | undefined): string | undefined {
   return Array.isArray(v) ? v.join(", ") : v;
 }
 
-function requestPath(url: string): string {
-  return url.split("?")[0] ?? url;
-}
-
 type BodyReadResult =
   | { readonly kind: "ok"; readonly rawBody: Buffer }
   | { readonly kind: "too_large" };
@@ -92,20 +88,13 @@ function readNodeRawBody(req: IncomingMessage, maxBodyBytes: number): Promise<Bo
   });
 }
 
-function payloadTooLargeResponse() {
-  return HttpServerResponse.text("payload too large", {
-    status: 413,
-    contentType: "text/plain; charset=utf-8",
-  });
-}
-
 function buildEffectWebhookApp(cfg: Config) {
   return HttpRouter.empty.pipe(
     HttpRouter.all(
       "*",
       Effect.gen(function* () {
         const req = yield* HttpServerRequest.HttpServerRequest;
-        const path = requestPath(req.url);
+        const path = req.url.split("?")[0] ?? req.url;
 
         if (req.method === "GET" && path === "/health") {
           return HttpServerResponse.text("ok", {
@@ -129,7 +118,10 @@ function buildEffectWebhookApp(cfg: Config) {
 
         const body = yield* readRawBody(req, WEBHOOK_MAX_BODY_BYTES);
         if (body.kind === "too_large") {
-          return payloadTooLargeResponse();
+          return HttpServerResponse.text("payload too large", {
+            status: 413,
+            contentType: "text/plain; charset=utf-8",
+          });
         }
 
         const intakeLog = createOperationLogger({

--- a/src/effect/server.ts
+++ b/src/effect/server.ts
@@ -8,7 +8,7 @@ import { AgentWorkScheduler } from "../agentWork/scheduler.js";
 import type { Config } from "../config.js";
 import { createOperationLogger } from "../evlog.js";
 import { processWebhookPostRequestEffect } from "./programs/processWebhookRequestEffect.js";
-import { WebhookHandlersLive } from "./services/webhookHandlers.js";
+import { WebhookHandlersCore } from "./services/webhookHandlers.js";
 import { WEBHOOK_MAX_BODY_BYTES } from "../settings/index.js";
 
 function singleHeader(v: string | string[] | undefined): string | undefined {
@@ -168,7 +168,7 @@ export function buildEffectWebhookLayer(
 ) {
   const appLayer = Layer.mergeAll(
     schedulerLayer,
-    WebhookHandlersLive.pipe(Layer.provide(schedulerLayer)),
+    WebhookHandlersCore.pipe(Layer.provide(schedulerLayer)),
   );
   const serverLayer = NodeHttpServer.layer(serverFactory, { port: cfg.port });
   return buildEffectWebhookApp(cfg).pipe(

--- a/src/effect/services/webhookHandlers.ts
+++ b/src/effect/services/webhookHandlers.ts
@@ -9,6 +9,7 @@ import { isSlashAssociationAllowed } from "../../commands/slashAssociation.js";
 import { AgentWorkScheduler } from "../../agentWork/scheduler.js";
 import type { WebhookHeaders } from "../../agentWork/types.js";
 import { getAppBotIdentity, type BotIdentity } from "../../github/appAuth.js";
+import { IGNORED_BOT_SLASH_COMMAND, IGNORED_UNAUTHORIZED_SLASH } from "../../settings/index.js";
 import type { ParsedGithubEvent } from "../../webhook/parseGithubPayload.js";
 import { codeAnchorFromReviewComment } from "../../webhook/payloads/pullRequestReviewCommentEvent.js";
 import { prNumbersForWorkflowRunHead } from "../../webhook/payloads/workflowRunEvent.js";
@@ -75,11 +76,11 @@ export const WebhookHandlersCore = Layer.effect(
       Effect.gen(function* () {
         const bot = yield* resolveBotIdentityEffect(cfg);
         if (commenterId === bot.userId) {
-          yield* scheduler.recordIgnored(headers, "ignored_bot_slash_command", intakeLog);
+          yield* scheduler.recordIgnored(headers, IGNORED_BOT_SLASH_COMMAND, intakeLog);
           return null;
         }
         if (!isSlashAssociationAllowed(cfg.slashAllowedAssociations, association)) {
-          yield* scheduler.recordIgnored(headers, "ignored_unauthorized_slash", intakeLog);
+          yield* scheduler.recordIgnored(headers, IGNORED_UNAUTHORIZED_SLASH, intakeLog);
           return null;
         }
         return bot;
@@ -311,5 +312,3 @@ export const WebhookHandlersCore = Layer.effect(
     });
   }),
 );
-
-export const WebhookHandlersLive = WebhookHandlersCore;

--- a/src/errors/appError.ts
+++ b/src/errors/appError.ts
@@ -48,7 +48,6 @@ function causeMessage(cause: unknown): string {
   }
 }
 
-/** JSON-safe snapshot of a non-Error throw value for context bags. */
 function jsonSafeRawValue(value: unknown): unknown {
   if (
     value === null ||
@@ -66,7 +65,6 @@ function jsonSafeRawValue(value: unknown): unknown {
   }
 }
 
-/** Wrap unknown values as AppError without losing an existing AppError. */
 export function toAppError(
   error: unknown,
   fallback: { readonly code: string; readonly context?: AppErrorContext },
@@ -96,7 +94,6 @@ function serializeCause(cause: unknown): SerializedAppError["errorCause"] {
   return { errorMessage: causeMessage(cause) };
 }
 
-/** JSON-safe bag for logs (and later analytics sinks). */
 export function serializeAppError(error: AppError): SerializedAppError {
   const errorCause = serializeCause(error.cause);
   return {
@@ -107,7 +104,6 @@ export function serializeAppError(error: AppError): SerializedAppError {
   };
 }
 
-/** Merge into logError meta; empty object when not an AppError. */
 export function errorLogFields(error: unknown): Partial<SerializedAppError> {
   if (!isAppError(error)) return {};
   return serializeAppError(error);

--- a/src/errors/appError.ts
+++ b/src/errors/appError.ts
@@ -7,7 +7,7 @@ export type AppErrorInit = {
   readonly cause?: unknown;
 };
 
-export type SerializedCause =
+type SerializedCause =
   | SerializedAppError
   | { readonly errorMessage: string; readonly errorName?: string };
 

--- a/src/github/actionsLogs.ts
+++ b/src/github/actionsLogs.ts
@@ -22,8 +22,7 @@ export type DownloadActionsJobLogsResult =
   | { readonly ok: true; readonly text: string }
   | { readonly ok: false; readonly reason: "actions_permission" | "empty" };
 
-/** True when Actions API is unavailable to this installation (missing permission or 404). */
-function isMissingActionsPermissionError(error: unknown): boolean {
+export function isMissingActionsPermissionError(error: unknown): boolean {
   const status = httpStatus(error);
   if (status !== 403 && status !== 404) return false;
   const message = error instanceof Error ? error.message : String(error);
@@ -34,10 +33,6 @@ function isMissingActionsPermissionError(error: unknown): boolean {
   );
 }
 
-/**
- * Lists Actions jobs for workflow runs on `headSha`.
- * Reports `actions_permission` when the installation cannot read Actions.
- */
 export async function listFailingActionsJobsForHead(
   token: string,
   owner: string,
@@ -98,7 +93,6 @@ export async function listFailingActionsJobsForHead(
   }
 }
 
-/** Downloads plain-text job logs, distinguishing permission misses from empty bodies. */
 export async function downloadActionsJobLogs(
   token: string,
   owner: string,

--- a/src/github/actionsLogs.ts
+++ b/src/github/actionsLogs.ts
@@ -7,7 +7,7 @@ const WORKFLOW_RUNS_MAX_PAGES = 2;
 const JOBS_PAGE_SIZE = 50;
 const JOBS_MAX_PAGES = 2;
 
-export type ActionsJobSnapshot = {
+type ActionsJobSnapshot = {
   readonly id: number;
   readonly name: string;
   readonly conclusion: string | null;
@@ -23,7 +23,7 @@ export type DownloadActionsJobLogsResult =
   | { readonly ok: false; readonly reason: "actions_permission" | "empty" };
 
 /** True when Actions API is unavailable to this installation (missing permission or 404). */
-export function isMissingActionsPermissionError(error: unknown): boolean {
+function isMissingActionsPermissionError(error: unknown): boolean {
   const status = httpStatus(error);
   if (status !== 403 && status !== 404) return false;
   const message = error instanceof Error ? error.message : String(error);

--- a/src/github/appAuth.ts
+++ b/src/github/appAuth.ts
@@ -6,7 +6,7 @@ import type { Config } from "../config.js";
 import { AppError } from "../errors/appError.js";
 import { logDebug } from "../evlog.js";
 import { onRateLimit, onSecondaryRateLimit } from "./octokitThrottle.js";
-import { INSTALLATION_TOKEN_FALLBACK_TTL_MS } from "./installationTokenExpiry.js";
+import { INSTALLATION_TOKEN_FALLBACK_TTL_MS } from "../settings/index.js";
 
 const ThrottledOctokit = Octokit.plugin(retry, throttling);
 export type InstallationOctokit = InstanceType<typeof ThrottledOctokit>;

--- a/src/github/appAuth.ts
+++ b/src/github/appAuth.ts
@@ -6,7 +6,6 @@ import type { Config } from "../config.js";
 import { AppError } from "../errors/appError.js";
 import { logDebug } from "../evlog.js";
 import { onRateLimit, onSecondaryRateLimit } from "./octokitThrottle.js";
-import { httpStatus } from "./httpStatus.js";
 import { INSTALLATION_TOKEN_FALLBACK_TTL_MS } from "./installationTokenExpiry.js";
 
 const ThrottledOctokit = Octokit.plugin(retry, throttling);
@@ -186,35 +185,4 @@ async function resolveBotIdentityViaAppSlug(
     username: `${slug}[bot]`,
   });
   return { userId: user.id, login: user.login };
-}
-
-/**
- * Mint bot identity for the authenticated installation, with the public-slug fallback.
- * Caching is the caller's responsibility — production callers should go through the
- * `BotIdentity` Effect service.
- */
-export async function mintBotIdentity(
-  cfg: Pick<Config, "githubAppId" | "githubAppPrivateKey">,
-  installationToken: string,
-): Promise<BotIdentity> {
-  const o = installationOctokit(installationToken);
-  let u: BotIdentity;
-  try {
-    const { data } = await o.rest.users.getAuthenticated();
-    u = { userId: data.id, login: data.login };
-  } catch (e: unknown) {
-    const status = httpStatus(e);
-    if (status !== 403) throw e;
-
-    logDebug("resolved_bot_identity_fallback_jwt_slug", {
-      githubAppId: cfg.githubAppId,
-    });
-    u = await resolveBotIdentityViaAppSlug(cfg);
-  }
-
-  logDebug("resolved_bot_identity", {
-    login: u.login,
-    githubAppId: cfg.githubAppId,
-  });
-  return u;
 }

--- a/src/github/ciStatus.ts
+++ b/src/github/ciStatus.ts
@@ -1,5 +1,5 @@
+import { isMissingActionsPermissionError } from "./actionsLogs.js";
 import { installationOctokit } from "./appAuth.js";
-import { httpStatus } from "./httpStatus.js";
 import { paginateOctokitPages } from "./paginateOctokit.js";
 import type {
   CiCheckAnnotation,
@@ -12,17 +12,7 @@ const CHECK_RUNS_MAX_PAGES = 5;
 const ANNOTATIONS_PAGE_SIZE = 50;
 const ANNOTATIONS_MAX_PAGES = 2;
 
-/** True when Checks API is unavailable to this installation (missing permission or 404). */
-export function isMissingChecksPermissionError(error: unknown): boolean {
-  const status = httpStatus(error);
-  if (status !== 403 && status !== 404) return false;
-  const message = error instanceof Error ? error.message : String(error);
-  return (
-    message.includes("Resource not accessible by integration") ||
-    message.includes("Not Found") ||
-    status === 404
-  );
-}
+export const isMissingChecksPermissionError = isMissingActionsPermissionError;
 
 export async function listCheckRunsForHead(
   token: string,

--- a/src/github/installationTokenExpiry.ts
+++ b/src/github/installationTokenExpiry.ts
@@ -1,7 +1,5 @@
 import { TOKEN_FRESHNESS_BUFFER_MS } from "../settings/index.js";
 
-export { INSTALLATION_TOKEN_FALLBACK_TTL_MS } from "../settings/index.js";
-
 export function isInstallationTokenNearExpiry(
   expiresAtTs: number,
   now: number = Date.now(),

--- a/src/github/reviewPublishRetry.ts
+++ b/src/github/reviewPublishRetry.ts
@@ -3,12 +3,6 @@ import { isTransientGitHubReviewError } from "./reviewErrors.js";
 
 export { isTransientGitHubReviewError } from "./reviewErrors.js";
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
-
 export async function withTransientReviewRetry<T>(
   fn: () => Promise<T>,
   delaysMs: readonly number[] = REVIEW_PUBLISH_TRANSIENT_RETRY_DELAYS_MS,
@@ -22,7 +16,9 @@ export async function withTransientReviewRetry<T>(
       if (attempt >= delaysMs.length || !isTransientGitHubReviewError(error)) {
         throw error;
       }
-      await sleep(delaysMs[attempt]);
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, delaysMs[attempt]);
+      });
     }
   }
   throw lastError;

--- a/src/github/reviewPublishRetry.ts
+++ b/src/github/reviewPublishRetry.ts
@@ -1,8 +1,6 @@
 import { REVIEW_PUBLISH_TRANSIENT_RETRY_DELAYS_MS } from "../settings/index.js";
 import { isTransientGitHubReviewError } from "./reviewErrors.js";
 
-export { isTransientGitHubReviewError } from "./reviewErrors.js";
-
 export async function withTransientReviewRetry<T>(
   fn: () => Promise<T>,
   delaysMs: readonly number[] = REVIEW_PUBLISH_TRANSIENT_RETRY_DELAYS_MS,

--- a/src/github/reviewThreadResolution.ts
+++ b/src/github/reviewThreadResolution.ts
@@ -60,10 +60,6 @@ function fullDatabaseId(value: unknown): number | null {
   return null;
 }
 
-function pageInfoValue(page: ReviewThreadsPage) {
-  return page.repository?.pullRequest?.reviewThreads?.pageInfo;
-}
-
 export async function listReviewThreadResolution(
   token: string,
   owner: string,
@@ -93,7 +89,7 @@ export async function listReviewThreadResolution(
       });
     }
 
-    const pageInfo = pageInfoValue(page);
+    const pageInfo = page.repository?.pullRequest?.reviewThreads?.pageInfo;
     if (pageInfo?.hasNextPage !== true) break;
     cursor = typeof pageInfo.endCursor === "string" ? pageInfo.endCursor : null;
     if (!cursor) break;

--- a/src/prWorkspace/localPrWorkspace.ts
+++ b/src/prWorkspace/localPrWorkspace.ts
@@ -81,7 +81,7 @@ type GitGrepChunkResult = GitGrepWorkspaceResult & {
   readonly stdoutBytes: number;
 };
 
-export type GitGrepWorkspaceMatch = {
+type GitGrepWorkspaceMatch = {
   readonly path: string;
   readonly line: number;
   readonly text: string;

--- a/src/prWorkspace/localPrWorkspace.ts
+++ b/src/prWorkspace/localPrWorkspace.ts
@@ -212,14 +212,6 @@ function errorStdout(error: unknown): string {
   return typeof error.stdout === "string" ? error.stdout : "";
 }
 
-function failedWithExitCode(error: unknown, code: number): boolean {
-  return errorCode(error) === code;
-}
-
-function failedWithMaxBuffer(error: unknown): boolean {
-  return errorCode(error) === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER";
-}
-
 function parseGitGrepOutput(stdout: string): GitGrepWorkspaceMatch[] {
   const matches: GitGrepWorkspaceMatch[] = [];
   let offset = 0;
@@ -243,15 +235,15 @@ function parseGitGrepOutput(stdout: string): GitGrepWorkspaceMatch[] {
   return matches;
 }
 
-function literalPathspec(path: string): string {
-  return `:(literal)${path}`;
-}
-
 function pathspecChunks(paths?: readonly string[]): string[][] {
   if (paths == null) return [["."]];
   const chunks: string[][] = [];
   for (let i = 0; i < paths.length; i += LOCAL_WORKSPACE_GREP_PATHSPEC_CHUNK_SIZE) {
-    chunks.push(paths.slice(i, i + LOCAL_WORKSPACE_GREP_PATHSPEC_CHUNK_SIZE).map(literalPathspec));
+    chunks.push(
+      paths
+        .slice(i, i + LOCAL_WORKSPACE_GREP_PATHSPEC_CHUNK_SIZE)
+        .map((path) => `:(literal)${path}`),
+    );
   }
   return chunks;
 }
@@ -288,8 +280,8 @@ async function gitGrepWorkspaceChunk(
       stdoutBytes: Buffer.byteLength(stdout),
     };
   } catch (error) {
-    if (failedWithExitCode(error, 1)) return { matches: [], truncated: false, stdoutBytes: 0 };
-    if (failedWithMaxBuffer(error)) {
+    if (errorCode(error) === 1) return { matches: [], truncated: false, stdoutBytes: 0 };
+    if (errorCode(error) === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER") {
       const stdout = errorStdout(error);
       return {
         matches: parseGitGrepOutput(stdout),

--- a/src/prWorkspace/writablePrCheckout.ts
+++ b/src/prWorkspace/writablePrCheckout.ts
@@ -101,10 +101,6 @@ function assertHeadRef(value: string): void {
   }
 }
 
-function isSensitivePath(path: string): boolean {
-  return SENSITIVE_PATH_PATTERNS.some((pattern) => pattern.test(path));
-}
-
 function validateSubject(subject: string): void {
   if (subject.length > TRIAGE_COMMIT_SUBJECT_MAX_CHARS) {
     throw new AppError({
@@ -194,7 +190,7 @@ function validateFiles(root: string, files: readonly string[]): readonly string[
         context: { path: file },
       });
     }
-    if (isSensitivePath(file)) {
+    if (SENSITIVE_PATH_PATTERNS.some((pattern) => pattern.test(file))) {
       throw new AppError({
         code: "pr_workspace.sensitive_path",
         message: `commitFix blocked sensitive path "${file}"`,

--- a/src/review/agentInstructionFiles.ts
+++ b/src/review/agentInstructionFiles.ts
@@ -7,7 +7,7 @@ import {
   MAX_AGENT_INSTRUCTION_FILE_BYTES,
 } from "../settings/index.js";
 
-export type AgentInstructionFilename = (typeof AGENT_INSTRUCTION_FILENAMES)[number];
+type AgentInstructionFilename = (typeof AGENT_INSTRUCTION_FILENAMES)[number];
 
 export type AgentInstructionFile = {
   readonly filename: AgentInstructionFilename;

--- a/src/review/ci/analyzeCi.ts
+++ b/src/review/ci/analyzeCi.ts
@@ -257,15 +257,6 @@ function buildAuthorInput(
   };
 }
 
-/**
- * Builds a CI summary for the review progress stub or completed review summary.
- * Missing Checks permission yields a visible grant-Checks row. Missing Actions
- * permission on a failing head attaches a grant-Actions note. Other fetch errors
- * soft-fail to a short unavailable headline. The review itself still publishes.
- *
- * Failing non-lightweight paths fetch condensed Actions logs and optionally call
- * `author` for model-authored reason/fixHint fields (ADR 0026).
- */
 export async function buildCiSummary(options: BuildCiSummaryOptions): Promise<CiSummary> {
   try {
     const loaded = await waitForTerminalCi(options);

--- a/src/review/ci/analyzeCi.ts
+++ b/src/review/ci/analyzeCi.ts
@@ -68,31 +68,14 @@ type ExternalCiLoad =
     }
   | { readonly ok: false; readonly reason: "checks_permission" | "fetch_error" };
 
-function sleepMs(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 export function isOwnCiCheckName(name: string): boolean {
   return name.startsWith(OWN_CHECK_NAME_PREFIX);
-}
-
-function isOwnCommitStatusContext(context: string): boolean {
-  return context === OWN_COMMIT_STATUS_CONTEXT;
-}
-
-function isCheckPending(run: CiCheckRunSnapshot): boolean {
-  if (run.status === "completed") return false;
-  return PENDING_CHECK_STATUSES.has(run.status) || run.conclusion == null;
 }
 
 function isCheckFailing(run: CiCheckRunSnapshot): boolean {
   return (
     run.status === "completed" && run.conclusion != null && FAILING_CONCLUSIONS.has(run.conclusion)
   );
-}
-
-function isLegacyPending(status: CiLegacyStatus): boolean {
-  return PENDING_LEGACY_STATES.has(status.state);
 }
 
 function isLegacyFailing(status: CiLegacyStatus): boolean {
@@ -120,7 +103,7 @@ async function loadExternalCi(options: BuildCiSummaryOptions): Promise<ExternalC
     return {
       ok: true,
       checks: checks.filter((run) => !isOwnCiCheckName(run.name)),
-      statuses: statuses.filter((status) => !isOwnCommitStatusContext(status.context)),
+      statuses: statuses.filter((status) => status.context !== OWN_COMMIT_STATUS_CONTEXT),
     };
   } catch (error) {
     if (isMissingChecksPermissionError(error)) {
@@ -148,7 +131,12 @@ function classifySnapshot(
   if (checks.length === 0 && statuses.length === 0) return "none";
   const anyFailing = checks.some(isCheckFailing) || statuses.some(isLegacyFailing);
   if (anyFailing) return "failing";
-  const anyPending = checks.some(isCheckPending) || statuses.some(isLegacyPending);
+  const anyPending =
+    checks.some(
+      (run) =>
+        run.status !== "completed" &&
+        (PENDING_CHECK_STATUSES.has(run.status) || run.conclusion == null),
+    ) || statuses.some((status) => PENDING_LEGACY_STATES.has(status.state));
   if (anyPending) return "pending";
   return "passing";
 }
@@ -165,7 +153,7 @@ async function waitForTerminalCi(options: BuildCiSummaryOptions): Promise<Extern
     if (state !== "pending") return loaded;
     const remaining = deadline - Date.now();
     if (remaining <= 0) break;
-    await sleepMs(Math.min(pollMs, remaining));
+    await new Promise<void>((resolve) => setTimeout(resolve, Math.min(pollMs, remaining)));
     loaded = await loadExternalCi(options);
     if (!loaded.ok) return loaded;
   }
@@ -223,14 +211,6 @@ export function summarizeCiSnapshot(params: {
       return exhaustive;
     }
   }
-}
-
-function checksPermissionSummary(): CiSummary {
-  return {
-    status: "unavailable",
-    headline: REVIEW_CI_SUMMARY_GRANT_CHECKS,
-    failures: [],
-  };
 }
 
 function unavailableSummary(): CiSummary {
@@ -291,7 +271,11 @@ export async function buildCiSummary(options: BuildCiSummaryOptions): Promise<Ci
     const loaded = await waitForTerminalCi(options);
     if (!loaded.ok) {
       return loaded.reason === "checks_permission"
-        ? checksPermissionSummary()
+        ? {
+            status: "unavailable",
+            headline: REVIEW_CI_SUMMARY_GRANT_CHECKS,
+            failures: [],
+          }
         : unavailableSummary();
     }
 

--- a/src/review/ci/analyzeCi.ts
+++ b/src/review/ci/analyzeCi.ts
@@ -76,7 +76,7 @@ export function isOwnCiCheckName(name: string): boolean {
   return name.startsWith(OWN_CHECK_NAME_PREFIX);
 }
 
-export function isOwnCommitStatusContext(context: string): boolean {
+function isOwnCommitStatusContext(context: string): boolean {
   return context === OWN_COMMIT_STATUS_CONTEXT;
 }
 

--- a/src/review/ci/authorCiSummary.ts
+++ b/src/review/ci/authorCiSummary.ts
@@ -80,7 +80,6 @@ export function mergeCiSummaryWithFacts(input: CiAuthorInput, llm: CiSummaryLlmF
   };
 }
 
-/** Production author: one tool-free agent turn, JSON out. Soft-fails to null. */
 export function createAgentCiSummaryAuthor(cfg: Config): CiSummaryAuthor {
   return async (input) => {
     if (input.status !== "failing") {
@@ -122,7 +121,6 @@ export function createAgentCiSummaryAuthor(cfg: Config): CiSummaryAuthor {
   };
 }
 
-/** Facts-only failing summary when the LLM call is skipped or fails. */
 export function factsOnlyFailingSummary(input: CiAuthorInput): CiSummary {
   const nameList = input.failingNames.slice(0, 3).join(", ");
   const more = input.failingNames.length > 3 ? ` (+${input.failingNames.length - 3} more)` : "";

--- a/src/review/ci/ciSummarySchema.ts
+++ b/src/review/ci/ciSummarySchema.ts
@@ -7,20 +7,16 @@ import {
 } from "../../settings/index.js";
 
 /** Structured fields the CI-summary LLM must return (status/names come from server facts). */
-function createCiSummaryLlmSchema() {
-  return z.object({
-    headline: z.string().min(1).max(REVIEW_CI_SUMMARY_HEADLINE_MAX_CHARS),
-    failures: z
-      .array(
-        z.object({
-          name: z.string().min(1).max(200),
-          reason: z.string().min(1).max(REVIEW_CI_SUMMARY_REASON_MAX_CHARS),
-          fixHint: z.string().min(1).max(REVIEW_CI_SUMMARY_FIX_HINT_MAX_CHARS),
-        }),
-      )
-      .max(REVIEW_CI_SUMMARY_MAX_FAILURES),
-  });
-}
-
-export const ciSummaryLlmSchema = createCiSummaryLlmSchema();
+export const ciSummaryLlmSchema = z.object({
+  headline: z.string().min(1).max(REVIEW_CI_SUMMARY_HEADLINE_MAX_CHARS),
+  failures: z
+    .array(
+      z.object({
+        name: z.string().min(1).max(200),
+        reason: z.string().min(1).max(REVIEW_CI_SUMMARY_REASON_MAX_CHARS),
+        fixHint: z.string().min(1).max(REVIEW_CI_SUMMARY_FIX_HINT_MAX_CHARS),
+      }),
+    )
+    .max(REVIEW_CI_SUMMARY_MAX_FAILURES),
+});
 export type CiSummaryLlmFields = z.infer<typeof ciSummaryLlmSchema>;

--- a/src/review/ci/ciSummarySchema.ts
+++ b/src/review/ci/ciSummarySchema.ts
@@ -7,7 +7,7 @@ import {
 } from "../../settings/index.js";
 
 /** Structured fields the CI-summary LLM must return (status/names come from server facts). */
-export function createCiSummaryLlmSchema() {
+function createCiSummaryLlmSchema() {
   return z.object({
     headline: z.string().min(1).max(REVIEW_CI_SUMMARY_HEADLINE_MAX_CHARS),
     failures: z

--- a/src/review/ci/condenseCiLogs.ts
+++ b/src/review/ci/condenseCiLogs.ts
@@ -39,10 +39,6 @@ export function isDeprecationNoiseLine(line: string): boolean {
   return DEPRECATION_NOISE_RE.test(line);
 }
 
-function isErrorSignalLine(line: string): boolean {
-  return ERROR_SIGNAL_RE.test(line) && !isDeprecationNoiseLine(line);
-}
-
 /**
  * Keeps failed-step tails and error lines; drops Node/Actions deprecation noise unless
  * it is the only remaining signal.
@@ -59,7 +55,7 @@ export function condenseJobLogText(
     const line = lines[i] ?? "";
     if (isDeprecationNoiseLine(line)) continue;
     const isMarker = FAILED_STEP_MARKERS.some((re) => re.test(line));
-    const isError = isErrorSignalLine(line);
+    const isError = ERROR_SIGNAL_RE.test(line) && !isDeprecationNoiseLine(line);
     if (isMarker || isError) {
       sawRealError = true;
       const start = Math.max(0, i - 2);

--- a/src/review/ci/condenseCiLogs.ts
+++ b/src/review/ci/condenseCiLogs.ts
@@ -39,7 +39,7 @@ export function isDeprecationNoiseLine(line: string): boolean {
   return DEPRECATION_NOISE_RE.test(line);
 }
 
-export function isErrorSignalLine(line: string): boolean {
+function isErrorSignalLine(line: string): boolean {
   return ERROR_SIGNAL_RE.test(line) && !isDeprecationNoiseLine(line);
 }
 

--- a/src/review/ci/renderCiSummary.ts
+++ b/src/review/ci/renderCiSummary.ts
@@ -38,7 +38,6 @@ export type RenderableCiSummary = CiSummary & {
   readonly status: "passing" | "failing" | "pending" | "unavailable";
 };
 
-/** Whether the CI row should appear in the summary / stub table. */
 export function shouldRenderCiSummaryRow(
   summary: CiSummary | null | undefined,
 ): summary is RenderableCiSummary {
@@ -60,7 +59,6 @@ export function patchCiSummaryCellInCommentBody(body: string, summary: CiSummary
   return body.replace(CI_SUMMARY_CELL_RE, renderCiSummaryCell(summary));
 }
 
-/** True when the body already has a CI cell region (pending or terminal). */
 export function commentBodyHasCiSummaryCell(body: string): boolean {
   return CI_SUMMARY_CELL_RE.test(body);
 }

--- a/src/review/findings/findingPipeline.ts
+++ b/src/review/findings/findingPipeline.ts
@@ -40,11 +40,6 @@ export type PreparedFindingTargets = {
   };
 };
 
-function passesSeverityFloor(severity: ReviewFinding["severity"], severityFloor?: number): boolean {
-  if (severityFloor == null) return true;
-  return REVIEW_SEVERITY_RANK[severity] <= severityFloor;
-}
-
 export function prepareReviewPayloadForPublish(params: {
   payload: ReviewPayload;
   mode: AnyReviewLens;
@@ -61,9 +56,10 @@ export function prepareReviewPayloadForPublish(params: {
   const confidenceFiltered = deduped.filter(
     (finding) => finding.confidence == null || finding.confidence >= minConfidence,
   );
-  const severityFiltered = confidenceFiltered.filter((finding) =>
-    passesSeverityFloor(finding.severity, params.severityFloor),
-  );
+  const severityFiltered = confidenceFiltered.filter((finding) => {
+    if (params.severityFloor == null) return true;
+    return REVIEW_SEVERITY_RANK[finding.severity] <= params.severityFloor;
+  });
   const candidate = { ...normalized, findings: severityFiltered };
   const dedupedCount = normalized.findings.length - deduped.length;
 

--- a/src/review/findings/findingPipeline.ts
+++ b/src/review/findings/findingPipeline.ts
@@ -21,7 +21,6 @@ import {
   type ReviewFinding,
   type ReviewPayload,
 } from "../reviewSchema.js";
-import type { AnyReviewLens } from "../../settings/legacyReviewLenses.js";
 
 export type PreparedReviewPayload = {
   readonly payload: ReviewPayload;
@@ -42,7 +41,6 @@ export type PreparedFindingTargets = {
 
 export function prepareReviewPayloadForPublish(params: {
   payload: ReviewPayload;
-  mode: AnyReviewLens;
   reviewMinConfidence?: number;
   severityFloor?: number;
   cachedDiffIndex?: CachedPrDiffIndex;
@@ -113,7 +111,6 @@ export function prepareReviewPayloadForPublish(params: {
 
 export function prepareFindingsForPublish(params: {
   payload: ReviewPayload;
-  mode: AnyReviewLens;
   cachedDiffIndex?: CachedPrDiffIndex;
   inlinePlacements?: readonly InlinePlacement[];
   storedInlineFingerprints?: readonly string[];

--- a/src/review/findings/reviewFindingDedup.ts
+++ b/src/review/findings/reviewFindingDedup.ts
@@ -8,6 +8,10 @@ type NormalizedFinding = {
   readonly detail: string;
 };
 
+function rangesOverlap(aStart: number, aEnd: number, bStart: number, bEnd: number): boolean {
+  return aStart <= bEnd && bStart <= aEnd;
+}
+
 /** Drop duplicates when same file, overlapping lines, and matching title/detail; keep higher severity. */
 export function dedupeReviewFindings(findings: readonly ReviewFinding[]): ReviewFinding[] {
   const sorted = [...findings].toSorted(compareReviewFindingsBySeverityFileLine);
@@ -23,10 +27,13 @@ export function dedupeReviewFindings(findings: readonly ReviewFinding[]): Review
     const key = `${normalized.finding.file}\0${normalized.title}\0${normalized.detail}`;
     const bucket = buckets.get(key) ?? [];
     if (
-      bucket.some(
-        (existing) =>
-          existing.finding.startLine <= normalized.finding.endLine &&
-          normalized.finding.startLine <= existing.finding.endLine,
+      bucket.some((existing) =>
+        rangesOverlap(
+          existing.finding.startLine,
+          existing.finding.endLine,
+          normalized.finding.startLine,
+          normalized.finding.endLine,
+        ),
       )
     ) {
       continue;

--- a/src/review/findings/reviewFindingDedup.ts
+++ b/src/review/findings/reviewFindingDedup.ts
@@ -2,33 +2,11 @@ import { normalizeFindingSubstance } from "./reviewFindingFingerprint.js";
 import { compareReviewFindingsBySeverityFileLine } from "./reviewFindingSort.js";
 import type { ReviewFinding } from "../reviewSchema.js";
 
-function rangesOverlap(aStart: number, aEnd: number, bStart: number, bEnd: number): boolean {
-  return aStart <= bEnd && bStart <= aEnd;
-}
-
 type NormalizedFinding = {
   readonly finding: ReviewFinding;
   readonly title: string;
   readonly detail: string;
 };
-
-function dedupeKey(finding: NormalizedFinding): string {
-  return `${finding.finding.file}\0${finding.title}\0${finding.detail}`;
-}
-
-function isDuplicateFinding(existing: NormalizedFinding, candidate: NormalizedFinding): boolean {
-  if (
-    !rangesOverlap(
-      existing.finding.startLine,
-      existing.finding.endLine,
-      candidate.finding.startLine,
-      candidate.finding.endLine,
-    )
-  ) {
-    return false;
-  }
-  return true;
-}
 
 /** Drop duplicates when same file, overlapping lines, and matching title/detail; keep higher severity. */
 export function dedupeReviewFindings(findings: readonly ReviewFinding[]): ReviewFinding[] {
@@ -42,9 +20,17 @@ export function dedupeReviewFindings(findings: readonly ReviewFinding[]): Review
       title: normalizeFindingSubstance(candidate.title),
       detail: normalizeFindingSubstance(candidate.detail),
     };
-    const key = dedupeKey(normalized);
+    const key = `${normalized.finding.file}\0${normalized.title}\0${normalized.detail}`;
     const bucket = buckets.get(key) ?? [];
-    if (bucket.some((existing) => isDuplicateFinding(existing, normalized))) continue;
+    if (
+      bucket.some(
+        (existing) =>
+          existing.finding.startLine <= normalized.finding.endLine &&
+          normalized.finding.startLine <= existing.finding.endLine,
+      )
+    ) {
+      continue;
+    }
     bucket.push(normalized);
     buckets.set(key, bucket);
     kept.push(candidate);

--- a/src/review/findings/reviewFindingValidator.ts
+++ b/src/review/findings/reviewFindingValidator.ts
@@ -37,17 +37,13 @@ export type ReviewPayloadValidationResult =
       readonly anchorFailures: readonly AnchorFailure[];
     };
 
-function formatRangePair([start, end]: [number, number]): string {
-  return start === end ? `${start}` : `${start}-${end}`;
-}
-
 function formatSuggestedRanges(ranges: CommentableRightLineRanges): string {
   const shown = ranges.slice(0, REVIEW_ANCHOR_MENU_MAX_RANGES_PER_FILE);
   const suffix =
     ranges.length > REVIEW_ANCHOR_MENU_MAX_RANGES_PER_FILE
       ? ` …${ranges.length - REVIEW_ANCHOR_MENU_MAX_RANGES_PER_FILE} more ranges`
       : "";
-  return `${shown.map(formatRangePair).join(", ")}${suffix}`;
+  return `${shown.map(([start, end]) => (start === end ? `${start}` : `${start}-${end}`)).join(", ")}${suffix}`;
 }
 
 function validatePlacementAnchor(

--- a/src/review/orchestrator/orchestratorRun.ts
+++ b/src/review/orchestrator/orchestratorRun.ts
@@ -86,12 +86,6 @@ async function settleBefore<T>(
   return result;
 }
 
-function tokenTtlMs(value: number | undefined): number {
-  return typeof value === "number" && Number.isFinite(value) && value > 0
-    ? value
-    : TOKEN_FRESHNESS_BUFFER_MS;
-}
-
 function initialState(): OrchestratedRunState {
   return {
     recon: "running",
@@ -233,7 +227,12 @@ export async function runOrchestratedPrReview(
   });
   const setup = buildReviewRunSetup({
     ...params,
-    tokenTtlMs: tokenTtlMs(params.tokenTtlMs),
+    tokenTtlMs:
+      typeof params.tokenTtlMs === "number" &&
+      Number.isFinite(params.tokenTtlMs) &&
+      params.tokenTtlMs > 0
+        ? params.tokenTtlMs
+        : TOKEN_FRESHNESS_BUFFER_MS,
   });
   const briefTool = buildSpecialistBriefTool();
   const state = initialState();

--- a/src/review/orchestrator/orchestratorTypes.ts
+++ b/src/review/orchestrator/orchestratorTypes.ts
@@ -25,7 +25,7 @@ export type SpecialistOutcome =
       readonly durationMs: number;
     };
 
-export type ReviewRunGateResult =
+type ReviewRunGateResult =
   | { readonly kind: "continue" }
   | { readonly kind: "stop"; readonly reason: "superseded" | "stale_head" }
   | { readonly kind: "finalize"; readonly reason: "deadline" };

--- a/src/review/orchestrator/publishSummaryTool.ts
+++ b/src/review/orchestrator/publishSummaryTool.ts
@@ -26,7 +26,7 @@ const summaryFindingCopySchema = z.object({
   category: reviewFindingSchema.shape.category,
 });
 
-export const publishSummarySchema = createReviewPayloadSchema()
+const publishSummarySchema = createReviewPayloadSchema()
   .omit({ findings: true })
   .extend({
     findings: z.array(summaryFindingCopySchema).max(MAX_REVIEW_PAYLOAD_FINDINGS),

--- a/src/review/orchestrator/publishThreadTool.ts
+++ b/src/review/orchestrator/publishThreadTool.ts
@@ -14,11 +14,11 @@ import {
   type SpecialistId,
 } from "./orchestratorTypes.js";
 
-export const publishThreadSchema = z.object({
+const publishThreadSchema = z.object({
   findings: z.array(reviewFindingSchema),
 });
 
-export type PublishedThreadOverlapHint = {
+type PublishedThreadOverlapHint = {
   readonly findingId: string;
   readonly severity: ReviewFinding["severity"];
   readonly file: string;

--- a/src/review/orchestrator/specialistRun.ts
+++ b/src/review/orchestrator/specialistRun.ts
@@ -47,17 +47,28 @@ type SubmissionState = {
   validationError: string | null;
 };
 
-function timeoutError(): Error {
-  return new Error("Specialist timeout deadline exceeded");
+function timeoutError(): AppError {
+  return new AppError({
+    code: "review.specialist_timeout",
+    message: "Specialist timeout deadline exceeded",
+  });
 }
 
-function externalAbortError(): Error {
-  return new Error("Specialist run aborted by external signal");
+function externalAbortError(): AppError {
+  return new AppError({
+    code: "review.specialist_aborted",
+    message: "Specialist run aborted by external signal",
+  });
 }
 
 function assertCanContinue(params: RunSpecialistParams, deadlineMs: number): void {
   if (params.signal?.aborted) throw externalAbortError();
-  if (!params.shouldContinue()) throw new Error("Specialist run stopped before completion");
+  if (!params.shouldContinue()) {
+    throw new AppError({
+      code: "review.specialist_stopped",
+      message: "Specialist run stopped before completion",
+    });
+  }
   if (Date.now() >= deadlineMs) throw timeoutError();
 }
 
@@ -259,7 +270,10 @@ async function runAttempt(
 
     if (!state.report) {
       assertCanContinue(params, deadlineMs);
-      throw new Error(state.validationError ?? "Specialist did not submit a valid report");
+      throw new AppError({
+        code: "review.specialist_invalid_report",
+        message: state.validationError ?? "Specialist did not submit a valid report",
+      });
     }
     return state.report;
   } finally {
@@ -296,7 +310,10 @@ export async function runSpecialist(params: RunSpecialistParams): Promise<Specia
   const deadlineMs = startedAtMs + params.timeoutMs;
   let attempts = 0;
   let ordinaryRetryUsed = false;
-  let lastError: unknown = new Error("Specialist did not start");
+  let lastError: unknown = new AppError({
+    code: "review.specialist_not_started",
+    message: "Specialist did not start",
+  });
   let classification: ProviderErrorKind = "unknown";
 
   try {

--- a/src/review/orchestrator/specialistRun.ts
+++ b/src/review/orchestrator/specialistRun.ts
@@ -55,13 +55,9 @@ function externalAbortError(): Error {
   return new Error("Specialist run aborted by external signal");
 }
 
-function stoppedError(): Error {
-  return new Error("Specialist run stopped before completion");
-}
-
 function assertCanContinue(params: RunSpecialistParams, deadlineMs: number): void {
   if (params.signal?.aborted) throw externalAbortError();
-  if (!params.shouldContinue()) throw stoppedError();
+  if (!params.shouldContinue()) throw new Error("Specialist run stopped before completion");
   if (Date.now() >= deadlineMs) throw timeoutError();
 }
 
@@ -271,10 +267,6 @@ async function runAttempt(
   }
 }
 
-function retryBackoffMs(attempts: number): number {
-  return RETRY_BACKOFF_BASE_MS * 2 ** Math.max(0, attempts - 1);
-}
-
 function failureOutcome(params: {
   readonly specialist: SpecialistId;
   readonly startedAtMs: number;
@@ -346,7 +338,11 @@ export async function runSpecialist(params: RunSpecialistParams): Promise<Specia
 
     if (classification === "rate_limit" || classification === "timeout") {
       try {
-        await waitBeforeStage(retryBackoffMs(attempts), params, deadlineMs);
+        await waitBeforeStage(
+          RETRY_BACKOFF_BASE_MS * 2 ** Math.max(0, attempts - 1),
+          params,
+          deadlineMs,
+        );
       } catch (error) {
         lastError = error;
         classification = classifyProviderError(error);

--- a/src/review/orchestrator/stubTick.ts
+++ b/src/review/orchestrator/stubTick.ts
@@ -3,7 +3,7 @@ import { logWarn } from "../../evlog.js";
 import type { AnyReviewLens } from "../../settings/legacyReviewLenses.js";
 import type { CiSummary } from "../ci/ciSummaryTypes.js";
 import { upsertSummaryCommentWithCreationClaim } from "../publish/publishReview.js";
-import { reviewSummarySentinelForMode, type WorkSource } from "../reviewSchema.js";
+import { REVIEW_SUMMARY_SENTINEL, type WorkSource } from "../reviewSchema.js";
 import { renderReviewProgressComment, type SpecialistTickState } from "../run/progressComment.js";
 
 type ProgressTickRevision = 1 | 2 | 3 | 4 | 5;
@@ -62,7 +62,7 @@ export async function tickProgressComment(args: TickProgressCommentArgs): Promis
         progressRevision: args.progressRevision,
         progressWorkItemId: args.workItemId,
       }),
-      sentinel: reviewSummarySentinelForMode(args.mode),
+      sentinel: REVIEW_SUMMARY_SENTINEL,
       expiresAtTs,
       hintCommentId: args.hintCommentId,
       progressRevision: args.progressRevision,

--- a/src/review/placement/reviewDiffIndex.ts
+++ b/src/review/placement/reviewDiffIndex.ts
@@ -175,10 +175,6 @@ export function resolveInlineAnchorLine(
   return anchor;
 }
 
-function formatRangePair([start, end]: [number, number]): string {
-  return start === end ? `${start}` : `${start}-${end}`;
-}
-
 export function renderAnchorMenuBlock(
   index: CachedPrDiffIndex,
   caps: { maxFiles: number; maxRangesPerFile: number },
@@ -196,7 +192,9 @@ export function renderAnchorMenuBlock(
   const shown = entries.slice(0, caps.maxFiles);
   for (const [filename, file] of shown) {
     const ranges = file.commentableRightLineRanges.slice(0, caps.maxRangesPerFile);
-    const formatted = ranges.map(formatRangePair).join(", ");
+    const formatted = ranges
+      .map(([start, end]) => (start === end ? `${start}` : `${start}-${end}`))
+      .join(", ");
     const rangeSuffix =
       file.commentableRightLineRanges.length > caps.maxRangesPerFile
         ? ` …${file.commentableRightLineRanges.length - caps.maxRangesPerFile} more ranges`

--- a/src/review/placement/reviewPathProfile.ts
+++ b/src/review/placement/reviewPathProfile.ts
@@ -7,16 +7,17 @@ export type ReviewPathProfile = {
   readonly riskCategories: readonly ReviewPathRiskCategory[];
 };
 
-function matchesCategory(filename: string, category: ReviewPathRiskCategory): boolean {
-  return REVIEW_RISK_PATH_PATTERNS[category].some((pattern) => pattern.test(filename));
-}
-
 export function buildReviewPathProfile(changedFiles: readonly string[]): ReviewPathProfile {
   const found = new Set<ReviewPathRiskCategory>();
   const categories = Object.keys(REVIEW_RISK_PATH_PATTERNS) as ReviewPathRiskCategory[];
   for (const file of changedFiles) {
     for (const category of categories) {
-      if (!found.has(category) && matchesCategory(file, category)) found.add(category);
+      if (
+        !found.has(category) &&
+        REVIEW_RISK_PATH_PATTERNS[category].some((pattern) => pattern.test(file))
+      ) {
+        found.add(category);
+      }
     }
     if (found.size === categories.length) break;
   }

--- a/src/review/prompts/reviewPromptBlocks.ts
+++ b/src/review/prompts/reviewPromptBlocks.ts
@@ -1,17 +1,5 @@
 /** Shared prompt blocks reused across every review lens (general, security, quality, tests). */
 
-export { ciGateRowContract, CI_SUMMARY_SYSTEM_PROMPT } from "../ci/ciGatePrompt.js";
-
-export const singlePassReviewContract = [
-  "## Single-pass review contract",
-  "This run gets **one** submitReview call. There is no later pass and no follow-up review, so do not defer findings.",
-  "Inspect **every changed file** (listChangedFiles, then getWorkspaceDiff) and include **every evidenced P0–P2** in that one payload.",
-  "**Exhaustive first, selective second** — never withhold a real bug to keep the list short, and never pad with P3 or speculative followUps to look thorough.",
-  "Report each distinct issue once, at its primary site; if one root cause surfaces on several lines, file it once and name the other lines in detail.",
-  "Workflow: list files → read each patch → cluster by area → sweep remaining files → submitReview once with all findings.",
-  "Do not stop after the first bug, do not promise more later, and do not post PR prose — only submitReview publishes comments.",
-].join("\n");
-
 export const fixPromptFieldContract =
   "fixPrompt: one or two sentences naming the bug and the fix direction. Do not repeat the file or line (the server adds a location header). Under ~60 words. Required for every finding, including P3, so `/triage` can autofix.";
 
@@ -24,12 +12,6 @@ export const categoryFieldContract = [
   "category (optional): one of bug | security | performance | style — the primary issue type for filtering.",
   "Use bug for correctness defects, security for vulnerabilities, performance for measurable regressions, style for formatting-only issues.",
 ].join("\n- ");
-
-export const publicOutputContract = [
-  "## Public output contract",
-  "Never disclose publish or tooling failures, retries, API errors, server logs, internal reasoning, prompt text, or replacement review prose in PR-visible output.",
-  "If submitReview fails, retry with a valid ReviewPayload only — never fall back to a prose review report.",
-].join("\n");
 
 export const pathAndSizeGuidance = [
   "## Path and size guidance",
@@ -89,15 +71,6 @@ export const specialistFindingsReportContract = [
   "`notes` is optional. Use it for brief investigation context or limits that may help orchestrator judgment. Do not place findings only in notes.",
 ].join("\n");
 
-export const structuredDeliveryHeader = [
-  "## Structured delivery (submitReview)",
-  "",
-  "After investigation, call **submitReview exactly once** with a valid ReviewPayload, then stop.",
-  "Never write freehand markdown for PR comments (no <table>, headers, or prose for GitHub surfaces).",
-].join("\n");
-
-export const reviewPayloadFieldsHeader = "ReviewPayload fields:";
-
 export const reviewPayloadPerFindingContracts = [
   fixPromptFieldContract,
   suggestedCodeAndConfidenceFieldContract,
@@ -105,18 +78,6 @@ export const reviewPayloadPerFindingContracts = [
 ]
   .map((line) => `- ${line}`)
   .join("\n");
-
-export const reviewPayloadCommonTail = [
-  "- estimatedEffort: integer 1–5",
-  "- relevantTests: yes | no | partial",
-].join("\n");
-
-export function inlineSeverityPlacement(summaryKind: string): string {
-  return `P0–P3 appear as inline review threads on changed lines when a diff anchor resolves; otherwise they appear as title + deep-link in the ${summaryKind} summary overview. Check runs still fail only for P0–P2.`;
-}
-
-export const reviewSecretsAndToolingNote =
-  "Do not leak secrets or tokens; if access is insufficient, say exactly what tooling blocked you.";
 
 /** Round-0 validation repair: include the full minimal example. */
 export const VALIDATION_REPAIR_ROUND0_SUFFIX =

--- a/src/review/publish/publishFindingBatch.ts
+++ b/src/review/publish/publishFindingBatch.ts
@@ -29,7 +29,7 @@ import type {
   FindingSource,
 } from "../orchestrator/orchestratorTypes.js";
 
-export type StoredInlineBatch = {
+type StoredInlineBatch = {
   readonly version: 2;
   readonly batchId: string;
   readonly workItemId: string;

--- a/src/review/publish/publishFindingBatch.ts
+++ b/src/review/publish/publishFindingBatch.ts
@@ -97,12 +97,6 @@ function emptyDelta(overrides?: Partial<FindingLedgerDelta>): FindingLedgerDelta
   };
 }
 
-function isSuppressed(placement: FingerprintedInlinePlacement, ledger: FindingLedger): boolean {
-  return fingerprintCandidates(placement.finding).some((candidate) =>
-    ledger.suppressionFingerprints.has(candidate),
-  );
-}
-
 function hasAcceptedFingerprint(
   placement: FingerprintedInlinePlacement,
   ledger: FindingLedger,
@@ -136,7 +130,11 @@ function acceptedSummaryPlacements(params: {
     params.planned.map((placement) => [reviewFindingPlacementKey(placement.finding), placement]),
   );
   return params.targets.flatMap((placement) => {
-    if (isSuppressed(placement, params.ledger)) {
+    if (
+      fingerprintCandidates(placement.finding).some((candidate) =>
+        params.ledger.suppressionFingerprints.has(candidate),
+      )
+    ) {
       if (hasAcceptedFingerprint(placement, params.ledger)) return [];
       return [summaryOnlyPlacement(placement, params.source, "historical")];
     }

--- a/src/review/publish/publishFindingBatch.ts
+++ b/src/review/publish/publishFindingBatch.ts
@@ -171,7 +171,6 @@ export async function publishFindingBatch(
 ): Promise<FindingBatchResult> {
   const prepared = prepareReviewPayloadForPublish({
     payload: batchPayload(batch),
-    mode: "review",
     cachedDiffIndex: context.cachedDiffIndex,
     enforceInlineAnchorValidation: false,
   });
@@ -188,7 +187,6 @@ export async function publishFindingBatch(
   );
   const targets = prepareFindingsForPublish({
     payload: prepared.prepared.payload,
-    mode: "review",
     cachedDiffIndex: context.cachedDiffIndex,
     inlinePlacements: prepared.prepared.placements,
     storedInlineFingerprints: [...context.ledger.suppressionFingerprints],

--- a/src/review/publish/publishReview.ts
+++ b/src/review/publish/publishReview.ts
@@ -17,11 +17,6 @@ export {
   attachSummaryCommentCoordination,
   upsertSummaryCommentWithCreationClaim,
 } from "./publishSummaryOnly.js";
-export type {
-  RecordPublishStepFn,
-  RecordPublishStepWithCoordination,
-  SummaryCommentCoordination,
-} from "./publishSummaryOnly.js";
 
 export async function publishReview(
   params: ReviewPublishContext & {

--- a/src/review/publish/publishSummaryOnly.ts
+++ b/src/review/publish/publishSummaryOnly.ts
@@ -74,10 +74,6 @@ export function attachSummaryCommentCoordination(
   return Object.assign(recordPublishStep, { summaryCommentCoordination: coordination });
 }
 
-function sleepMs(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 async function resolveKnownSummaryCommentRef(
   token: string,
   owner: string,
@@ -213,7 +209,7 @@ async function upsertSummaryCommentWithoutRevision(
         REVIEW_PUBLISH_TRANSIENT_RETRY_DELAYS_MS[attempt - 1] ??
         REVIEW_PUBLISH_TRANSIENT_RETRY_DELAYS_MS.at(-1) ??
         0;
-      await sleepMs(delay);
+      await new Promise<void>((resolve) => setTimeout(resolve, delay));
     }
     const polledId = await getSummaryCommentGithubId(pool, resourceKey, reviewLens);
     if (polledId == null) continue;

--- a/src/review/publish/publishSummaryOnly.ts
+++ b/src/review/publish/publishSummaryOnly.ts
@@ -47,7 +47,7 @@ import { resolveReviewWallClockMs } from "../run/reviewRunFooter.js";
 import { snapshotReviewRunMetrics } from "../run/reviewRunMetrics.js";
 import { parseProgressRevisionState, withProgressRevisionComment } from "../run/progressComment.js";
 import {
-  reviewSummarySentinelForMode,
+  REVIEW_SUMMARY_SENTINEL,
   type ReviewPayload,
   type ReviewPublishContext,
 } from "../reviewSchema.js";
@@ -411,7 +411,7 @@ export async function publishReviewSummaryOnly(params: {
   const partialCoverageNote = coverage.kind === "partial" ? coverage.note : undefined;
   const { owner, repo, prNumber, headSha } = params.ctx;
   const mode = params.mode ?? "review";
-  const summarySentinel = reviewSummarySentinelForMode(mode);
+  const summarySentinel = REVIEW_SUMMARY_SENTINEL;
   const summaryPlacements = params.ledger.accepted.map((accepted) => accepted.placement);
   const reviewComments: Awaited<ReturnType<typeof listPullRequestReviewCommentsForReview>> = [];
   for (const inlineReviewId of params.ledger.inlineReviewIds) {
@@ -676,13 +676,13 @@ export async function publishReviewSummaryOnly(params: {
         security: syncSecurityLabel,
         category: syncCategoryLabels,
       };
-      if (labelsAlreadySynced(currentLabels, params.payload, options, mode)) {
+      if (labelsAlreadySynced(currentLabels, params.payload, options)) {
         await params.recordPublishStep?.("labels", {
           meta: { labels: currentLabels, alreadySynced: true },
         });
       } else {
-        const managed = reviewLabelsFromPayload(params.payload, options, mode);
-        const next = syncReviewLabels(currentLabels, managed, mode);
+        const managed = reviewLabelsFromPayload(params.payload, options);
+        const next = syncReviewLabels(currentLabels, managed);
         await params.refreshLiveAuth?.();
         const labelsWriteToken = params.getToken();
         const labelsWriteTokenExpiresAtTs = params.getTokenExpiresAtTs?.();

--- a/src/review/publish/publishSummaryOnly.ts
+++ b/src/review/publish/publishSummaryOnly.ts
@@ -99,7 +99,7 @@ async function resolveKnownSummaryCommentRef(
   return resolved ? { id: resolved.id, url: resolved.url } : null;
 }
 
-export type ProgressCommentRevision = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+type ProgressCommentRevision = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
 type SummaryCommentUpsertResult = {
   readonly id: number;

--- a/src/review/publish/submitReviewTool.ts
+++ b/src/review/publish/submitReviewTool.ts
@@ -18,7 +18,7 @@ import {
   coerceReviewPayloadInput,
   createReviewPayloadSchema,
   formatReviewValidationError,
-  reviewSummarySentinelForMode,
+  REVIEW_SUMMARY_SENTINEL,
   type ReviewPublishContext,
 } from "../reviewSchema.js";
 import type { AnyReviewLens } from "../../settings/legacyReviewLenses.js";
@@ -85,7 +85,7 @@ export function buildSubmitReviewTool(params: {
 } {
   const mode = params.mode ?? "review";
 
-  const summarySentinel = reviewSummarySentinelForMode(mode);
+  const summarySentinel = REVIEW_SUMMARY_SENTINEL;
   const piTool: PiTool = {
     name: "submitReview",
     description: [
@@ -170,7 +170,6 @@ export function buildSubmitReviewTool(params: {
 
     const prepared = prepareReviewPayloadForPublish({
       payload: parsed.data,
-      mode,
       reviewMinConfidence: REVIEW_MIN_CONFIDENCE,
       severityFloor: params.severityFloor,
       cachedDiffIndex: params.cachedDiffIndex,

--- a/src/review/repoPolicy.ts
+++ b/src/review/repoPolicy.ts
@@ -20,7 +20,7 @@ const frontmatterSchema = z
   })
   .passthrough();
 
-export type RepoPolicyRule = {
+type RepoPolicyRule = {
   readonly filename: string;
   readonly relativePath: string;
   readonly alwaysApply: boolean;

--- a/src/review/reviewSchema.ts
+++ b/src/review/reviewSchema.ts
@@ -88,25 +88,6 @@ export type ReviewPublishContext = {
   hasDescriptionAgentBlock: boolean;
 };
 
-export const REVIEW_PAYLOAD_MINIMAL_EXAMPLE = {
-  prCharacter: "Adds retry logic to the webhook dispatcher.",
-  findings: [
-    {
-      severity: "P1",
-      file: "src/handler.ts",
-      startLine: 42,
-      endLine: 42,
-      title: "Missing await on promise",
-      detail: "The handler returns before the async work completes.",
-      fixPrompt: "Await the promise before returning so errors propagate.",
-    },
-  ],
-  estimatedEffort: 2,
-  relevantTests: "partial",
-  securityConcerns: null,
-  followUps: [],
-} as const;
-
 const SEVERITY_ALIAS: Record<string, ReviewFinding["severity"]> = {
   CRITICAL: "P0",
   HIGH: "P1",

--- a/src/review/reviewSchema.ts
+++ b/src/review/reviewSchema.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import type { AnyReviewLens } from "../settings/legacyReviewLenses.js";
 import {
   MAX_REVIEW_FOLLOW_UPS,
   MAX_REVIEW_PAYLOAD_FINDINGS,
@@ -12,7 +11,6 @@ import {
   REVIEW_FOLLOW_UP_MAX_CHARS,
   REVIEW_OVERVIEW_MAX_CHARS,
   REVIEW_SECURITY_CONCERNS_MAX_CHARS,
-  REVIEW_SUMMARY_SENTINEL,
   type ReviewValidationFailureKind,
 } from "../settings/index.js";
 import { compareReviewFindingsBySeverityFileLine } from "./findings/reviewFindingSort.js";
@@ -24,10 +22,6 @@ export type ReviewMode = "review";
 
 /** How a review run was triggered (automated webhook vs slash command). */
 export type WorkSource = "auto" | "slash";
-
-export function reviewSummarySentinelForMode(_mode: AnyReviewLens): string {
-  return REVIEW_SUMMARY_SENTINEL;
-}
 
 const severitySchema = z.enum(["P0", "P1", "P2", "P3"]);
 

--- a/src/review/run/progressComment.ts
+++ b/src/review/run/progressComment.ts
@@ -90,12 +90,6 @@ function renderSpecialistPhase(state: SpecialistPhase): string {
   }
 }
 
-function renderTerminalProgress(source: WorkSource): string {
-  return source === "slash"
-    ? "Superseded. Rescheduled for new head."
-    : "Superseded by a newer pull request update.";
-}
-
 /** Ack stub: Recon running, specialists waiting. */
 export function initialProgressTickState(): Extract<SpecialistTickState, { kind: "specialists" }> {
   return {
@@ -176,7 +170,9 @@ export function renderReviewProgressComment(params: {
   }
   const progressNote =
     params.tickState?.kind === "terminal"
-      ? renderTerminalProgress(params.source)
+      ? params.source === "slash"
+        ? "Superseded. Rescheduled for new head."
+        : "Superseded by a newer pull request update."
       : REVIEW_PROGRESS_NOTE;
   return [
     reviewSummarySentinelForMode(params.mode),

--- a/src/review/run/progressComment.ts
+++ b/src/review/run/progressComment.ts
@@ -38,7 +38,7 @@ const PROGRESS_REVISION_RE =
 
 type SpecialistPhase = SpecialistRunPhase;
 
-export type ReconPhase = ReconRunPhase;
+type ReconPhase = ReconRunPhase;
 
 export type SpecialistTickState =
   | {
@@ -110,7 +110,7 @@ export function initialProgressTickState(): Extract<SpecialistTickState, { kind:
   };
 }
 
-export function renderProgressRevisionComment(revision: number, workItemId?: string): string {
+function renderProgressRevisionComment(revision: number, workItemId?: string): string {
   return workItemId == null
     ? `<!-- pr-agent:progress-revision ${revision} -->`
     : `<!-- pr-agent:progress-revision workItemId=${encodeURIComponent(workItemId)} value=${revision} -->`;

--- a/src/review/run/progressComment.ts
+++ b/src/review/run/progressComment.ts
@@ -20,7 +20,7 @@ import {
   REVIEW_PROGRESS_SOURCE_AUTO,
   REVIEW_PROGRESS_SOURCE_SLASH,
 } from "../../settings/index.js";
-import { reviewSummarySentinelForMode } from "../reviewSchema.js";
+import { REVIEW_SUMMARY_SENTINEL } from "../reviewSchema.js";
 import type { AnyReviewLens } from "../../settings/legacyReviewLenses.js";
 import type { WorkSource } from "../reviewSchema.js";
 import type { CiSummary } from "../ci/ciSummaryTypes.js";
@@ -175,7 +175,7 @@ export function renderReviewProgressComment(params: {
         : "Superseded by a newer pull request update."
       : REVIEW_PROGRESS_NOTE;
   return [
-    reviewSummarySentinelForMode(params.mode),
+    REVIEW_SUMMARY_SENTINEL,
     "",
     renderGitHubAlert(REVIEW_OVERVIEW_ALERT, progressNote),
     "",
@@ -195,7 +195,7 @@ export function renderReviewFailureNotice(params: {
   retryCommand: string;
 }): string {
   return [
-    reviewSummarySentinelForMode(params.mode),
+    REVIEW_SUMMARY_SENTINEL,
     "",
     renderGitHubAlert(
       REVIEW_FAILURE_ALERT,

--- a/src/review/run/reviewChangeGate.ts
+++ b/src/review/run/reviewChangeGate.ts
@@ -1,5 +1,3 @@
-/** Docs-only trivial change exemption for automated reviews. */
-
 import path from "node:path";
 
 export type PreflightFileEntry = {

--- a/src/review/run/reviewLabels.ts
+++ b/src/review/run/reviewLabels.ts
@@ -36,10 +36,6 @@ function categoryLabelForPayload(payload: ReviewPayload): string | undefined {
   return category == null ? undefined : `${LABEL_CATEGORY_PREFIX}${category}`;
 }
 
-function currentCategoryLabel(currentLabels: readonly string[]): string | undefined {
-  return currentLabels.find((label) => label.startsWith(LABEL_CATEGORY_PREFIX));
-}
-
 export function hasManagedCategoryLabel(currentLabels: readonly string[]): boolean {
   return currentLabels.some((label) => label.startsWith(LABEL_CATEGORY_PREFIX));
 }
@@ -62,7 +58,8 @@ export function labelsAlreadySynced(
   }
   if (opts.category) {
     const wantsCategory = categoryLabelForPayload(payload);
-    if (currentCategoryLabel(currentLabels) !== wantsCategory) return false;
+    if (currentLabels.find((label) => label.startsWith(LABEL_CATEGORY_PREFIX)) !== wantsCategory)
+      return false;
   }
   return true;
 }

--- a/src/review/run/reviewLabels.ts
+++ b/src/review/run/reviewLabels.ts
@@ -9,7 +9,6 @@ import {
   type ReviewFindingCategory,
   type ReviewPayload,
 } from "../reviewSchema.js";
-import type { AnyReviewLens } from "../../settings/legacyReviewLenses.js";
 
 export function dominantReviewCategory(
   findings: readonly ReviewFinding[],
@@ -44,7 +43,6 @@ export function labelsAlreadySynced(
   currentLabels: string[],
   payload: ReviewPayload,
   opts: { effort: boolean; security: boolean; category: boolean },
-  _mode: AnyReviewLens = "review",
 ): boolean {
   if (opts.effort) {
     const effortPrefix = LABEL_REVIEW_EFFORT_PREFIX;
@@ -67,7 +65,6 @@ export function labelsAlreadySynced(
 export function reviewLabelsFromPayload(
   payload: ReviewPayload,
   opts: { effort: boolean; security: boolean; category: boolean },
-  _mode: AnyReviewLens = "review",
 ): string[] {
   const labels: string[] = [];
   if (opts.effort) {
@@ -83,11 +80,7 @@ export function reviewLabelsFromPayload(
   return labels;
 }
 
-export function syncReviewLabels(
-  currentLabels: string[],
-  nextManaged: string[],
-  _mode: AnyReviewLens = "review",
-): string[] {
+export function syncReviewLabels(currentLabels: string[], nextManaged: string[]): string[] {
   const preserved = currentLabels.filter(
     (name) =>
       !name.startsWith(LABEL_REVIEW_EFFORT_PREFIX) &&

--- a/src/review/run/reviewPriorFeedback.ts
+++ b/src/review/run/reviewPriorFeedback.ts
@@ -68,10 +68,6 @@ function extractBotSeverity(body: string): BotFindingThread["severity"] {
   return match ? (`P${match[1]}` as BotFindingThread["severity"]) : null;
 }
 
-function isTriageEligibleLens(lens: AnyReviewLens): boolean {
-  return isAnyReviewLens(lens);
-}
-
 const REVIEW_POINTER_LENS_MARKER_RE = /<!--\s*pr-agent:review-pointer\s+lens=([^\s>]+)\s*-->/;
 
 function findVerificationStubCommentId(
@@ -204,7 +200,7 @@ async function listBotReviewIds(
   for (const review of reviews) {
     if (review.user?.id !== botUserId || review.id == null) continue;
     const lens = classifyReviewLensFromPointerBody(review.body ?? "");
-    if (lens && isTriageEligibleLens(lens)) reviewIds.add(review.id);
+    if (lens && isAnyReviewLens(lens)) reviewIds.add(review.id);
   }
   return reviewIds;
 }
@@ -237,7 +233,7 @@ async function listBotReviewIdsForTriage(
   for (const review of reviews) {
     if (review.user?.id !== botUserId || review.id == null) continue;
     const lens = resolveReviewLensForTriage(review.body ?? "", review.id, publishRecordLenses);
-    if (lens && isTriageEligibleLens(lens)) {
+    if (lens && isAnyReviewLens(lens)) {
       reviewIds.set(review.id, lens);
     }
   }

--- a/src/review/run/reviewRender.ts
+++ b/src/review/run/reviewRender.ts
@@ -31,7 +31,7 @@ import {
 import { compareReviewFindingsBySeverityFileLine } from "../findings/reviewFindingSort.js";
 import { reviewFindingPlacementKey } from "../placement/reviewDiffPlacement.js";
 import type { ReviewFinding, ReviewPayload, ReviewPublishContext } from "../reviewSchema.js";
-import { reviewSummarySentinelForMode } from "../reviewSchema.js";
+import { REVIEW_SUMMARY_SENTINEL } from "../reviewSchema.js";
 import type { AnyReviewLens } from "../../settings/legacyReviewLenses.js";
 import type { FindingSource } from "../orchestrator/orchestratorTypes.js";
 import type { InlinePlacement } from "../placement/reviewDiffPlacement.js";
@@ -83,10 +83,9 @@ export function renderRepeatNoBugsReviewBody(
 }
 
 export function renderLightweightReviewCompletion(
-  mode: AnyReviewLens,
   footer: { readonly headSha: string } & ReviewRunFooterMeta,
 ): string {
-  const summarySentinel = reviewSummarySentinelForMode(mode);
+  const summarySentinel = REVIEW_SUMMARY_SENTINEL;
   const rows: string[] = [];
   rows.push(summarySentinel);
   rows.push("");
@@ -103,7 +102,6 @@ export function renderLightweightReviewCompletion(
   rows.push(
     renderReviewRunFooter({
       headSha: footer.headSha,
-      mode,
       durationMs: footer.durationMs,
       model: footer.model,
     }),
@@ -451,7 +449,6 @@ function buildReviewSummaryBody(
   rows.push(
     renderReviewRunFooter({
       headSha: ctx.headSha,
-      mode: ctx.mode,
       durationMs: ctx.runFooter.durationMs,
       model: ctx.runFooter.model,
     }),

--- a/src/review/run/reviewRender.ts
+++ b/src/review/run/reviewRender.ts
@@ -116,14 +116,10 @@ export function renderStaleReviewMetadataComment(params: {
   mode: AnyReviewLens;
   stale: boolean;
 }): string {
-  const headSha = sanitizeReviewMetaHeadSha(params.headSha);
+  const headSha = normalizeGitHeadSha(params.headSha) ?? "invalid";
   const lens = escapeHtmlCommentAttr(params.mode);
   const staleValue = params.stale ? "true" : "false";
   return `<!-- pr-agent:review-meta headSha=${headSha} lens=${lens} stale=${staleValue} -->`;
-}
-
-function sanitizeReviewMetaHeadSha(headSha: string): string {
-  return normalizeGitHeadSha(headSha) ?? "invalid";
 }
 
 function escapeHtmlCommentAttr(value: string): string {
@@ -132,16 +128,6 @@ function escapeHtmlCommentAttr(value: string): string {
 
 function formatLineRange(startLine: number, endLine: number): string {
   return startLine === endLine ? `line ${startLine}` : `lines ${startLine}-${endLine}`;
-}
-
-function sortPlacements(placements: readonly InlinePlacement[]): InlinePlacement[] {
-  return [...placements].toSorted((a, b) =>
-    compareReviewFindingsBySeverityFileLine(a.finding, b.finding),
-  );
-}
-
-function sortFindingsForAgentFixPrompt(findings: ReviewFinding[]): ReviewFinding[] {
-  return [...findings].toSorted(compareReviewFindingsBySeverityFileLine);
 }
 
 function renderFindingFixBlock(finding: ReviewFinding, opts: { inlinePosted: boolean }): string {
@@ -271,7 +257,7 @@ export function renderAgentFixPrompt(
   const placementByKey = new Map(
     placements.map((placement) => [reviewFindingPlacementKey(placement.finding), placement]),
   );
-  const sorted = sortFindingsForAgentFixPrompt(payload.findings);
+  const sorted = [...payload.findings].toSorted(compareReviewFindingsBySeverityFileLine);
 
   const blocks = sorted.map((f) => {
     const placement = placementByKey.get(reviewFindingPlacementKey(f));
@@ -340,7 +326,7 @@ type ReviewSummaryRenderCtx = RenderContext & {
   partialCoverageNote?: string;
 };
 
-/** Expects `ctx.placements` pre-sorted by severity, file, and line (`sortPlacements`). */
+/** Expects `ctx.placements` pre-sorted by severity, file, and line. */
 function buildReviewSummaryBody(
   payload: ReviewPayload,
   ctx: ReviewSummaryRenderCtx,
@@ -479,7 +465,9 @@ export function fitReviewSummaryBody(
   ctx: ReviewSummaryRenderCtx,
   maxBodyChars: number,
 ): string {
-  const sortedPlacements = sortPlacements(ctx.placements);
+  const sortedPlacements = [...ctx.placements].toSorted((a, b) =>
+    compareReviewFindingsBySeverityFileLine(a.finding, b.finding),
+  );
   const sortedCtx = { ...ctx, placements: sortedPlacements };
   const sortedCount = sortedPlacements.length;
 

--- a/src/review/run/reviewRunFallback.ts
+++ b/src/review/run/reviewRunFallback.ts
@@ -3,7 +3,7 @@ import { logWarn } from "../../evlog.js";
 import { upsertReviewSummaryComment } from "../../github/reviewPublish.js";
 import { renderReviewFailureNotice } from "./progressComment.js";
 import type { ReviewRunSetup } from "./reviewRunSetup.js";
-import { reviewSummarySentinelForMode } from "../reviewSchema.js";
+import { REVIEW_SUMMARY_SENTINEL } from "../reviewSchema.js";
 import type { AnyReviewLens } from "../../settings/legacyReviewLenses.js";
 import { MAX_REVIEW_PUBLISH_CALLS } from "../../settings/index.js";
 
@@ -23,7 +23,7 @@ export async function publishReviewRunFailureNotice(params: {
   });
   const token = params.setup.getToken();
   const tokenExpiresAtTs = params.setup.getTokenExpiresAtTs();
-  const sentinel = reviewSummarySentinelForMode(params.reviewMode);
+  const sentinel = REVIEW_SUMMARY_SENTINEL;
   try {
     await upsertReviewSummaryComment(
       token,

--- a/src/review/run/reviewRunFooter.ts
+++ b/src/review/run/reviewRunFooter.ts
@@ -1,5 +1,4 @@
 import { escapeTableHtml } from "../../github/markdownFormat.js";
-import type { AnyReviewLens } from "../../settings/legacyReviewLenses.js";
 
 export type ReviewRunFooterMeta = {
   readonly durationMs: number;
@@ -7,10 +6,6 @@ export type ReviewRunFooterMeta = {
 };
 
 const FOOTER_SEP = " ⋅ ";
-
-export function reviewLensFooterLabel(_mode: AnyReviewLens): string {
-  return "general";
-}
 
 /** Compact wall-clock duration (`45s`, `11m 20s`, `1h 2m`). */
 export function formatReviewDuration(durationMs: number): string {
@@ -62,13 +57,12 @@ export function shortHeadSha(headSha: string): string {
 /** Muted provenance line: `<sub>a1b2c3d ⋅ general ⋅ 11m 20s ⋅ grok-4.5</sub>`. */
 export function renderReviewRunFooter(params: {
   readonly headSha: string;
-  readonly mode: AnyReviewLens;
   readonly durationMs: number;
   readonly model: string;
 }): string {
   const parts = [
     shortHeadSha(params.headSha),
-    reviewLensFooterLabel(params.mode),
+    "general",
     formatReviewDuration(params.durationMs),
     params.model.trim() || "unknown",
   ].map((part) => escapeTableHtml(part));

--- a/src/review/triageSchema.ts
+++ b/src/review/triageSchema.ts
@@ -37,11 +37,11 @@ export type TriageVerdict = z.infer<typeof TriageVerdictSchema>;
 export type TriagePayload = z.infer<typeof TriagePayloadSchema>;
 
 /**
- * Verification verdict schema — shared verdict vocabulary with triage but read-only.
+ * Same verdict vocabulary as triage, but read-only.
  * "fixed" cites the user's pushed commit sha (no committed-by-bot check).
  * "dismissed" still requires maintainer reply evidence.
  */
-export const VerificationVerdictSchema = TriageVerdictSchema;
+const VerificationVerdictSchema = TriageVerdictSchema;
 
 export const VerificationPayloadSchema = z.object({
   verdicts: z.array(VerificationVerdictSchema).min(1).max(MAX_TRIAGE_FINDINGS),

--- a/src/security/sanitizePostHogEvent.ts
+++ b/src/security/sanitizePostHogEvent.ts
@@ -19,11 +19,6 @@ const STACK_FRAME_STRING_KEYS = [
 
 const STACK_FRAME_STRING_ARRAY_KEYS = ["pre_context", "post_context"] as const;
 
-function redactStringArray(value: unknown): unknown {
-  if (!Array.isArray(value)) return value;
-  return value.map((entry) => (typeof entry === "string" ? redactOutboundSecrets(entry) : entry));
-}
-
 function sanitizeStackFrame(frame: unknown): unknown {
   if (typeof frame !== "object" || frame == null) return frame;
   const next: Record<string, unknown> = { ...(frame as Record<string, unknown>) };
@@ -32,7 +27,12 @@ function sanitizeStackFrame(frame: unknown): unknown {
     if (typeof value === "string") next[key] = redactOutboundSecrets(value);
   }
   for (const key of STACK_FRAME_STRING_ARRAY_KEYS) {
-    if (key in next) next[key] = redactStringArray(next[key]);
+    if (key in next) {
+      const value = next[key];
+      next[key] = Array.isArray(value)
+        ? value.map((entry) => (typeof entry === "string" ? redactOutboundSecrets(entry) : entry))
+        : value;
+    }
   }
   return next;
 }

--- a/src/settings/askConstants.ts
+++ b/src/settings/askConstants.ts
@@ -71,24 +71,5 @@ export const SENSITIVE_PATH_PATTERNS: readonly RegExp[] = [
   /\.key$/i,
 ];
 
-export const ASK_TOOLS_WITH_OWNER_REPO = new Set([
-  "getPullRequest",
-  "listPullRequests",
-  "listPullRequestFiles",
-  "listPullRequestReviews",
-  "getFileContent",
-  "listCommits",
-  "getCommit",
-  "getBlame",
-  "getRepository",
-  "listBranches",
-]);
-
-export const ASK_TOOLS_WITH_PULL_NUMBER = new Set([
-  "getPullRequest",
-  "listPullRequestFiles",
-  "listPullRequestReviews",
-]);
-
 export const MAX_ASK_TOOL_ROUNDS = 12;
 export const MAX_ASK_FINALIZE_ROUNDS = 2;

--- a/src/settings/githubConstants.ts
+++ b/src/settings/githubConstants.ts
@@ -10,5 +10,3 @@ export type GithubReactionContent =
   | typeof GITHUB_REACTION_EYES
   | typeof GITHUB_REACTION_PLUS_ONE
   | typeof GITHUB_REACTION_MINUS_ONE;
-
-export const DEFAULT_COOLDOWN_SECONDS = 60;

--- a/src/settings/legacyReviewLenses.ts
+++ b/src/settings/legacyReviewLenses.ts
@@ -12,7 +12,7 @@ export const LEGACY_REVIEW_POINTER_BODIES = [
   "See the proposed test cases summary in the PR conversation.",
 ] as const;
 
-export type LegacyReviewLens = (typeof LEGACY_REVIEW_LENSES)[number];
+type LegacyReviewLens = (typeof LEGACY_REVIEW_LENSES)[number];
 export type AnyReviewLens = "review" | LegacyReviewLens;
 
 export function isAnyReviewLens(value: string): value is AnyReviewLens {

--- a/src/settings/modelsJson.ts
+++ b/src/settings/modelsJson.ts
@@ -6,7 +6,7 @@ import { ModelRuntime } from "@earendil-works/pi-coding-agent";
 import { AppError } from "../errors/appError.js";
 
 /** Fixed project-root catalog filename (Pi native `models.json` format). */
-export const MODELS_JSON_FILENAME = "models.json";
+const MODELS_JSON_FILENAME = "models.json";
 
 export type ResolveModelsJsonPathOptions = {
   readonly cwd?: string;

--- a/src/settings/reviewConstants.ts
+++ b/src/settings/reviewConstants.ts
@@ -157,10 +157,7 @@ export const REVIEW_DIFF_CACHE_REQUIRED_MESSAGE =
 /** Review harness: anchor menu block header (untrusted user content). */
 export const REVIEW_ANCHOR_MENU_BLOCK_LABEL = "anchor_menu";
 
-/**
- * ReviewValidationFailureKind — taxonomy for Zod validation failures on ReviewPayload.
- * Used by review harness metrics and repair prompts.
- */
+/** Zod ReviewPayload failure kinds for harness metrics and repair prompts. */
 export type ReviewValidationFailureKind =
   | "missing_field"
   | "wrong_type"

--- a/src/settings/triageConstants.ts
+++ b/src/settings/triageConstants.ts
@@ -4,9 +4,6 @@ export const TRIAGE_ALREADY_IN_PROGRESS =
   "A `/triage` run is already queued or in progress for this pull request.";
 export const TRIAGE_FAILURE_MESSAGE =
   "PR Agent could not complete the triage run after retries. Try `/triage` again later.";
-export const TRIAGE_NO_PRIOR_FINDINGS =
-  "No prior PR Agent inline findings to triage on this pull request. Run `/review` first.";
-
 export const TRIAGE_NO_ELIGIBLE_FINDINGS =
   "No triage-eligible unresolved PR Agent inline findings on this pull request.";
 export const TRIAGE_THREAD_NOT_ELIGIBLE =

--- a/test/appAuth.test.ts
+++ b/test/appAuth.test.ts
@@ -3,7 +3,7 @@ import {
   clearInstallationOctokitCacheForTest,
   installationOctokit,
 } from "../src/github/appAuth.js";
-import { INSTALLATION_TOKEN_FALLBACK_TTL_MS } from "../src/github/installationTokenExpiry.js";
+import { INSTALLATION_TOKEN_FALLBACK_TTL_MS } from "../src/settings/index.js";
 
 describe("installationOctokit", () => {
   beforeEach(() => {

--- a/test/findingPipeline.test.ts
+++ b/test/findingPipeline.test.ts
@@ -55,7 +55,6 @@ describe("findingPipeline", () => {
       payload: payload({
         findings: [finding({ startLine: 99, endLine: 99, confidence: 1 })],
       }),
-      mode: "review",
       reviewMinConfidence: 3,
       cachedDiffIndex: index,
     });
@@ -74,7 +73,6 @@ describe("findingPipeline", () => {
 
     const result = prepareReviewPayloadForPublish({
       payload: payload({ findings: [secretFinding] }),
-      mode: "review",
     });
 
     expect(result.ok).toBe(true);
@@ -90,7 +88,6 @@ describe("findingPipeline", () => {
 
     const result = prepareFindingsForPublish({
       payload: payload({ findings: [suppressed, capped, kept] }),
-      mode: "review",
       inlinePlacements: [placement(suppressed), placement(capped), placement(kept)],
       storedInlineFingerprints: [fingerprintFinding(suppressed, "review")],
       maxInlineComments: 1,
@@ -112,7 +109,6 @@ describe("findingPipeline", () => {
     const item = finding();
     const result = prepareFindingsForPublish({
       payload: payload({ findings: [item] }),
-      mode: "review-security",
       inlinePlacements: [placement(item)],
     });
 

--- a/test/helpers/promptCost.ts
+++ b/test/helpers/promptCost.ts
@@ -51,40 +51,26 @@ function assertDimension(
   cost: PromptCost,
 ): void {
   if (actual > allowed) {
-    throw new Error(budgetMessage(name, dimension, actual, allowed, cost));
+    throw new Error(
+      `${name} prompt cost exceeded ${dimension} budget: actual=${actual}, allowed=${allowed}, bytes=${cost.bytes}, characters=${cost.characters}, estimatedTokens=${cost.estimatedTokens}`,
+    );
   }
 }
 
-function budgetMessage(
-  name: string,
-  dimension: keyof PromptCost,
-  actual: number,
-  allowed: number,
-  cost: PromptCost,
-): string {
-  return `${name} prompt cost exceeded ${dimension} budget: actual=${actual}, allowed=${allowed}, bytes=${cost.bytes}, characters=${cost.characters}, estimatedTokens=${cost.estimatedTokens}`;
-}
-
 function sortJson(value: unknown): unknown {
-  if (hasToJson(value)) return sortJson(value.toJSON());
-  if (Array.isArray(value)) return value.map(sortJson);
-  if (!isRecord(value)) return value;
-  return Object.fromEntries(
-    Object.keys(value)
-      .toSorted()
-      .map((key) => [key, sortJson(value[key])]),
-  );
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value != null && !Array.isArray(value);
-}
-
-function hasToJson(value: unknown): value is { readonly toJSON: () => unknown } {
-  return (
+  if (
     typeof value === "object" &&
     value != null &&
     "toJSON" in value &&
     typeof value.toJSON === "function"
+  ) {
+    return sortJson(value.toJSON());
+  }
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (!(typeof value === "object" && value != null && !Array.isArray(value))) return value;
+  return Object.fromEntries(
+    Object.keys(value)
+      .toSorted()
+      .map((key) => [key, sortJson((value as Record<string, unknown>)[key])]),
   );
 }

--- a/test/helpers/promptCost.ts
+++ b/test/helpers/promptCost.ts
@@ -6,12 +6,6 @@ export type PromptCost = {
   readonly estimatedTokens: number;
 };
 
-export type PromptCostBudget = {
-  readonly bytes: number;
-  readonly characters: number;
-  readonly estimatedTokens: number;
-};
-
 export function measurePromptCost(content: string): PromptCost {
   const characters = Array.from(content).length;
   return {
@@ -28,7 +22,7 @@ export function stableJson(value: unknown): string {
 export function assertPromptCostWithinBudget(params: {
   readonly name: string;
   readonly content: string;
-  readonly budget: PromptCostBudget;
+  readonly budget: PromptCost;
 }): PromptCost {
   const cost = measurePromptCost(params.content);
   assertDimension(params.name, "bytes", cost.bytes, params.budget.bytes, cost);

--- a/test/helpers/promptCost.ts
+++ b/test/helpers/promptCost.ts
@@ -51,6 +51,10 @@ function assertDimension(
   }
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value != null && !Array.isArray(value);
+}
+
 function sortJson(value: unknown): unknown {
   if (
     typeof value === "object" &&
@@ -61,10 +65,10 @@ function sortJson(value: unknown): unknown {
     return sortJson(value.toJSON());
   }
   if (Array.isArray(value)) return value.map(sortJson);
-  if (!(typeof value === "object" && value != null && !Array.isArray(value))) return value;
+  if (!isRecord(value)) return value;
   return Object.fromEntries(
     Object.keys(value)
       .toSorted()
-      .map((key) => [key, sortJson((value as Record<string, unknown>)[key])]),
+      .map((key) => [key, sortJson(value[key])]),
   );
 }

--- a/test/helpers/reviewPublishTestHelpers.ts
+++ b/test/helpers/reviewPublishTestHelpers.ts
@@ -1,7 +1,6 @@
 import { publishReview } from "../../src/review/publish/publishReview.js";
 import { prepareReviewPayloadForPublish } from "../../src/review/findings/findingPipeline.js";
 import type { InlinePlacement } from "../../src/review/placement/reviewDiffPlacement.js";
-import { planInlinePlacements } from "../../src/review/placement/reviewDiffPlacement.js";
 import type { ReviewFinding, ReviewPayload } from "../../src/review/reviewSchema.js";
 import type { AnyReviewLens } from "../../src/settings/legacyReviewLenses.js";
 import {
@@ -15,10 +14,8 @@ import { createSubmitReviewState } from "../../src/review/publish/submitReviewTo
 export async function publishReviewForTest(
   params: Parameters<typeof publishReview>[0] & { mode?: AnyReviewLens },
 ): Promise<void> {
-  const mode = params.mode ?? "review";
   const prepared = prepareReviewPayloadForPublish({
     payload: params.payload,
-    mode,
     cachedDiffIndex: params.cachedDiffIndex,
   });
   if (!prepared.ok) {
@@ -47,20 +44,6 @@ export function testPlacements(
     inlineLine: inlinePosted ? (opts.inlineLine ?? finding.startLine) : null,
     inlinePosted,
   }));
-}
-
-export function planInlineFromPayload(
-  payload: ReviewPayload,
-  diffIndex?: CachedPrDiffIndex,
-): InlinePlacement[] {
-  return planInlinePlacements(payload.findings, diffIndex);
-}
-
-export function testPlacementsFromPayload(
-  payload: ReviewPayload,
-  inlinePosted = true,
-): InlinePlacement[] {
-  return testPlacements(payload.findings, { inlinePosted });
 }
 
 export function cachedDiffForLines(

--- a/test/helpers/reviewPublishTestHelpers.ts
+++ b/test/helpers/reviewPublishTestHelpers.ts
@@ -1,7 +1,7 @@
 import { publishReview } from "../../src/review/publish/publishReview.js";
 import { prepareReviewPayloadForPublish } from "../../src/review/findings/findingPipeline.js";
 import type { InlinePlacement } from "../../src/review/placement/reviewDiffPlacement.js";
-import type { ReviewFinding, ReviewPayload } from "../../src/review/reviewSchema.js";
+import type { ReviewFinding } from "../../src/review/reviewSchema.js";
 import type { AnyReviewLens } from "../../src/settings/legacyReviewLenses.js";
 import {
   createCachedPrDiffIndex,

--- a/test/promptCostBaselines.test.ts
+++ b/test/promptCostBaselines.test.ts
@@ -18,7 +18,7 @@ import {
   assertPromptCostWithinBudget,
   measurePromptCost,
   stableJson,
-  type PromptCostBudget,
+  type PromptCost,
 } from "./helpers/promptCost.js";
 import { makeTestConfig } from "./helpers/config.js";
 import { mockLocalPrWorkspace } from "./helpers/mockWorkspace.js";
@@ -26,7 +26,7 @@ import { mockLocalPrWorkspace } from "./helpers/mockWorkspace.js";
 type PromptSurface = {
   readonly name: string;
   readonly content: string;
-  readonly budget: PromptCostBudget;
+  readonly budget: PromptCost;
 };
 
 const SEVERITIES = ["P0", "P1", "P2", "P3"] as const;

--- a/test/reviewAnchorMenu.test.ts
+++ b/test/reviewAnchorMenu.test.ts
@@ -4,14 +4,18 @@ import {
   ingestListPullRequestFilesResult,
   renderAnchorMenuBlock,
 } from "../src/review/placement/reviewDiffIndex.js";
-import { REVIEW_ANCHOR_MENU_BLOCK_LABEL } from "../src/settings/index.js";
+import {
+  REVIEW_ANCHOR_MENU_BLOCK_LABEL,
+  REVIEW_ANCHOR_MENU_MAX_FILES,
+  REVIEW_ANCHOR_MENU_MAX_RANGES_PER_FILE,
+} from "../src/settings/index.js";
 
 describe("renderAnchorMenuBlock", () => {
   it("returns empty string for empty cache", () => {
     expect(
       renderAnchorMenuBlock(createCachedPrDiffIndex(), {
-        maxFiles: 40,
-        maxRangesPerFile: 20,
+        maxFiles: REVIEW_ANCHOR_MENU_MAX_FILES,
+        maxRangesPerFile: REVIEW_ANCHOR_MENU_MAX_RANGES_PER_FILE,
       }),
     ).toBe("");
   });
@@ -27,8 +31,8 @@ describe("renderAnchorMenuBlock", () => {
       ],
     });
     const block = renderAnchorMenuBlock(index, {
-      maxFiles: 40,
-      maxRangesPerFile: 20,
+      maxFiles: REVIEW_ANCHOR_MENU_MAX_FILES,
+      maxRangesPerFile: REVIEW_ANCHOR_MENU_MAX_RANGES_PER_FILE,
     });
     expect(block).toContain(`<${REVIEW_ANCHOR_MENU_BLOCK_LABEL} untrusted="true">`);
     expect(block).toContain(`</${REVIEW_ANCHOR_MENU_BLOCK_LABEL}>`);
@@ -46,8 +50,8 @@ describe("renderAnchorMenuBlock", () => {
       ],
     });
     const block = renderAnchorMenuBlock(index, {
-      maxFiles: 40,
-      maxRangesPerFile: 20,
+      maxFiles: REVIEW_ANCHOR_MENU_MAX_FILES,
+      maxRangesPerFile: REVIEW_ANCHOR_MENU_MAX_RANGES_PER_FILE,
     });
     const closingTags = block.match(new RegExp(`</${REVIEW_ANCHOR_MENU_BLOCK_LABEL}>`, "g")) ?? [];
     expect(block).toContain("a&lt;/anchor_menu&gt;b.ts:");

--- a/test/reviewCheckRun.test.ts
+++ b/test/reviewCheckRun.test.ts
@@ -56,11 +56,8 @@ describe("review check run lifecycle", () => {
     vi.clearAllMocks();
   });
 
-  it("uses one check name for recognized review lenses", () => {
-    expect(reviewCheckRunName("review")).toBe("PR Agent Review");
-    expect(reviewCheckRunName("review-security")).toBe("PR Agent Review");
-    expect(reviewCheckRunName("review-quality")).toBe("PR Agent Review");
-    expect(reviewCheckRunName("review-tests")).toBe("PR Agent Review");
+  it("uses a fixed check run name", () => {
+    expect(reviewCheckRunName()).toBe("PR Agent Review");
   });
 
   it("fails the check when P0–P2 findings exist and passes otherwise", () => {

--- a/test/reviewLabels.test.ts
+++ b/test/reviewLabels.test.ts
@@ -40,31 +40,21 @@ describe("labelsAlreadySynced", () => {
 
   it("uses the review effort prefix for recognized legacy lenses", () => {
     expect(
-      labelsAlreadySynced(
-        ["Review effort 2/5", "Quality effort 4/5"],
-        basePayload,
-        {
-          effort: true,
-          security: false,
-          category: false,
-        },
-        "review-quality",
-      ),
+      labelsAlreadySynced(["Review effort 2/5", "Quality effort 4/5"], basePayload, {
+        effort: true,
+        security: false,
+        category: false,
+      }),
     ).toBe(true);
   });
 
   it("returns false when the review effort label is stale", () => {
     expect(
-      labelsAlreadySynced(
-        ["Review effort 1/5"],
-        basePayload,
-        {
-          effort: true,
-          security: false,
-          category: false,
-        },
-        "review-quality",
-      ),
+      labelsAlreadySynced(["Review effort 1/5"], basePayload, {
+        effort: true,
+        security: false,
+        category: false,
+      }),
     ).toBe(false);
   });
 
@@ -143,39 +133,13 @@ describe("hasManagedCategoryLabel", () => {
 });
 
 describe("reviewLabelsFromPayload", () => {
-  it("uses one effort prefix for recognized review lenses", () => {
+  it("uses the review effort prefix", () => {
     expect(
-      reviewLabelsFromPayload(
-        basePayload,
-        {
-          effort: true,
-          security: false,
-          category: false,
-        },
-        "review-security",
-      ),
-    ).toEqual(["Review effort 2/5"]);
-    expect(
-      reviewLabelsFromPayload(
-        basePayload,
-        {
-          effort: true,
-          security: false,
-          category: false,
-        },
-        "review-quality",
-      ),
-    ).toEqual(["Review effort 2/5"]);
-    expect(
-      reviewLabelsFromPayload(
-        basePayload,
-        {
-          effort: true,
-          security: false,
-          category: false,
-        },
-        "review-tests",
-      ),
+      reviewLabelsFromPayload(basePayload, {
+        effort: true,
+        security: false,
+        category: false,
+      }),
     ).toEqual(["Review effort 2/5"]);
   });
 
@@ -222,19 +186,19 @@ describe("syncReviewLabels", () => {
 
   it("replaces the review effort label family for recognized legacy lenses", () => {
     const current = ["Review effort 3/5", "Quality effort 1/5", "bug"];
-    const next = syncReviewLabels(current, ["Review effort 2/5"], "review-quality");
+    const next = syncReviewLabels(current, ["Review effort 2/5"]);
     expect(next).toEqual(["Quality effort 1/5", "bug", "Review effort 2/5"]);
   });
 
   it("replaces category labels without touching effort labels", () => {
     const current = ["Review effort 2/5", "Category: bug", "enhancement"];
-    const next = syncReviewLabels(current, ["Review effort 2/5", "Category: security"], "review");
+    const next = syncReviewLabels(current, ["Review effort 2/5", "Category: security"]);
     expect(next).toEqual(["enhancement", "Review effort 2/5", "Category: security"]);
   });
 
   it("removes stale category labels when payload has no dominant category", () => {
     const current = ["Category: bug", "enhancement"];
-    const next = syncReviewLabels(current, [], "review");
+    const next = syncReviewLabels(current, []);
     expect(next).toEqual(["enhancement"]);
   });
 });

--- a/test/reviewPrePublish.test.ts
+++ b/test/reviewPrePublish.test.ts
@@ -44,7 +44,7 @@ describe("prepareReviewPayloadForPublish", () => {
       ],
     });
 
-    const result = prepareReviewPayloadForPublish({ payload, mode: "review" });
+    const result = prepareReviewPayloadForPublish({ payload });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.prepared.payload.findings).toHaveLength(1);
@@ -58,7 +58,7 @@ describe("prepareReviewPayloadForPublish", () => {
       findings: [makeFinding({ severity: "P2", detail, fixPrompt: "Fix the handler." })],
     });
 
-    const result = prepareReviewPayloadForPublish({ payload, mode: "review" });
+    const result = prepareReviewPayloadForPublish({ payload });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.prepared.payload.findings[0]?.detail).toBe(detail);
@@ -69,7 +69,7 @@ describe("prepareReviewPayloadForPublish", () => {
       prCharacter: "Structured publish failed after 3/3 attempt(s). Check server logs.",
     });
 
-    const result = prepareReviewPayloadForPublish({ payload, mode: "review" });
+    const result = prepareReviewPayloadForPublish({ payload });
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error).toMatch(/prCharacter/);
@@ -86,7 +86,7 @@ describe("prepareReviewPayloadForPublish", () => {
       ],
     });
 
-    const result = prepareReviewPayloadForPublish({ payload, mode: "review" });
+    const result = prepareReviewPayloadForPublish({ payload });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.prepared.payload.findings[0]?.detail).toContain("[redacted]");
@@ -104,7 +104,7 @@ describe("prepareReviewPayloadForPublish", () => {
       ],
     });
 
-    const result = prepareReviewPayloadForPublish({ payload, mode: "review" });
+    const result = prepareReviewPayloadForPublish({ payload });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.prepared.placements).toEqual(
@@ -124,7 +124,6 @@ describe("prepareReviewPayloadForPublish", () => {
 
     const result = prepareReviewPayloadForPublish({
       payload,
-      mode: "review",
       reviewMinConfidence: 3,
     });
 

--- a/test/reviewPublish.test.ts
+++ b/test/reviewPublish.test.ts
@@ -182,7 +182,7 @@ describe("listPullRequestLabels", () => {
     });
 
     const current = await listPullRequestLabels("tok", "o", "r", 7);
-    const next = syncReviewLabels(current, ["Review effort 2/5"], "review");
+    const next = syncReviewLabels(current, ["Review effort 2/5"]);
 
     expect(current).toHaveLength(COMMENTS_PAGE_SIZE + 2);
     expect(next).toContain("must-preserve");

--- a/test/reviewPublishRetry.test.ts
+++ b/test/reviewPublishRetry.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
+import { withTransientReviewRetry } from "../src/github/reviewPublishRetry.js";
 import {
+  isLineResolutionPublishError,
   isTransientGitHubReviewError,
-  withTransientReviewRetry,
-} from "../src/github/reviewPublishRetry.js";
-import { isLineResolutionPublishError } from "../src/github/reviewErrors.js";
+} from "../src/github/reviewErrors.js";
 
 describe("reviewPublishRetry", () => {
   it("treats non-line-resolution 422 as transient", () => {

--- a/test/reviewRender.test.ts
+++ b/test/reviewRender.test.ts
@@ -24,12 +24,8 @@ import {
 import type { ReviewPayload } from "../src/review/reviewSchema.js";
 import { makeReviewPayload } from "./helpers/reviewPayloadFactory.js";
 import { REVIEW_SUMMARY_SENTINEL } from "../src/review/reviewSchema.js";
-import {
-  testPlacementsFromPayload,
-  planInlineFromPayload,
-  cachedDiffForFiles,
-  testPlacements,
-} from "./helpers/reviewPublishTestHelpers.js";
+import { planInlinePlacements } from "../src/review/placement/reviewDiffPlacement.js";
+import { cachedDiffForFiles, testPlacements } from "./helpers/reviewPublishTestHelpers.js";
 
 const ctx = {
   owner: "acme",
@@ -55,7 +51,7 @@ describe("renderReviewSummaryComment", () => {
   it("(a) no findings", () => {
     const body = renderReviewSummaryComment(basePayload(), {
       ...ctx,
-      placements: testPlacementsFromPayload(basePayload()),
+      placements: testPlacements(basePayload().findings),
     });
     expect(body).toContain("## PR Agent Review");
     expect(body).toContain("[!NOTE]");
@@ -70,7 +66,7 @@ describe("renderReviewSummaryComment", () => {
   it("renders a CI gate row when a CI summary is provided", () => {
     const body = renderReviewSummaryComment(basePayload(), {
       ...ctx,
-      placements: testPlacementsFromPayload(basePayload()),
+      placements: testPlacements(basePayload().findings),
       ciSummary: {
         status: "failing",
         headline: "❌ CI failing — lint",
@@ -97,7 +93,7 @@ describe("renderReviewSummaryComment", () => {
   it("shows the CI gate row when Checks permission is missing", () => {
     const body = renderReviewSummaryComment(basePayload(), {
       ...ctx,
-      placements: testPlacementsFromPayload(basePayload()),
+      placements: testPlacements(basePayload().findings),
       ciSummary: {
         status: "unavailable",
         headline:
@@ -270,7 +266,7 @@ describe("renderReviewSummaryComment", () => {
     });
     const body = renderReviewSummaryComment(payload, {
       ...ctx,
-      placements: testPlacementsFromPayload(payload),
+      placements: testPlacements(payload.findings),
     });
     const tableClose = body.indexOf("</table>");
     const fixAll = body.indexOf(`<summary>${AGENT_FIX_PROMPT_ACCORDION_SUMMARY}</summary>`);
@@ -382,7 +378,7 @@ describe("renderReviewSummaryComment", () => {
     });
     const body = renderReviewSummaryComment(payload, {
       ...ctx,
-      placements: testPlacementsFromPayload(payload),
+      placements: testPlacements(payload.findings),
     });
     expect(body).toContain("Webhook secret compared");
   });
@@ -391,7 +387,7 @@ describe("renderReviewSummaryComment", () => {
     const payload = basePayload({ prCharacter: "Adds auth | breaks table" });
     const body = renderReviewSummaryComment(payload, {
       ...ctx,
-      placements: testPlacementsFromPayload(payload),
+      placements: testPlacements(payload.findings),
     });
     expect(body).toContain("[!NOTE]");
     expect(body).toContain("Adds auth | breaks table");
@@ -402,7 +398,7 @@ describe("renderReviewSummaryComment", () => {
     const body = renderReviewSummaryComment(payload, {
       ...ctx,
       mode: "review-security",
-      placements: testPlacementsFromPayload(payload),
+      placements: testPlacements(payload.findings),
     });
     expect(body).toContain("## PR Agent Review");
     expect(body).toContain("<sub>abc123d ⋅ general ⋅ 11m 20s ⋅ grok-4.5</sub>");
@@ -415,7 +411,7 @@ describe("renderReviewSummaryComment", () => {
     });
     const body = renderReviewSummaryComment(payload, {
       ...ctx,
-      placements: testPlacementsFromPayload(payload),
+      placements: testPlacements(payload.findings),
     });
     expect(body).toContain("foo | bar");
     expect(body).toContain("baz | qux");
@@ -459,7 +455,7 @@ describe("renderReviewSummaryComment", () => {
     const payload = basePayload({ findings });
     const body = renderReviewSummaryComment(payload, {
       ...ctx,
-      placements: testPlacementsFromPayload(payload, false),
+      placements: testPlacements(payload.findings, { inlinePosted: false }),
     });
 
     expect(body.length).toBeLessThanOrEqual(REVIEW_SUMMARY_BODY_MAX_CHARS);
@@ -484,7 +480,7 @@ describe("renderReviewSummaryComment", () => {
       payload,
       {
         ...ctx,
-        placements: testPlacementsFromPayload(payload, false),
+        placements: testPlacements(payload.findings, { inlinePosted: false }),
       },
       2_500,
     );
@@ -501,7 +497,7 @@ describe("renderReviewSummaryComment", () => {
     const payload = basePayload();
     const body = renderReviewSummaryComment(payload, {
       ...ctx,
-      placements: testPlacementsFromPayload(payload),
+      placements: testPlacements(payload.findings),
     });
     expect(body).not.toContain("Merge verdict");
     expect(body).not.toContain("No blocking findings on this pass");
@@ -543,7 +539,7 @@ describe("renderReviewSummaryComment", () => {
     const body = renderReviewSummaryComment(payload, {
       ...ctx,
       hasDescriptionAgentBlock: true,
-      placements: testPlacementsFromPayload(payload),
+      placements: testPlacements(payload.findings),
     });
     expect(body).toContain(
       "See the [file walkthrough](https://github.com/acme/widgets/pull/42) in the PR description.",
@@ -554,7 +550,7 @@ describe("renderReviewSummaryComment", () => {
     const payload = basePayload();
     const body = renderReviewSummaryComment(payload, {
       ...ctx,
-      placements: testPlacementsFromPayload(payload),
+      placements: testPlacements(payload.findings),
     });
     expect(body).not.toContain("file walkthrough");
   });
@@ -739,8 +735,8 @@ describe("renderAgentFixPrompt", () => {
     const prompt = renderAgentFixPrompt(
       payload,
       renderCtx,
-      planInlineFromPayload(
-        payload,
+      planInlinePlacements(
+        payload.findings,
         cachedDiffForFiles([
           { file: "src/a.ts", lines: [5, 6, 7] },
           { file: "src/b.ts", lines: [20, 21, 22] },
@@ -789,7 +785,7 @@ describe("renderAgentFixPrompt", () => {
     const prompt = renderAgentFixPrompt(
       payload,
       renderCtx,
-      planInlineFromPayload(payload, diffIndex),
+      planInlinePlacements(payload.findings, diffIndex),
     );
 
     expect(prompt.indexOf("[P1]")).toBeLessThan(prompt.indexOf("[P2]"));
@@ -811,7 +807,11 @@ describe("renderAgentFixPrompt", () => {
         },
       ],
     });
-    const prompt = renderAgentFixPrompt(payload, renderCtx, planInlineFromPayload(payload));
+    const prompt = renderAgentFixPrompt(
+      payload,
+      renderCtx,
+      planInlinePlacements(payload.findings, undefined),
+    );
 
     expect(prompt).toContain("@src/single.ts line 9");
     expect(prompt).not.toContain("lines 9-9");
@@ -831,7 +831,11 @@ describe("renderAgentFixPrompt", () => {
         },
       ],
     });
-    const prompt = renderAgentFixPrompt(payload, renderCtx, planInlineFromPayload(payload));
+    const prompt = renderAgentFixPrompt(
+      payload,
+      renderCtx,
+      planInlinePlacements(payload.findings, undefined),
+    );
 
     expect(prompt).toContain("[inline thread omitted — summary only]");
     expect(prompt).not.toContain("[inline thread omitted — severity cap]");
@@ -942,7 +946,7 @@ describe("renderLightweightReviewCompletion", () => {
   };
 
   it("preserves sentinel, alert, and table structure", () => {
-    const body = renderLightweightReviewCompletion("review", lightweightFooter);
+    const body = renderLightweightReviewCompletion(lightweightFooter);
     expect(body).toContain("## PR Agent Review");
     expect(body).toContain("[!NOTE]");
     expect(body).toContain("<table>");
@@ -950,12 +954,7 @@ describe("renderLightweightReviewCompletion", () => {
     expect(body).not.toContain("—");
     expect(body).toContain("Use /review for a full review.");
     expect(body).toContain("<sub>abc123d ⋅ general ⋅ 12s ⋅ grok-4.5</sub>");
-  });
-
-  it("uses the general sentinel and footer for recognized legacy modes", () => {
-    const body = renderLightweightReviewCompletion("review-security", lightweightFooter);
     expect(body).toContain(REVIEW_SUMMARY_SENTINEL);
-    expect(body).toContain("<sub>abc123d ⋅ general ⋅ 12s ⋅ grok-4.5</sub>");
   });
 });
 
@@ -965,7 +964,7 @@ describe("review hardening render helpers", () => {
       ...ctx,
       mode: "review",
       staleReview: true,
-      placements: testPlacementsFromPayload(basePayload()),
+      placements: testPlacements(basePayload().findings),
     });
     expect(body).toContain(
       renderStaleReviewMetadataComment({

--- a/test/reviewRunFooter.test.ts
+++ b/test/reviewRunFooter.test.ts
@@ -3,18 +3,8 @@ import {
   formatReviewDuration,
   renderReviewRunFooter,
   resolveReviewWallClockMs,
-  reviewLensFooterLabel,
   shortHeadSha,
 } from "../src/review/run/reviewRunFooter.js";
-
-describe("reviewLensFooterLabel", () => {
-  it("uses one footer label for recognized review lenses", () => {
-    expect(reviewLensFooterLabel("review")).toBe("general");
-    expect(reviewLensFooterLabel("review-security")).toBe("general");
-    expect(reviewLensFooterLabel("review-quality")).toBe("general");
-    expect(reviewLensFooterLabel("review-tests")).toBe("general");
-  });
-});
 
 describe("formatReviewDuration", () => {
   it("formats seconds, minutes, and hours compactly", () => {
@@ -102,7 +92,6 @@ describe("renderReviewRunFooter", () => {
     expect(
       renderReviewRunFooter({
         headSha: "abc123def456",
-        mode: "review",
         durationMs: 680_000,
         model: "grok-4.5",
       }),
@@ -113,7 +102,6 @@ describe("renderReviewRunFooter", () => {
     expect(
       renderReviewRunFooter({
         headSha: "abc1234",
-        mode: "review-security",
         durationMs: 1_000,
         model: "evil<script>",
       }),
@@ -124,7 +112,6 @@ describe("renderReviewRunFooter", () => {
     expect(
       renderReviewRunFooter({
         headSha: "abc1234",
-        mode: "review",
         durationMs: 1_000,
         model: "",
       }),
@@ -132,7 +119,6 @@ describe("renderReviewRunFooter", () => {
     expect(
       renderReviewRunFooter({
         headSha: "abc1234",
-        mode: "review",
         durationMs: 1_000,
         model: "   ",
       }),

--- a/test/reviewSchema.test.ts
+++ b/test/reviewSchema.test.ts
@@ -6,7 +6,7 @@ import {
   isInlineSeverity,
   reviewEventForFindings,
   reviewPayloadSchema,
-  reviewSummarySentinelForMode,
+  REVIEW_SUMMARY_SENTINEL,
   selectInlineFindings,
 } from "../src/review/reviewSchema.js";
 import { REVIEW_FINDING_SUGGESTED_CODE_MAX_CHARS } from "../src/settings/index.js";
@@ -417,9 +417,9 @@ describe("formatReviewValidationError", () => {
   });
 });
 
-describe("reviewSummarySentinelForMode", () => {
+describe("REVIEW_SUMMARY_SENTINEL", () => {
   it("uses one live review mode and the general summary sentinel", () => {
     expectTypeOf<ReviewMode>().toEqualTypeOf<"review">();
-    expect(reviewSummarySentinelForMode("review")).toBe("## PR Agent Review");
+    expect(REVIEW_SUMMARY_SENTINEL).toBe("## PR Agent Review");
   });
 });

--- a/test/triageRender.test.ts
+++ b/test/triageRender.test.ts
@@ -65,7 +65,6 @@ describe("renderTriageReport policy suggestion footer", () => {
     expect(result).toContain("Create `.pr-agent/src-auth-login.mdc` with:");
     expect(result).toContain("False positive: input is sanitized upstream.");
     expect(result).not.toContain(".pr-agent.yml");
-    // The non-dismissed thread should not appear in the suggestions
     const suggestionSection = result.split("Policy suggestions")[1];
     expect(suggestionSection).not.toContain("src/other.ts");
   });

--- a/test/writablePrCheckout.test.ts
+++ b/test/writablePrCheckout.test.ts
@@ -86,14 +86,7 @@ describe("writable PR checkout", () => {
       buildCommitCommandArgs({
         files: ["x"],
         subject: "fix: guard null user",
-        body: [
-          "- One",
-          "- Two",
-          "- Three",
-          "- Four",
-          "- Five",
-          "- Six",
-        ],
+        body: ["- One", "- Two", "- Three", "- Four", "- Five", "- Six"],
       }),
     ).toThrow(/at most 5 bullets/);
     expect(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Full-codebase two-axis review (empty-tree fixed point) plus cleanup shipped on this branch.

- Knip workspace config, dead exports, unused deps, ignored-slash constant wiring
- Inline one-caller Middle Man helpers; delete dead re-exports and unused lens `mode` params
- Convert domain bare `Error` throws to `AppError` with stable codes
- Dedupe GitHub permission-miss helpers; strip narrating AI JSDoc
- Align site slash marketing with live intake (`/review`, `/describe`, `/ask`, `/triage`)

## Standards

Hard findings addressed:
- Bare `Error` in specialist/triage/cursor/pi domain paths → `AppError`
- Dead re-exports (`reviewPublishRetry`, `installationTokenExpiry`)
- Duplicate `isMissing*PermissionError` twins collapsed
- Site CONTEXT violation: legacy lenses marketed as live commands

Judgement-call smells addressed where reader load dropped:
- Middle Man helpers (`formatAskFailureReply`, `isTriageEligibleLens`, `reviewSingletonSlotDb`, `pgBossJob`, test placement wrappers)
- Speculative Generality (`reviewSummarySentinelForMode`, unused `_mode` params, `createCiSummaryLlmSchema` wrapper)
- Narrating JSDoc / AI comment slop in site + selected src modules

Left for later (large or lower ROI): Effect/evlog Error normalizers, triage/verification harness merge, `reviewPublish.ts` module split, `defineLocalTool` identity wrapper.

## Spec

Against `docs/superpowers/plans/2026-07-22-codebase-cleanup-spec.md`:
- Reqs 2–5 largely closed for high-confidence targets (inline/delete, speculative params, AI slop, AppError hard path)
- Pin verified: `nub run test` 1256, `nubx knip` 0, `nub run check:code` green
- Shipped on `pd/chore/knip-deslop-15a1` (this PR)

Standards: multiple hard + judgement findings; worst hard was bare `Error` in `src/`. Spec: cleanup incomplete on some large harness/Effect seams; worst remaining is Effect catch normalizers still minting bare `Error`.

## Verification

- `nubx knip` exit 0
- `nub run check:code` green
- `nub run test` 1256 passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80e06ce5-878f-4abc-a6a4-0833efe615a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80e06ce5-878f-4abc-a6a4-0833efe615a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

___

## PR Agent Description

### PR Type

Enhancement, Documentation, Tests

### Description

- Add workspace-aware `knip.json` for root and site
- Remove unused dep `@octokit/request-error`, dead `mintBotIdentity`, and stale prompt blocks
- Unexport 16 internal-only types and functions across src/
- Replace hardcoded ignore-reason strings with `IGNORED_*` constants in webhook handler
- Trim verbose/slop comments in hero.tsx, reviewSchema, appAuth, reviewPromptBlocks, and test files
- Update docs: drop removed-symbol rows from configuration.md
- Tests use `REVIEW_ANCHOR_MENU_*` constants instead of magic numbers

### Changes Diagram

```mermaid
flowchart LR
  A["Add knip.json"] --> B["Remove dead exports"]
  B --> C["Drop unused @octokit/request-error"]
  C --> D["Wire IGNORED_* constants in webhook"]
  D --> E["Unexport internal-only APIs"]
  E --> F["Deslop verbose comments"]
  F --> G["Update docs and tests"]
```

### File Walkthrough

<details>
<summary>Enhancement (17 files)</summary>

<details>
<summary>Workspace-aware knip configuration</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/331/files#diff-5086ee3d4f07acf8704cd800423a4681bb25515a3f704afeebda27281a32eea3"><code>knip.json</code></a>

- Root workspace scans src/ and test/
- Site workspace includes router, app, and routeTree

</details>

<details>
<summary>Remove unused @octokit/request-error dependency</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/331/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519"><code>package.json</code></a>

- Dropped from direct dependencies; still present as transitive dep

</details>

<details>
<summary>Remove dead prompt block exports</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/331/files#diff-e7575c6284069631afc2ac0a72c8aaf2e4324839c1214b7a5b61656f64233d7c"><code>src/review/prompts/reviewPromptBlocks.ts</code></a>

- Removed singlePassReviewContract, publicOutputContract, structuredDeliveryHeader, reviewPayloadFieldsHeader, reviewPayloadCommonTail, inlineSeverityPlacement, reviewSecretsAndToolingNote
- Removed re-export of ciGateRowContract and CI_SUMMARY_SYSTEM_PROMPT

</details>

<details>
<summary>Remove unused REVIEW_PAYLOAD_MINIMAL_EXAMPLE</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/331/files#diff-70f9afc9f063392f9404c555d3389e87e327857d2bd07da4d8c31ad9c3c899b5"><code>src/review/reviewSchema.ts</code></a>

- Dropped the minimal example constant and its slop comment block

</details>

<details>
<summary>Remove dead mintBotIdentity and unused httpStatus import</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/331/files#diff-89b5a37459390a193fc32ea9022bde071cc9de1701c79c994a2e328028971aa1"><code>src/github/appAuth.ts</code></a>

- Deleted 50-line mintBotIdentity function (no callers)
- Removed unused httpStatus import

</details>

<details>
<summary>Use IGNORED_* constants instead of string literals</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/331/files#diff-f2fc71d4243b5e9b5d6e49bf08cc775cbd26dbbef43ec17555ef1ac62c3c7aa0"><code>src/effect/services/webhookHandlers.ts</code></a>

- Replaced 'ignored_bot_slash_command' and 'ignored_unauthorized_slash' string literals with exported constants from queueConstants
- Removed WebhookHandlersLive re-export alias; callers use WebhookHandlersCore directly

</details>

<details>
<summary>Remove unused ASK_TOOLS_WITH_OWNER_REPO and ASK_TOOLS_WITH_PULL_NUMBER</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/331/files#diff-acb9622b1f54d7d91b2ba2a8ff162f2210b2a8baafbafe141e8bed599d1a7fc9"><code>src/settings/askConstants.ts</code></a>

- Both tool scope sets were dead code with no consumers

</details>

<details>
<summary>Remove unused DEFAULT_COOLDOWN_SECONDS</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/331/files#diff-9453577f596b332b32abfd8264fbf041f0608b4e0cf16506449a812b10615922"><code>src/settings/githubConstants.ts</code></a>

- Dead constant with zero references after this change

</details>

<details>
<summary>Remove deprecated TRIAGE_NO_PRIOR_FINDINGS alias</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/331/files#diff-93b4de36c9ea8d0712d90951d708e19d49edb3eaa05f6de2864d6a29d471eb06"><code>src/settings/triageConstants.ts</code></a>

- Legacy empty inventory text alias already replaced by TRIAGE_NO_ELIGIBLE_FINDINGS

</details>

<details>
<summary>Unexport LegacyReviewLens type</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/331/files#diff-a057209e9fbcc986a2f0cab5c17dbe09e54bb2cdd95f9b38f959775368ef5416"><code>src/settings/legacyReviewLenses.ts</code></a>

- Changed from export to file-local; only used internally for AnyReviewLens

</details>

<details>
<summary>Unexport MODELS_JSON_FILENAME constant</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/331/files#diff-118e4a169c578aa43e90f7efbef5bbd8e9adc9ce90ef2848c8d3450ec5b9fab3"><code>src/settings/modelsJson.ts</code></a>

- Changed from export to file-local; no external consumers

</details>

<details>
<summary>Stop re-exporting unused AgentRunnerPromptMetadata and AgentRunnerUsageMetadata</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/331/files#diff-7318d230cb109b71ef2eb61f22ef7237cb2ce46ef9946313b61f0c79ecd97392"><code>src/agent/providers/interface.ts</code></a>

- Only AgentRunnerTurn is re-exported now
- Removed unused type imports

</details>

<details>
<summary>Unexport SerializedCause type</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/331/files#diff-3131e08af206ac42032a6f306a3dddf0c0a7d14eeb7ae1d878c0554e545fb9c2"><code>src/errors/appError.ts</code></a>

- Internal-only type; no external consumers

</details>

<details>
<summary>Unexport createCiSummaryLlmSchema</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/331/files#diff-11c2f83c199203d0b7a9b2f205cc9dae100fe62f625e62fe8b6b68bf2564d1c1"><code>src/review/ci/ciSummarySchema.ts</code></a>

- Factory function only used within the module

</details>

<details>
<summary>Unexport publishSummarySchema</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/331/files#diff-7c6e741ed9a0db2dd8849fb1a47b42e7e94f721de7cd7ce17f35fd92ffef87c4"><code>src/review/orchestrator/publishSummaryTool.ts</code></a>

- Zod schema only used locally for tool definition

</details>

<details>
<summary>Unexport publishThreadSchema and PublishedThreadOverlapHint</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/331/files#diff-93eef586db5d0dce79dc31be255f6bf435334fff6eec906c88953acba073eca8"><code>src/review/orchestrator/publishThreadTool.ts</code></a>

- Both only used within the module

</details>

<details>
<summary>Unexport six JSON-LD helper functions</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/331/files#diff-cf47298f05a6a287d7f2e9f5f6094545cab650a2a8eda73c13a7ffbb2af63ed7"><code>site/lib/seo.ts</code></a>

- softwareApplicationJsonLd, webSiteJsonLd, organizationJsonLd, faqPageJsonLd, itemListJsonLd changed to file-local
- Exported only via JSON_LD_GRAPHS array

</details>

</details>

<details>
<summary>Documentation (2 files)</summary>

<details>
<summary>Remove deleted symbol rows from config docs</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/331/files#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180"><code>docs/configuration.md</code></a>

- Removed TRIAGE_NO_PRIOR_FINDINGS, DEFAULT_COOLDOWN_SECONDS, ASK_TOOLS_* rows
- Re-aligned table formatting

</details>

<details>
<summary>Knip cleanup plan document</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/331/files#diff-eb758f35d2521344a92cf2c1ccfb7702722528e5fbb16f90d53d5a1a1d0b07c2"><code>docs/superpowers/plans/2026-07-22-knip-deslop.md</code></a>

- Describes goal, requirements, steps, and non-goals for this cleanup pass

</details>

</details>

<details>
<summary>Tests (1 file)</summary>

<details>
<summary>Use REVIEW_ANCHOR_MENU_* constants in tests</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/331/files#diff-2d9b896979e7675e5832ee3c7f097a3492adb8b84020aa9ed2762497bfa669e7"><code>test/reviewAnchorMenu.test.ts</code></a>

- Replaced magic numbers 40 and 20 with REVIEW_ANCHOR_MENU_MAX_FILES and REVIEW_ANCHOR_MENU_MAX_RANGES_PER_FILE

</details>

</details>