### PR TITLE
Salvage summary when synthesis never publishes

### DIFF
--- a/src/review/orchestrator/orchestratorRun.ts
+++ b/src/review/orchestrator/orchestratorRun.ts
@@ -891,10 +891,20 @@ export async function runOrchestratedPrReview(
         state.summary = { kind: "pending" };
       } else if (summaryState.published) {
         state.summary = { kind: "published" };
-      } else if (state.judgment === "degraded" || sessionRetired) {
-        await publishDeterministicSummary();
       } else {
-        await publishFailureNotice();
+        // Model/session stayed healthy but never landed publish_summary after recovery.
+        // Salvage accepted findings the same way as the degraded path instead of a hard fail.
+        if (state.judgment !== "degraded" && !sessionRetired) {
+          logWarn("review_synthesis_publish_salvage", {
+            owner: params.owner,
+            repo: params.repo,
+            pr: params.prNumber,
+            publishAttempts,
+            judgment: state.judgment,
+            lastValidationError: summaryState.lastValidationError,
+          });
+        }
+        await publishDeterministicSummary();
       }
       markCompleteUnlessStopped();
     }

--- a/src/review/run/reviewRunFallback.ts
+++ b/src/review/run/reviewRunFallback.ts
@@ -5,7 +5,6 @@ import { renderReviewFailureNotice } from "./progressComment.js";
 import type { ReviewRunSetup } from "./reviewRunSetup.js";
 import { REVIEW_SUMMARY_SENTINEL } from "../reviewSchema.js";
 import type { AnyReviewLens } from "../../settings/legacyReviewLenses.js";
-import { MAX_REVIEW_PUBLISH_CALLS } from "../../settings/index.js";
 
 export async function publishReviewRunFailureNotice(params: {
   readonly cfg: Config;
@@ -19,7 +18,6 @@ export async function publishReviewRunFailureNotice(params: {
   logWarn("agent_publish_fallback", {
     mode: params.reviewMode,
     publishAttempts: params.publishAttempts,
-    maxPublishCalls: MAX_REVIEW_PUBLISH_CALLS,
   });
   const token = params.setup.getToken();
   const tokenExpiresAtTs = params.setup.getTokenExpiresAtTs();

--- a/test/orchestratorRun.test.ts
+++ b/test/orchestratorRun.test.ts
@@ -55,6 +55,7 @@ const testState = vi.hoisted(() => ({
   } | null,
   restrictionFailureTool: null as string | null,
   publishedBatchCount: 0,
+  synthesisPublishesSummary: true,
 }));
 
 vi.mock("../src/review/run/reviewRunSetup.js", () => ({
@@ -338,6 +339,7 @@ describe("runOrchestratedPrReview", () => {
     testState.sendDelay = null;
     testState.restrictionFailureTool = null;
     testState.publishedBatchCount = 0;
+    testState.synthesisPublishesSummary = true;
     for (const specialist of ["correctness", "security", "quality", "tests"] as const) {
       testState.outcomes.set(specialist, deferred());
     }
@@ -384,9 +386,15 @@ describe("runOrchestratedPrReview", () => {
             }
             await sessionParams.refreshBeforeTool?.("publish_thread");
             await executors.publish_thread?.({ findings: [] });
-          } else if (prompt.includes("Synthesize the final")) {
-            await sessionParams.refreshBeforeTool?.("publish_summary");
-            await executors.publish_summary?.({});
+          } else if (
+            prompt.includes("Synthesize the final") ||
+            prompt.includes("Call publish_summary now") ||
+            prompt.includes("Fix the summary and call publish_summary")
+          ) {
+            if (testState.synthesisPublishesSummary) {
+              await sessionParams.refreshBeforeTool?.("publish_summary");
+              await executors.publish_summary?.({});
+            }
           }
           return { text: "ok" };
         }),
@@ -600,6 +608,21 @@ describe("runOrchestratedPrReview", () => {
     await expect(run).resolves.toMatchObject({ published: false });
     expect(testState.publishOrder).toEqual([]);
     expect(testState.failureNotices).toBe(1);
+  });
+
+  it("publishes a deterministic summary when synthesis never calls publish_summary", async () => {
+    testState.synthesisPublishesSummary = false;
+    const run = runOrchestratedPrReview(params());
+    testState.outcomes.get("correctness")?.resolve(report("correctness"));
+    await vi.waitFor(() => expect(testState.publishOrder).toEqual(["correctness"]));
+    testState.outcomes.get("security")?.resolve(empty("security"));
+    testState.outcomes.get("quality")?.resolve(empty("quality"));
+    testState.outcomes.get("tests")?.resolve(empty("tests"));
+
+    await expect(run).resolves.toMatchObject({ published: true, publishSuperseded: false });
+    expect(testState.publishOrder).toEqual(["correctness", "summary"]);
+    expect(testState.failureNotices).toBe(0);
+    expect(testState.deterministicSummaries).toHaveLength(1);
   });
 
   it("falls back to a deterministic brief when recon never submits one", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Fall back to a deterministic summary when synthesis never lands `publish_summary`
- Log `review_synthesis_publish_salvage` with the last validation error
- Stop attaching `submitReview`'s `maxPublishCalls` to `agent_publish_fallback`
- Cover the no-`publish_summary` salvage path in orchestrator tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6afe389-afb5-42c8-807b-c9a718879ff6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6afe389-afb5-42c8-807b-c9a718879ff6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

