### PR TITLE
Add orb setup and resume lifecycle scripts

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Orb resume for pr-agent — fast, idempotent repair on every orb wake.
+# Target: complete within ~10s. No dependency installs here.
+set -euo pipefail
+
+# Ensure the Postgres cluster is up (systemd-managed on the base orb).
+if ! pg_isready -q -h localhost -p 5432; then
+  sudo systemctl start postgresql@18-main 2>/dev/null || sudo pg_ctlcluster 18 main start 2>/dev/null || true
+fi
+
+# Re-copy env template if it vanished (e.g. fresh checkout in a restored snapshot).
+[ -f .env ] || cp -- .env.example .env
+
+pg_isready -h localhost -p 5432 -U pr_agent -d pr_agent >/dev/null 2>&1 \
+  && echo "[resume] postgres ready" \
+  || echo "[resume] WARN: postgres not reachable on localhost:5432"

--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Orb setup for pr-agent — runs once per fresh orb (and after snapshot restore).
+# Installs the Nub package manager + pinned Node 22 toolchain, installs workspace
+# dependencies from the lockfile, prepares a tuned Postgres database, and copies
+# the env template. Idempotent and non-interactive.
+set -euo pipefail
+
+echo "[setup] pr-agent orb bootstrap"
+
+# --- Toolchain: Nub (provisions the Node 22.22.0 pinned in .node-version) ---
+if ! command -v nub >/dev/null 2>&1; then
+  echo "[setup] installing @nubjs/nub globally"
+  sudo npm install -g --ignore-scripts=false @nubjs/nub
+else
+  echo "[setup] nub already available ($(nub -v))"
+fi
+
+# --- Dependencies (frozen install from pnpm-lock.yaml, both workspaces) ---
+echo "[setup] installing workspace dependencies (nub ci)"
+nub ci --filter pr-agent... --filter pr-agent-landing...
+
+# --- Postgres: ensure server tooling is present ---
+if ! command -v pg_ctlcluster >/dev/null 2>&1; then
+  echo "[setup] installing postgresql via apt-get"
+  sudo apt-get update
+  sudo apt-get install -y --no-install-recommends postgresql
+fi
+
+# Tune the cluster for speed over durability (dev orb; data is ephemeral).
+echo "[setup] tuning postgres (fsync=off, synchronous_commit=off)"
+sudo -u postgres psql -v ON_ERROR_STOP=1 -c "ALTER SYSTEM SET fsync = off;" \
+  -c "ALTER SYSTEM SET synchronous_commit = off;" >/dev/null
+
+# Ensure the cluster is running (systemd-managed on the base orb).
+if ! pg_isready -q -h localhost -p 5432; then
+  echo "[setup] starting postgres cluster"
+  sudo systemctl start postgresql@18-main 2>/dev/null || sudo pg_ctlcluster 18 main start
+fi
+# (Re)start so ALTER SYSTEM fsync change takes effect; no-op-safe on a fresh orb.
+sudo systemctl restart postgresql@18-main 2>/dev/null || sudo pg_ctlcluster 18 main restart || true
+
+# --- Postgres: create pr_agent role + database idempotently ---
+echo "[setup] ensuring pr_agent role + database"
+sudo -u postgres psql -v ON_ERROR_STOP=1 <<'SQL'
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'pr_agent') THEN
+    CREATE ROLE pr_agent LOGIN PASSWORD 'pr_agent';
+  END IF;
+END $$;
+SQL
+if ! sudo -u postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname = 'pr_agent'" | grep -q 1; then
+  sudo -u postgres createdb -O pr_agent pr_agent
+fi
+
+# --- Env: copy template without clobbering an existing .env ---
+if [ ! -f .env ]; then
+  echo "[setup] copying .env.example -> .env"
+  cp -- .env.example .env
+else
+  echo "[setup] .env already present, leaving as-is"
+fi
+
+# --- Orb agent guidance ---
+mkdir -p "$HOME/.config/amp"
+cat > "$HOME/.config/amp/AGENTS.md" <<'AGENTS'
+# pr-agent orb notes
+
+- **Package manager is Nub**, not pnpm/npm directly. Node 22.22.0 is pinned in `.node-version`; `nub` provisions it. Use `nub run <script>` (see `package.json`), `nub src/index.ts` to run, `nub watch src/index.ts` for auto-restart.
+- **Postgres 18 is preinstalled and running** on `localhost:5432`. The `pr_agent` role + database (password `pr_agent`) are created by `.agents/setup`, tuned `fsync=off` / `synchronous_commit=off` for dev speed. `DATABASE_URL=postgres://pr_agent:pr_agent@localhost:5432/pr_agent` (already in `.env`).
+- **Migrations auto-apply** at worker boot (`src/agentWork/runtime.ts`). Integration tests run migrations themselves per-suite, so the DB only needs to exist.
+- **Unit tests** (`nub run test`) need no DB. **Integration tests** require `DATABASE_URL` exported in the env (vitest does not auto-load `.env`): `DATABASE_URL=postgres://pr_agent:pr_agent@localhost:5432/pr_agent nub run test:integration`. Inventory-only: `nub run test:integration:inventory`.
+- **Checks**: `nub run check:code` (typecheck + oxlint + oxfmt), `nub run build`, `nub run check:effect-versions`, `nub run check:prod-deps`.
+- **Run the app**: `ROLE=web nub src/index.ts` and `ROLE=worker nub src/index.ts` (two terminals). `nub src/index.ts` loads `.env` automatically. Set real `GITHUB_APP_*`, `WEBHOOK_SECRET`, and provider keys (e.g. `OPENAI_API_KEY`) in `.env` before running; the template placeholders will fail `loadConfig()` at boot.
+- The landing site is workspace `pr-agent-landing` (`site/`): `nub run site:dev` / `nub run site:build`.
+AGENTS
+
+echo "[setup] done"

--- a/.agents/setup
+++ b/.agents/setup
@@ -56,6 +56,11 @@ fi
 git config --local user.name "Pratham Dubey"
 git config --local user.email "134331217+prathamdby@users.noreply.github.com"
 
+# --- Agent skills: install and update global skills from prathamdby/skills ---
+echo "[setup] installing global agent skills"
+nubx -y skills@latest add prathamdby/skills -g -y --skill '*'
+nubx -y skills@latest update -g -y
+
 # --- Env: copy template without clobbering an existing .env ---
 if [ ! -f .env ]; then
   echo "[setup] copying .env.example -> .env"

--- a/.agents/setup
+++ b/.agents/setup
@@ -52,6 +52,10 @@ if ! sudo -u postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname = 'pr_a
   sudo -u postgres createdb -O pr_agent pr_agent
 fi
 
+# --- Git: set identity in the repo-local config (persisted across orbs via setup) ---
+git config --local user.name "Pratham Dubey"
+git config --local user.email "134331217+prathamdby@users.noreply.github.com"
+
 # --- Env: copy template without clobbering an existing .env ---
 if [ ! -f .env ]; then
   echo "[setup] copying .env.example -> .env"


### PR DESCRIPTION
## Summary

- Add `.agents/setup` that installs Nub and workspace deps, provisions a tuned pr_agent Postgres database, sets Git identity, installs agent skills, copies `.env`, and writes orb agent guidance
- Add `.agents/resume` that ensures the Postgres cluster is up and `.env` exists on orb wake

___

## PR Agent Description

### PR Type

Other

### Description

- Add .agents/setup to bootstrap toolchain, deps, Postgres, and skills
- Add .agents/resume for fast, idempotent repair on each orb wake

### File Walkthrough

<details>
<summary>Other (2 files)</summary>

<details>
<summary>Orb setup bootstrap script</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/371/files#diff-cf50b316b9f77187201b9fc2e965c97d096abf89230e2a9575eaf01f65350bd0"><code>.agents/setup</code></a>

- Installs Nub + pinned Node 22 and workspace dependencies via nub ci
- Provisions tuned Postgres with pr_agent role and database
- Installs global agent skills and writes AGENTS.md guidance

</details>

<details>
<summary>Orb resume repair script</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/371/files#diff-124adabbbed0166760b9079b0192de0420fbd2644993bebc16f81d596ef1156f"><code>.agents/resume</code></a>

- Ensures the Postgres cluster is running on every orb wake
- Re-copies .env template if it has vanished

</details>

</details>