### PR TITLE
Add llms.txt to the landing site

### DIFF
--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -1,0 +1,27 @@
+# PR Agent
+
+> Self-hosted GitHub App for AI pull request reviews. You run webhook intake, Postgres, and workers. MIT licensed. No per-seat fee. You pay hosting and model usage.
+
+PR Agent accepts signed GitHub webhooks, records them in Postgres, and enqueues durable work with pg-boss. Workers run review, describe, ask, triage, and verification agents, then publish results back on the pull request. Slash commands are /review, /describe, /ask, and /triage. Automated review can also run on pull_request events.
+
+You keep model keys and review traffic in your own environment. Supported backends include OpenAI, Anthropic, Google, DeepSeek, OpenRouter, Groq, and the Cursor SDK.
+
+## Docs
+
+- [Getting started](https://github.com/prathamdby/pr-agent#getting-started): GitHub App setup and Docker Compose deploy
+- [Features](https://github.com/prathamdby/pr-agent/blob/main/docs/features.md): FEATURE_* catalog and capability modes (off, manual, auto)
+- [Configuration](https://github.com/prathamdby/pr-agent/blob/main/docs/configuration.md): Environment variables and knobs
+- [Operations](https://github.com/prathamdby/pr-agent/blob/main/docs/operations.md): Deploy steps, runtime behaviour, and scripts
+- [Domain vocabulary](https://github.com/prathamdby/pr-agent/blob/main/CONTEXT.md): Product terms used in code and docs
+
+## Product
+
+- [Landing page](https://pr-agent-site.vercel.app/): Product overview, pricing, FAQ, and deploy steps
+- [Repository](https://github.com/prathamdby/pr-agent): Source, issues, and releases
+- [How it works](https://github.com/prathamdby/pr-agent#how-it-works): Web intake vs worker topology
+
+## Optional
+
+- [Agent work ops](https://github.com/prathamdby/pr-agent/blob/main/docs/agent-work-ops.md): Queue health and recovery runbook
+- [Architecture decisions](https://github.com/prathamdby/pr-agent/tree/main/docs/adr): ADRs for major design choices
+- [License](https://github.com/prathamdby/pr-agent/blob/main/LICENSE): MIT


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a curated [`llms.txt`](https://llmstxt.org/) at `site/public/llms.txt` so LLM clients get a short product summary plus absolute links to docs, the landing page, and optional deep references.

Vite/Nitro copies `public/` into the Vercel static output, so the file is served at `/llms.txt` on deploy with no extra config.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7e76765-659a-4810-9a44-de6151ec2bf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7e76765-659a-4810-9a44-de6151ec2bf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

___

## PR Agent Description

### PR Type

Documentation

### Description

- Add site/public/llms.txt with project overview, doc links, and product URLs
- Follow llms.txt standard for LLM-friendly documentation indexing
- Covers getting started, features, configuration, operations, and architecture docs

### File Walkthrough

<details>
<summary>Documentation (1 file)</summary>

<details>
<summary>LLM documentation index file</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/339/files#diff-b855fb955af59168d9fa01ed0fe5dd0cf752bf9c9b12e673675a74b2e754af2e"><code>site/public/llms.txt</code></a>

- One-paragraph project summary for LLM context
- Links to getting-started, features, config, and operations docs
- Links to product landing page, repo, and how-it-works
- Optional section with ADRs, runbook, and license

</details>

</details>