### PR TITLE
Replace Docker corepack path with Nub ci and prune

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,10 @@
 **/.env.*
 !.env.example
 
-site
+# Backend image needs site/package.json so the workspace lockfile stays valid
+# under frozen Nub installs; exclude the rest of the landing package.
+site/**
+!site/package.json
 docs
 .github
 test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,4 +62,4 @@ Skip doc updates when none of the above apply.
 - **Tests (`nub run test`)** are pure unit/integration tests and do not need Postgres or any running service. Use `nub run --node test` if Vitest shows augmentation-related flakiness.
 - **Lint/fmt commands**: `nub run lint` (oxlint, type-aware), `nub run typecheck` (tsc), `nub run fmt:check` (oxfmt). Combined: `nub run check:code`.
 - **Ignored build scripts warning** from Nub is expected for some transitive deps (`esbuild`, `protobufjs`). The worker image does not need a native `sqlite3` build for the agent runtime (see ADR 0031).
-- **Vercel site deploys** remain on pnpm via [`site/vercel.json`](site/vercel.json); all other surfaces use Nub in pnpm incumbent mode.
+- **Vercel site deploys** keep the platform installer (pnpm via [`site/vercel.json`](site/vercel.json)) per Nub's hosted-builder pattern; add `@nubjs/nub` as a devDependency only if site scripts need `nub`. All other surfaces use Nub in pnpm incumbent mode.

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,20 +7,15 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 RUN npm install -g --ignore-scripts=false @nubjs/nub
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc .node-version ./
+COPY site/package.json ./site/package.json
+# nub ci uses a project-local store so node_modules is COPY-safe across stages.
 RUN --mount=type=cache,id=nub-store,target=/root/.local/share/nub/store \
-  sed -i '/- "site"/d' pnpm-workspace.yaml \
-  && nub install --no-frozen-lockfile
+  nub ci --filter 'pr-agent...'
 
 FROM deps AS prod-deps
-# Nub's virtual store uses absolute symlinks into the PM cache; copying node_modules
-# alone breaks between stages. pnpm deploy materializes a self-contained prod tree.
-RUN corepack enable && corepack prepare pnpm@10.34.1 --activate
-# Deploy re-resolves optional platform bindings (oxfmt/oxlint) from the lockfile.
-# Those packages already passed nub install's age gate; disable the check here so
-# unused host bindings (e.g. darwin) do not fail the linux prod image build.
-RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
-  pnpm deploy --filter=pr-agent --prod --legacy /app/prod \
-  --config.minimum-release-age=0
+# Drop devDependencies from the project-local tree. Leftover .store symlinks to
+# pruned packages are unused by production imports.
+RUN nub prune --prod --filter 'pr-agent...'
 
 FROM deps AS build
 COPY tsconfig.base.json tsconfig.build.json ./
@@ -38,8 +33,8 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends git ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
-COPY --from=prod-deps /app/prod/package.json ./package.json
-COPY --from=prod-deps /app/prod/node_modules ./node_modules
+COPY --from=prod-deps /app/package.json ./package.json
+COPY --from=prod-deps /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/migrations ./migrations
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ ROLE=worker DATABASE_URL=postgres://pr_agent:pr_agent@localhost:5432/pr_agent nu
 
 If you previously installed with pnpm, delete `node_modules` before your first `nub install` to avoid mixed virtual-store layouts (`.pnpm/` vs `.nub/`).
 
-**Vercel** site deploys still use pnpm via [`site/vercel.json`](site/vercel.json) until Vercel has native Nub support.
+**Vercel** site deploys still use the platform installer (pnpm via [`site/vercel.json`](site/vercel.json)). That matches Nub's hosted-builder guidance: keep the builder's install when there is no setup step; add `@nubjs/nub` as a devDependency only if site scripts need the `nub` binary (they currently call Vite/`node` directly).
 
 Minimal env:
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -96,7 +96,8 @@ PR_AGENT_ENV_FILE=/abs/path/to/.env docker compose up
 - **`GITHUB_APP_PRIVATE_KEY` must be a valid PEM key**. For local-only dev: `openssl genrsa 2048 > key.pem` and set the escaped PEM in `.env`.
 - Tunnel webhooks (e.g. [smee.io](https://smee.io)) to local `PORT`, then point the GitHub App webhook at the smee URL forwarding to `/webhooks`.
 - If switching from pnpm-installed trees, delete `node_modules` before the first `nub install`.
-- **Vercel** site deploys still use pnpm via [`site/vercel.json`](../site/vercel.json).
+- **Vercel** site deploys keep the platform installer (pnpm via [`site/vercel.json`](../site/vercel.json)). Add `@nubjs/nub` as a devDependency only if site scripts need the `nub` binary.
+- **Docker image** installs with Nub only (`nub ci` for build deps; `nub prune --prod` for the runtime tree). No `corepack` / `pnpm deploy` in the Dockerfile. [`.dockerignore`](../.dockerignore) keeps `site/package.json` in the build context so the workspace lockfile stays valid under frozen installs; the rest of `site/` stays excluded.
 
 Canonical quick start steps live in [README.md](../README.md) **Getting Started**.
 

--- a/docs/superpowers/plans/2026-07-25-nub-start-md-alignment.md
+++ b/docs/superpowers/plans/2026-07-25-nub-start-md-alignment.md
@@ -1,0 +1,83 @@
+# Align Docker/docs with Nub start.md + deployment guidance
+
+**Date:** 2026-07-25
+**Requirements source:** https://nubjs.com/start.md (+ offline `nub agent docs` for /docs/deployment/docker, /docs/deployment, /docs/install/virtual-store)
+**Repo map:** recon memory `/home/ubuntu/.agents/skills/recon/memory/workspace-c52ddf65.md`
+
+## Problem
+
+start.md and current Nub docs say:
+
+- Package-manager provisioning / corepack is subsumed by Nub (`nub pm` / Nub install).
+- Docker multi-stage installs should use Nub (`nub ci` / project-local or hoisted self-contained trees) so `node_modules` survives `COPY --from`.
+- Hosted builders without a setup step can add `@nubjs/nub` as a devDependency; GH Actions should use `nubjs/setup-nub` (already true here).
+
+Current repo discrepancies:
+
+1. `Dockerfile` prod stage still runs `corepack enable` + `pnpm deploy --prod` because of an outdated comment that Nub's virtual store cannot be copied across stages.
+2. README / AGENTS.md / docs/operations.md still frame Vercel as "pnpm until native Nub" without the documented hosted-builder pattern.
+3. Local/Docker install instructions only show `npm install -g --ignore-scripts=false @nubjs/nub` (still valid per Nub intro docs) and omit start.md's curl/brew options (docs-only nicety; optional).
+
+Evidence probes (Nub v0.5.0):
+
+- `nub ci` / project-local `.store` is self-contained and COPY-safe.
+- `nub deploy` is **not yet supported** (CLI says use `pnpm deploy` for now).
+- Corepack-free prod stand-in that is COPY-safe:  
+  `nub ci --filter 'pr-agent...'` then `nub prune --prod --filter 'pr-agent...'`  
+  (`nub install --prod --node-linker hoisted` left missing top-level links under Docker cache mounts in this repo).
+
+## Out of scope
+
+- Switching lockfile/PM away from pnpm (forbidden by start.md).
+- Removing cloud PATH/`EACCES` gotcha for global npm installs in AGENTS.md (still real for Cursor Cloud).
+- Installing the global Nub agent skill on the machine (environment-level; not a repo PR concern unless we add a project skill file).
+
+## Plan (independent steps — implement all)
+
+### A. Dockerfile: drop corepack / pnpm deploy
+
+Rewrite multi-stage deps/prod-deps to Nub-only:
+
+1. Keep Node 22.22.0 base and global Nub install (`npm install -g --ignore-scripts=false @nubjs/nub`).
+2. Copy workspace manifests **including** `site/package.json` so the lockfile stays valid under frozen installs (stop stripping `site` from `pnpm-workspace.yaml` and stop `--no-frozen-lockfile`).
+3. `deps` / build install: `nub ci --filter 'pr-agent...'` (project-local store; includes build tools). Keep a cache mount for Nub's store if useful.
+4. `prod-deps`: `FROM deps AS prod-deps` then `RUN nub prune --prod --filter 'pr-agent...'` (keeps project-local `.store` links; drops devDependencies).
+5. Allow `site/package.json` through `.dockerignore` (`site/**` + `!site/package.json`) so frozen workspace installs work without pulling the landing app sources.
+6. Runtime `COPY` paths must change from `/app/prod/package.json` and `/app/prod/node_modules` to `/app/package.json` and `/app/node_modules`. Keep models.json optional copy, healthcheck, and `CMD ["node", "dist/index.js"]`.
+7. Remove `corepack` / `pnpm deploy` entirely.
+
+Verify: `docker build` succeeds (or the buildx path CI's docker job uses). Smoke: container can `node -e "import('effect')"` (or equivalent) with the copied prod tree.
+
+### B. Docs: Vercel / hosted-builder wording
+
+Update README.md, AGENTS.md, docs/operations.md:
+
+- Keep the fact that Vercel still runs its own installer for `site/`.
+- Replace "until Vercel has native Nub support" with the current Nub guidance: hosted builders without a setup step keep the platform installer; add `@nubjs/nub` as a devDependency only if scripts need the `nub` binary. Site scripts currently call Vite/`node` directly, so no dependency add is required unless we choose to route site scripts through Nub.
+- Do **not** change `site/vercel.json` in this PR unless we also add `@nubjs/nub` and switch scripts (separate optional step C).
+
+### C. Optional (include only if low-risk): route site scripts via Nub on Vercel
+
+If chosen:
+
+1. `nub add -D @nubjs/nub` at repo root (or site package — prefer root workspace).
+2. Update `site/vercel.json` install/build to use Nub after the platform can resolve the binary, OR keep pnpm install and change `buildCommand` to invoke `nub` via `node_modules/.bin`.
+3. Update docs accordingly.
+
+**Default for this PR:** skip C; docs-only for Vercel (step B), code fix for Dockerfile (step A).
+
+### D. Same-PR doc table
+
+Per AGENTS.md: Dockerfile/deploy behaviour → update docs/operations.md (and README getting-started / AGENTS cloud notes as touched).
+
+## Verification
+
+1. `nub run check:code` (docs/Dockerfile shouldn't affect, but keep green).
+2. `nub run test` if any related tests exist (none currently reference Dockerfile).
+3. `docker build` for the image (required for A).
+4. Confirm grep shows no `corepack` in Dockerfile.
+5. Confirm runtime COPY paths no longer reference `/app/prod/`.
+
+## Rollback
+
+Revert the single PR branch; Docker consumers fall back to previous corepack/pnpm deploy path.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Replace `Dockerfile` `corepack` / `pnpm deploy` with `nub ci` plus `nub prune --prod`, copying `/app/node_modules` into the runtime stage
- Keep `site/package.json` in the Docker build context via `.dockerignore` so frozen workspace installs stay valid
- Align README, AGENTS.md, and operations docs with Nub hosted-builder guidance for Vercel
- Add the alignment plan under `docs/superpowers/plans/`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32b0d1a7-ba53-435a-a370-c528eda3dc39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32b0d1a7-ba53-435a-a370-c528eda3dc39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

___

## PR Agent Description

### PR Type

Enhancement, Documentation

### Description

- Swap corepack + pnpm deploy for nub ci and nub prune --prod in Dockerfile
- Allow site/package.json through .dockerignore for frozen workspace installs
- Update Vercel/hosted-builder docs to match current Nub guidance
- Add deployment plan doc for the alignment work

### File Walkthrough

<details>
<summary>Enhancement (2 files)</summary>

<details>
<summary>Nub-only Docker multi-stage build</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/353/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557"><code>Dockerfile</code></a>

- Replace corepack enable + pnpm deploy with nub ci and nub prune --prod
- Include site/package.json so frozen workspace installs succeed
- Update prod-deps COPY paths from /app/prod/ to /app/

</details>

<details>
<summary>Allow site/package.json in build context</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/353/files#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5"><code>.dockerignore</code></a>

- Exclude site/** but keep site/package.json via negation pattern
- Needed for frozen Nub installs to keep workspace lockfile valid

</details>

</details>

<details>
<summary>Documentation (4 files)</summary>

<details>
<summary>Add Docker and Vercel deployment notes</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/353/files#diff-ad74991b96593fdee570962fc5b1e319080abd55e16614f556f74b7de8fd02d1"><code>docs/operations.md</code></a>

- Document Nub-only Docker build and .dockerignore rationale
- Update Vercel wording to match Nub hosted-builder guidance

</details>

<details>
<summary>Update Vercel hosted-builder documentation</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/353/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5"><code>README.md</code></a>

- Replace outdated 'until native Nub support' phrasing
- Explain when to add @nubjs/nub as devDependency for hosted builders

</details>

<details>
<summary>Align Vercel docs with Nub guidance</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/353/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9"><code>AGENTS.md</code></a>

- Update Vercel deploy note to match current Nub hosted-builder pattern

</details>

<details>
<summary>Add deployment alignment plan document</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/353/files#diff-a945e73ac98625a6615fcc73d0a9c9522f1d573de37df772fb890a05dc48169e"><code>docs/superpowers/plans/2026-07-25-nub-start-md-alignment.md</code></a>

- Document discrepancies between repo and Nub start.md guidance
- Outline Dockerfile refactor and doc update plan with verification steps

</details>

</details>