### PR TITLE
Add Grok 4.5 agent mode

### DIFF
--- a/.amp/plugins/grok-45-mode.ts
+++ b/.amp/plugins/grok-45-mode.ts
@@ -1,0 +1,50 @@
+// @amp-agent-mode {"key":"grok45","label":"Grok 4.5"}
+
+import type { PluginAPI } from '@ampcode/plugin'
+
+const GROK_45_PROMPT = 'You are Amp. Help the user complete software engineering tasks.'
+
+const DEEP_TOOL_NAMES = [
+	'apply_patch',
+	'create_file',
+	'edit_file',
+	'find_thread',
+	'finder',
+	'librarian',
+	'oracle',
+	'painter',
+	'Read',
+	'read_mcp_resource',
+	'read_thread',
+	'read_web_page',
+	'shell_command',
+	'shell_command_status',
+	'skill',
+	'Task',
+	'view_media',
+	'web_search',
+] as const
+
+export default function (amp: PluginAPI) {
+	if (!amp.experimental) {
+		amp.logger.log('Experimental plugin API is not available.')
+		return
+	}
+
+	const agent = amp.experimental.createAgent({
+		name: 'grok-4-5',
+		model: 'xai/grok-4.5',
+		instructions: GROK_45_PROMPT,
+		tools: DEEP_TOOL_NAMES,
+		reasoningEffort: 'high',
+		display: { label: 'Grok 4.5', color: '#10b981' },
+	})
+
+	amp.experimental.registerAgentMode({
+		key: 'grok45',
+		label: 'Grok 4.5',
+		description: 'Grok 4.5 with deep-mode tools and a minimal prompt',
+		color: '#10b981',
+		agent: agent.definition,
+	})
+}


### PR DESCRIPTION
## Summary

- Register a custom Grok 4.5 mode backed by `xai/grok-4.5` with high reasoning effort
- Provide Amp’s default engineering prompt and deep-mode tool set

___

## PR Agent Description

### PR Type

Enhancement, Other

### Description

- Add Amp plugin registering a 'grok45' agent mode
- Configure xai/grok-4.5 model with deep-mode tools
- Use minimal prompt and high reasoning effort

### File Walkthrough

<details>
<summary>Enhancement (1 file)</summary>

<details>
<summary>Register Grok 4.5 agent mode</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/372/files#diff-ac4834456b911e11a83d1918cb40f02f992b2fc459b4cce8f3aff14912dcadba"><code>.amp/plugins/grok-45-mode.ts</code></a>

- Define minimal GROK_45_PROMPT and deep-mode tool list
- Create agent via experimental API with xai/grok-4.5
- Register grok45 mode with display label and color

</details>

</details>