### PR TITLE
Rewrite README for self-host Docker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,120 +2,153 @@
 
 # PR Agent
 
-**Self-hosted GitHub App for AI pull request reviews**
+Self-hosted GitHub App for AI pull request reviews
 
 `pr-agent` · Node 22+ · Postgres · pg-boss
 
 </div>
 
-> **Async by design.** Webhooks return **`200`** after durable intake (Postgres + pg-boss enqueue). Reactions, progress comments, reviews, descriptions, and ask answers publish on **`ROLE=worker`** and may appear seconds later.
+PR Agent installs on your GitHub org or repos, receives webhooks, and runs reviews (plus optional describe, ask, triage, and verification) on your own machines. You bring the GitHub App credentials, a Postgres database, and an LLM API key.
 
-PR Agent is a GitHub App that enqueues durable **agent work items** (reviews, descriptions, asks, triage, verification) from webhooks and slash commands, then runs LLM agent loops on workers using local PR workspaces or isolated writable checkouts and GitHub APIs for publish.
+Two processes must run together:
 
-Domain terms: [CONTEXT.md](CONTEXT.md). Features: [docs/features.md](docs/features.md). Configuration: [docs/configuration.md](docs/configuration.md). Behaviour and deployment: [docs/operations.md](docs/operations.md). Queue runbook: [docs/agent-work-ops.md](docs/agent-work-ops.md).
+1. **web** accepts signed webhooks, writes work to Postgres, and enqueues jobs. It returns `200` once that write succeeds.
+2. **worker** runs the queues: reactions, progress comments, model sessions, and everything posted back to the PR.
 
-**[Get started](#getting-started)**
+If only web is up, nothing appears on the PR. Comments and reviews show up a few seconds later once a worker picks up the job.
+
+Deeper docs: [features](docs/features.md) · [configuration](docs/configuration.md) · [operations](docs/operations.md) · [queue runbook](docs/agent-work-ops.md) · [domain terms](CONTEXT.md)
 
 ---
 
-## Table of Contents
+## Table of contents
 
-- [Getting Started](#getting-started)
-- [Configure the agent provider](#configure-the-agent-provider)
-- [Why Use PR Agent?](#why-use-pr-agent)
-- [Features](#features)
-- [See It in Action](#see-it-in-action)
-- [How It Works](#how-it-works)
-- [Data Privacy](#data-privacy)
+- [Host with Docker Compose](#host-with-docker-compose)
+- [Create the GitHub App](#create-the-github-app)
+- [Point GitHub at your server](#point-github-at-your-server)
+- [Choose an LLM provider](#choose-an-llm-provider)
+- [Check that it works](#check-that-it-works)
+- [What you get](#what-you-get)
+- [See it in action](#see-it-in-action)
+- [How it works](#how-it-works)
+- [Local development](#local-development)
+- [Data privacy](#data-privacy)
 
-## Getting Started
+## Host with Docker Compose
 
-### 1. GitHub App
+You need Docker Engine with Compose v2, a host that GitHub can reach over HTTPS (or a tunnel while testing), and about 15 minutes.
 
-1. Create a [GitHub App](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app).
-2. Set **Webhook URL** to `https://<host>/webhooks` and **Webhook secret** to match `WEBHOOK_SECRET`.
-3. Subscribe to events: **`pull_request`**, **`issue_comment`**, **`pull_request_review_comment`**, **`workflow_run`** (do not require `pull_request_review`). `workflow_run` powers CI-summary refresh when CI finishes after the review summary is posted.
-4. Repository permissions (typical): **Issues** and **Pull requests** read/write, **Contents** read/write, **Metadata** read, **Checks** read/write, **Actions** read. Contents write is only needed for `/triage`. **Commit statuses** read/write when `FEATURE_COMMIT_STATUS=true`. Checks + Actions read power the **CI summary** gate (status facts + condensed job logs for LLM-authored failure explanations).
-5. Install the app on target orgs or repos. Set `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY` in `.env` (see [`.env.example`](.env.example)).
-
-### 2. Docker Compose (recommended)
-
-Full stack: Postgres, web intake, and worker consumers.
+### 1. Clone and create `.env`
 
 ```bash
+git clone https://github.com/prathamdby/pr-agent.git
+cd pr-agent
 cp .env.example .env
-# Set GITHUB_*, WEBHOOK_SECRET, and agent provider keys (see Configure the agent provider)
-docker compose build
-docker compose up
 ```
 
-- Webhook URL (default ports): `http://<host>:7224/webhooks`
-- **`GET /health`**: liveness (`ok`) on web and worker
-- **`GET /ready`**: web = Postgres reachable; worker = consumers registered + Postgres/pg-boss
-- Both **`pr-agent-web`** (`ROLE=web`) and **`pr-agent-worker`** (`ROLE=worker`) are required for reviews and asks.
-
-More deployment detail: [docs/operations.md](docs/operations.md).
-
-### 3. Local development (optional)
-
-`DATABASE_URL` is required for both roles ([`src/config.ts`](src/config.ts)).
+Edit `.env` and set at least:
 
 ```bash
-docker compose up postgres
-cp .env.example .env
-npm install -g --ignore-scripts=false @nubjs/nub
-nub install
-
-# terminal 1: enqueue only
-ROLE=web DATABASE_URL=postgres://pr_agent:pr_agent@localhost:5432/pr_agent nub src/index.ts
-
-# terminal 2: reviews, descriptions, asks, triage, verification, CI refresh
-ROLE=worker DATABASE_URL=postgres://pr_agent:pr_agent@localhost:5432/pr_agent nub src/index.ts
-```
-
-`nub src/index.ts` loads `.env` automatically. For auto-restart on source changes, use `nub watch src/index.ts`. Tunnel webhooks (e.g. [smee.io](https://smee.io)) to `/webhooks`.
-
-If you previously installed with pnpm, delete `node_modules` before your first `nub install` to avoid mixed virtual-store layouts (`.pnpm/` vs `.nub/`).
-
-**Vercel** site deploys still use the platform installer (pnpm via [`site/vercel.json`](site/vercel.json)). That matches Nub's hosted-builder guidance: keep the builder's install when there is no setup step; add `@nubjs/nub` as a devDependency only if site scripts need the `nub` binary (they currently call Vite/`node` directly).
-
-Minimal env:
-
-```bash
-DATABASE_URL=...
 GITHUB_APP_ID=...
-GITHUB_APP_PRIVATE_KEY=...
-WEBHOOK_SECRET=...
-# Agent provider: see Configure the agent provider
+GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
+WEBHOOK_SECRET=replace-with-a-strong-secret
+PI_PROVIDER=openai
+PI_MODEL=gpt-4o-mini
+OPENAI_API_KEY=sk-...
 ```
 
-Integration tests need the same Postgres URL and fail fast without it:
+Notes:
+
+- Paste the GitHub App private key as one line with `\n` for newlines, as real multi-line PEM, or as base64-encoded PEM. Config loading accepts all three.
+- `WEBHOOK_SECRET` must match the secret you set on the GitHub App.
+- Compose overrides `ROLE` and `DATABASE_URL` for each service. You still need the GitHub and provider fields in `.env`.
+- Default HTTP port is `7224` (Compose and `.env.example`). Bare `nub src/index.ts` without `PORT` falls back to `3000`.
+
+Full env catalog: [docs/configuration.md](docs/configuration.md). Feature switches: [docs/features.md](docs/features.md).
+
+### 2. Start the stack
 
 ```bash
-docker compose up -d postgres
-# If the compose service has no host port, use the docker run from docs/cursor-cloud.md instead.
-DATABASE_URL=postgres://pr_agent:pr_agent@localhost:5432/pr_agent nub run test:integration
+docker compose build
+docker compose up -d
 ```
 
-Inventory-only (may skip DB suites): `nub run test:integration:inventory`.
+That starts three services from [docker-compose.yml](docker-compose.yml):
 
-Developer scripts: see [docs/operations.md](docs/operations.md#development).
+| Service | Role | What it does |
+| ------- | ---- | ------------ |
+| `postgres` | database | Durable webhook dedupe, work items, pg-boss jobs |
+| `pr-agent-web` | `ROLE=web` | `POST /webhooks`, `GET /health`, `GET /ready` on port `7224` |
+| `pr-agent-worker` | `ROLE=worker` | Consumes ack, review, ask, description, triage, verification, CI-refresh, and retention queues |
 
-## Configure the agent provider
+Migrations run automatically when each process opens its Postgres pool. You do not run them by hand.
 
-LLM runs happen on **`ROLE=worker`** only through the **Pi-native agent runtime** ([ADR 0031](docs/adr/0031-pi-native-agent-runtime.md)).
+```bash
+# optional: different env file path
+PR_AGENT_ENV_FILE=/abs/path/to/.env docker compose up -d
+```
 
-| Setting              | Env                                                 | Notes                                                          |
-| -------------------- | --------------------------------------------------- | -------------------------------------------------------------- |
-| General primary      | `PI_PROVIDER`, `PI_MODEL`                           | Specialist, Ask, Description, Triage, Verification, CI-summary |
-| Orchestrator primary | `PI_ORCHESTRATOR_PROVIDER`, `PI_ORCHESTRATOR_MODEL` | Optional; empty inherits general primary                       |
-| Shared fallback      | `PI_FALLBACK_PROVIDER`, `PI_FALLBACK_MODEL`         | Optional; availability failures only                           |
+If host port `7224` is taken, map another host port and keep the container on `7224`:
 
-Feature catalog: [docs/features.md](docs/features.md). Operator tunables: [docs/configuration.md](docs/configuration.md).
+```yaml
+# under pr-agent-web in a compose override
+ports:
+  - "7227:7224"
+```
 
-### Pi runtime
+Production credential hardening and extra deploy notes: [docs/operations.md](docs/operations.md).
 
-Uses [`@earendil-works/pi-coding-agent`](https://github.com/earendil-works/pi/tree/main/packages/coding-agent) through pr-agent's Pi session seam.
+## Create the GitHub App
+
+1. Open [Register a GitHub App](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app).
+2. Set **Webhook URL** to `https://<your-host>/webhooks` (Compose default port is `7224` if you terminate TLS in front of it).
+3. Set **Webhook secret** to the same value as `WEBHOOK_SECRET` in `.env`.
+4. Subscribe to these repository events (and only these for a normal install):
+   - `pull_request`
+   - `issue_comment`
+   - `pull_request_review_comment`
+   - `workflow_run` (refreshes the CI row on an existing review summary when Actions finish later)
+5. Do **not** require `pull_request_review` unless you have a reason. The bot does not need it for normal intake.
+6. Repository permissions:
+
+   | Permission | Access | Why |
+   | ---------- | ------ | --- |
+   | Issues | Read & write | PR conversation comments and reactions |
+   | Pull requests | Read & write | Reviews, inline threads, PR body for `/describe` |
+   | Contents | Read & write | Read code; write only needed for `/triage` pushes |
+   | Metadata | Read | Required by GitHub for apps |
+   | Checks | Read & write | Review check run + CI summary inputs |
+   | Actions | Read | Condensed job logs when CI fails |
+   | Commit statuses | Read & write | Only if you set `FEATURE_COMMIT_STATUS=true` |
+
+7. Create the app, generate a **private key**, and copy the **App ID**.
+8. Install the app on the orgs or repos you want reviewed.
+9. Put `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY` in `.env`, then recreate the containers so they pick up the change:
+
+```bash
+docker compose up -d --force-recreate pr-agent-web pr-agent-worker
+```
+
+## Point GitHub at your server
+
+GitHub must reach `POST /webhooks` on the web service.
+
+- **Production:** put TLS in front of `pr-agent-web` (Caddy, nginx, a load balancer, your PaaS). Forward to container port `7224`.
+- **Laptop test:** use a tunnel such as [smee.io](https://smee.io) or Cloudflare Tunnel. Point the GitHub App webhook at the public URL, and forward that traffic to `http://127.0.0.1:7224/webhooks`.
+
+Webhook handler path is always `/webhooks` (see [`src/effect/server.ts`](src/effect/server.ts)).
+
+## Choose an LLM provider
+
+LLM calls run on the **worker** only, through the Pi coding-agent runtime ([ADR 0031](docs/adr/0031-pi-native-agent-runtime.md)).
+
+| What | Env vars | Used for |
+| ---- | -------- | -------- |
+| General primary | `PI_PROVIDER`, `PI_MODEL` | Specialists, ask, describe, triage, verification, CI-summary authoring |
+| Orchestrator (optional) | `PI_ORCHESTRATOR_PROVIDER`, `PI_ORCHESTRATOR_MODEL` | Review orchestrator session; empty means inherit general primary |
+| Fallback (optional) | `PI_FALLBACK_PROVIDER`, `PI_FALLBACK_MODEL` | Availability failures only; both must be set to enable |
+
+Minimal OpenAI example:
 
 ```bash
 PI_PROVIDER=openai
@@ -123,51 +156,56 @@ PI_MODEL=gpt-4o-mini
 OPENAI_API_KEY=sk-...
 ```
 
-- **`PI_PROVIDER`**: pi-ai provider slug (for example `openai`, `anthropic`, `google`, `deepseek`, `openrouter`, `amazon-bedrock`, `groq`). Startup validates against the installed pi-ai provider list, or against project-root **`models.json`** when that file is present.
-- **`PI_MODEL`**: model id for that provider (for example `gpt-4o`, `claude-sonnet-4-5`).
-- **API keys**: set the env var for your provider. pr-agent loads **`OPENAI_API_KEY`**, **`ANTHROPIC_API_KEY`**, and **`GOOGLE_GENERATIVE_AI_API_KEY`** into the worker at startup. Other Pi providers use their standard env vars in the worker process (for example `DEEPSEEK_API_KEY`, `OPENROUTER_API_KEY`, `GROQ_API_KEY`). See the [Pi providers reference](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/providers.md) for the full key table, cloud setup (Azure, Bedrock, Vertex), and custom endpoints.
-- **Custom providers**: optional [`models.json`](models.json.example) in [Pi’s native format](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/models.md). If the catalog is loaded, the worker uses it and still selects with `PI_PROVIDER` / `PI_MODEL`. If it is absent, behavior falls back to env + built-ins. Delivery options: put `models.json` at the repo root in the Docker build context (copied to `/app/models.json` when present), mount it at runtime, or set **`MODELS_JSON_PATH`**. See [docs/operations.md](docs/operations.md) (Docker) and [docs/configuration.md](docs/configuration.md).
+- Startup checks `PI_PROVIDER` / `PI_MODEL` against the installed pi-ai list, or against a project `models.json` when that file is present.
+- pr-agent loads `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, and `GOOGLE_GENERATIVE_AI_API_KEY` in [`src/config.ts`](src/config.ts). Other Pi providers use their usual env vars on the worker (for example `DEEPSEEK_API_KEY`, `OPENROUTER_API_KEY`, `GROQ_API_KEY`). Full key table: [Pi providers](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/providers.md).
+- Optional custom catalog: copy [`models.json.example`](models.json.example), place `models.json` at the repo root before `docker build` (copied to `/app/models.json` when present), mount it at runtime on **both** web and worker, or set `MODELS_JSON_PATH`. Details: [docs/operations.md](docs/operations.md).
 
-Restart **`pr-agent-worker`** (or the `ROLE=worker` process) after changing provider env vars.
+Restart the worker after provider changes:
 
-## Why Use PR Agent?
+```bash
+docker compose up -d --force-recreate pr-agent-worker
+```
 
-### Fast, durable intake
+## Check that it works
 
-Webhook handlers validate, dedupe, and enqueue work in Postgres before responding. Workers scale independently; a review backlog does not block webhook acceptance.
+```bash
+curl -sS http://127.0.0.1:7224/health   # ok
+curl -sS http://127.0.0.1:7224/ready    # ready (web: Postgres up)
+```
 
-### Handles large pull requests
+Worker readiness (consumers registered + Postgres/pg-boss) is checked inside the Compose healthcheck on the worker container. From the host you only published the web port by default.
 
-File listing and patch caps (`MAX_PR_FILES_LISTED`, `MAX_PR_FILES_PATCH_BYTES`) plus Octokit throttling keep runs bounded. Truncation metadata is explicit when the change set is clipped.
+Then open a small PR on an installed repo, or comment `/help` on an existing PR.
 
-### Customizable via configuration
+| Expect | Where |
+| ------ | ----- |
+| Eyes reaction soon after intake | PR or triggering comment |
+| `## PR Agent Review` progress comment | PR conversation (auto review or `/review`) |
+| Inline findings on the Files tab | When the bot can anchor them |
+| Final summary replaces the progress comment | Same conversation comment |
 
-User-facing behavior is controlled by the `FEATURE_*` settings ([docs/features.md](docs/features.md)); operator tunables live in [docs/configuration.md](docs/configuration.md). Prompt prose stays in code; limits and shared strings live in `src/settings/`.
+If webhooks return 200 but the PR stays quiet, the worker is down, misconfigured, or failing on the provider key. Check `docker compose logs -f pr-agent-worker` and the queue runbook: [docs/agent-work-ops.md](docs/agent-work-ops.md).
 
-### Self-hosted control
+## What you get
 
-Run on your infrastructure with your GitHub App credentials and chosen LLM provider (Pi/OpenAI and others via `@earendil-works/pi-ai`).
+Defaults match [`.env.example`](.env.example) and [docs/features.md](docs/features.md).
 
-## Features
+| Capability | When it runs | Command |
+| ---------- | ------------ | ------- |
+| Orchestrated review | PR `opened` when `FEATURE_REVIEW=auto` | `/review` always |
+| PR description | PR `opened` when `FEATURE_DESCRIBE=auto` | `/describe` |
+| Verification | PR `synchronize` when `FEATURE_VERIFICATION=auto` | (no slash) |
+| Ask | On demand when `FEATURE_ASK=manual` | `/ask …` or `@bot …` |
+| Triage autofix | On demand when `FEATURE_TRIAGE=manual` | `/triage` |
+| Help | On demand | `/help` |
 
-| Capability              | Auto on PR            | Slash command     | Notes                                                                                                                          |
-| ----------------------- | --------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| Orchestrated review     | opened                | `/review`         | Four specialists feed one `## PR Agent Review`; inline P0–P3 appear on the Files tab when anchored (check fails only on P0–P2) |
-| PR description          | opened (configurable) | `/describe`       | Merges under `## PR Agent Description`                                                                                         |
-| Triage                  | No                    | `/triage`         | Fixes earlier findings, commits and pushes to the PR branch; `## PR Agent Triage`                                              |
-| Verification            | synchronize           | No                | Re-checks open bot findings against the new head; edits verification stubs in place                                            |
-| Ask                     | No                    | `/ask <question>` | Also `@bot` mentions; PR conversation or inline diff **code anchor**                                                           |
-| Help                    | No                    | `/help`           | Worker-published guidance                                                                                                      |
-| Lightweight auto-review | docs-only trivial PRs | No                | Skips full **orchestrated review run**; see [ADR 0014](docs/adr/0014-lightweight-review-completion.md)                         |
+Review runs four specialists (correctness, security, quality, tests) under one orchestrator and posts one `## PR Agent Review` summary. P0-P2 findings fail the review check run; P3 does not. Docs-only trivial PRs can take a short auto path instead of a full orchestrated run ([ADR 0014](docs/adr/0014-lightweight-review-completion.md)).
 
-| Deployment                               | Supported |
-| ---------------------------------------- | --------- |
-| Docker Compose (web + worker + Postgres) | Yes       |
-| Bare Node + Postgres                     | Yes       |
+Slash commands are case-sensitive. The command must be the first non-empty line of a **new** (`created`) comment. Who may run them is controlled by `SLASH_ALLOWED_ASSOCIATIONS` (default `OWNER,MEMBER,COLLABORATOR`).
 
-Slash commands are **case-sensitive** and must start the first non-empty line of a new comment. Full behaviour: [docs/operations.md](docs/operations.md).
+Optional labels, commit status, and title rewrite are separate `FEATURE_*` flags. Set `FEATURE_DESCRIBE=off`, `FEATURE_ASK=off`, and similar when you want those features to stop calling the model.
 
-## See It in Action
+## See it in action
 
 <details>
   <summary><h3>/describe</h3></summary>
@@ -184,7 +222,7 @@ Slash commands are **case-sensitive** and must start the first non-empty line of
   <img src="site/public/screenshots/ask.example.webp" alt="Example /ask answer on a pull request" width="800" />
 </details>
 
-## How It Works
+## How it works
 
 ```mermaid
 flowchart LR
@@ -225,35 +263,67 @@ flowchart LR
   Worker --> Push[git push PR branch]
 ```
 
-1. **Web** ([`processWebhookRequestEffect`](src/effect/programs/processWebhookRequestEffect.ts)): verify signature, parse payload, durable dedupe, schedule **agent work items** (slash commands, or `@bot` mentions promoted to ask).
-2. **Scheduler** ([`AgentWorkScheduler`](src/agentWork/scheduler.ts)): write Postgres rows and enqueue pg-boss jobs (ack, ci-refresh, review, ask, description, triage, verification).
-3. **Ack worker**: acknowledgement reaction and **review progress comment** stub before long runs. **CI-refresh worker**: after `workflow_run` completed, surgically updates the CI cell on the matching **review summary comment** (no full re-review).
-4. **Worker maintenance** ([`AgentWorkerLive`](src/agentWork/worker.ts)): owns pg-boss cron/supervision and the daily retention cleanup lane.
-5. **Review / ask / description / triage / verification workers** ([`executors/`](src/agentWork/executors/)): installation token, **local PR workspace** or isolated writable checkout, agent harness, **PR-surface I/O**. Ask workers load the containing comment thread before the LLM turn.
-6. **Reviews** ([`runOrchestratedPrReview`](src/review/orchestrator/orchestratorRun.ts)): reconnaissance, a specialist brief, four parallel specialists, incremental `COMMENT` thread batches, then the final summary.
+1. **Web** ([`processWebhookRequestEffect`](src/effect/programs/processWebhookRequestEffect.ts)) verifies the signature, parses the payload, dedupes the delivery in Postgres, and schedules work. It does not create installation tokens or post to the PR.
+2. **Scheduler** ([`AgentWorkScheduler`](src/agentWork/scheduler.ts)) inserts `agent_work_items` and enqueues pg-boss jobs.
+3. **Ack worker** posts the eyes reaction and the review progress stub. **CI-refresh worker** updates only the CI cell on a finished summary when `workflow_run` completes later.
+4. **Worker** ([`AgentWorkerLive`](src/agentWork/worker.ts)) owns queue consumers, pg-boss supervision, and the daily retention sweep.
+5. **Feature executors** ([`src/agentWork/executors/`](src/agentWork/executors/)) create a GitHub installation token, open a local PR workspace (or a writable checkout for triage), run the agent, and publish.
+6. **Reviews** ([`runOrchestratedPrReview`](src/review/orchestrator/orchestratorRun.ts)) inspect the PR, write a specialist brief, run four specialists in parallel, publish inline thread batches, then write the final summary.
 
-Queue inspection and recovery: [docs/agent-work-ops.md](docs/agent-work-ops.md). Architecture ADR: [docs/adr/0009-durable-agent-work.md](docs/adr/0009-durable-agent-work.md). Conversational ask: [docs/adr/0008-ask-command.md](docs/adr/0008-ask-command.md).
+Queue inspection and recovery: [docs/agent-work-ops.md](docs/agent-work-ops.md). Design background: [ADR 0009](docs/adr/0009-durable-agent-work.md), [ADR 0008](docs/adr/0008-ask-command.md).
 
-## Data Privacy
+## Local development
 
-### Self-hosted
+Use this when you are changing the code. For production hosting, prefer Compose above.
 
-Postgres, pg-boss, and GitHub App credentials run on your infrastructure. Webhook bodies and workflow state stay in your database.
+`DATABASE_URL` is required for both roles ([`src/config.ts`](src/config.ts)).
 
-### LLM providers
+```bash
+docker compose up -d postgres
+cp .env.example .env
+# fill GitHub + provider fields
 
-Review, description, and ask content is sent to your configured model provider during worker runs only (per `PI_PROVIDER` / `PI_MODEL`). See your provider's data policy (for example [OpenAI](https://openai.com/enterprise-privacy)).
+npm install -g --ignore-scripts=false @nubjs/nub
+nub install
 
-### Context7 (optional)
+# terminal 1: webhook intake only
+ROLE=web nub src/index.ts
 
-When enabled, library lookup tools may call `https://context7.com/api`. Set `CONTEXT7_API_KEY` for higher limits; queries leave your network to Context7 when those tools run.
+# terminal 2: all queue consumers
+ROLE=worker nub src/index.ts
+```
 
-### Logging
+`nub src/index.ts` loads `.env` automatically. Auto-restart: `nub watch src/index.ts`. Tunnel webhooks to `/webhooks` on your `PORT`.
 
-Structured logs use [evlog](https://www.evlog.dev) on your hosts. `LOG_REDACT` (default true) redacts secret-shaped substrings; tune via [docs/configuration.md](docs/configuration.md).
+If you previously installed with pnpm or npm at the repo root, delete `node_modules` before the first `nub install` so the virtual store is not mixed (`.pnpm/` vs `.nub/`).
 
-### Ask safety
+```bash
+# unit tests (no database)
+nub run test
 
-`/ask` replies apply outbound redaction before posting. Probes for bot internals may receive an **Ask meta refusal** without an LLM call ([ADR 0010](docs/adr/0010-ask-red-team-hardening.md)).
+# integration tests
+DATABASE_URL=postgres://pr_agent:pr_agent@localhost:5432/pr_agent nub run test:integration
+
+# typecheck + lint + format
+nub run check:code
+```
+
+Vitest does not load `.env` for you. Export `DATABASE_URL` in the shell for integration runs. Inventory-only suite that may skip DB cases: `nub run test:integration:inventory`.
+
+More scripts and edge cases: [docs/operations.md](docs/operations.md#development), [docs/cursor-cloud.md](docs/cursor-cloud.md).
+
+The marketing site under `site/` is a separate workspace package (`pr-agent-landing`). It is not required to run the bot.
+
+## Data privacy
+
+**Self-hosted.** Postgres, pg-boss, webhook bodies, and work-item state stay on your infrastructure. You own the GitHub App credentials.
+
+**LLM providers.** Review, description, ask, triage, verification, and CI-summary text leave your network only when the worker calls your configured provider (`PI_PROVIDER` / `PI_MODEL`). Read that provider's data policy (example: [OpenAI](https://openai.com/enterprise-privacy)).
+
+**Context7 (optional).** If you set `CONTEXT7_API_KEY`, library lookup tools may call `https://context7.com/api`.
+
+**Logging.** Structured logs use [evlog](https://www.evlog.dev) on your hosts. `LOG_REDACT` defaults to true and strips secret-shaped substrings.
+
+**Ask safety.** `/ask` applies outbound redaction before posting. Questions aimed at bot internals can get a short refusal without an LLM call ([ADR 0010](docs/adr/0010-ask-red-team-hardening.md)).
 
 More security detail: [docs/operations.md](docs/operations.md#security).

--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ docker compose up -d
 
 That starts three services from [docker-compose.yml](docker-compose.yml):
 
-| Service | Role | What it does |
-| ------- | ---- | ------------ |
-| `postgres` | database | Durable webhook dedupe, work items, pg-boss jobs |
-| `pr-agent-web` | `ROLE=web` | `POST /webhooks`, `GET /health`, `GET /ready` on port `7224` |
+| Service           | Role          | What it does                                                                                   |
+| ----------------- | ------------- | ---------------------------------------------------------------------------------------------- |
+| `postgres`        | database      | Durable webhook dedupe, work items, pg-boss jobs                                               |
+| `pr-agent-web`    | `ROLE=web`    | `POST /webhooks`, `GET /health`, `GET /ready` on port `7224`                                   |
 | `pr-agent-worker` | `ROLE=worker` | Consumes ack, review, ask, description, triage, verification, CI-refresh, and retention queues |
 
 Migrations run automatically when each process opens its Postgres pool. You do not run them by hand.
@@ -111,15 +111,15 @@ Production credential hardening and extra deploy notes: [docs/operations.md](doc
 5. Do **not** require `pull_request_review` unless you have a reason. The bot does not need it for normal intake.
 6. Repository permissions:
 
-   | Permission | Access | Why |
-   | ---------- | ------ | --- |
-   | Issues | Read & write | PR conversation comments and reactions |
-   | Pull requests | Read & write | Reviews, inline threads, PR body for `/describe` |
-   | Contents | Read & write | Read code; write only needed for `/triage` pushes |
-   | Metadata | Read | Required by GitHub for apps |
-   | Checks | Read & write | Review check run + CI summary inputs |
-   | Actions | Read | Condensed job logs when CI fails |
-   | Commit statuses | Read & write | Only if you set `FEATURE_COMMIT_STATUS=true` |
+   | Permission      | Access       | Why                                               |
+   | --------------- | ------------ | ------------------------------------------------- |
+   | Issues          | Read & write | PR conversation comments and reactions            |
+   | Pull requests   | Read & write | Reviews, inline threads, PR body for `/describe`  |
+   | Contents        | Read & write | Read code; write only needed for `/triage` pushes |
+   | Metadata        | Read         | Required by GitHub for apps                       |
+   | Checks          | Read & write | Review check run + CI summary inputs              |
+   | Actions         | Read         | Condensed job logs when CI fails                  |
+   | Commit statuses | Read & write | Only if you set `FEATURE_COMMIT_STATUS=true`      |
 
 7. Create the app, generate a **private key**, and copy the **App ID**.
 8. Install the app on the orgs or repos you want reviewed.
@@ -142,11 +142,11 @@ Webhook handler path is always `/webhooks` (see [`src/effect/server.ts`](src/eff
 
 LLM calls run on the **worker** only, through the Pi coding-agent runtime ([ADR 0031](docs/adr/0031-pi-native-agent-runtime.md)).
 
-| What | Env vars | Used for |
-| ---- | -------- | -------- |
-| General primary | `PI_PROVIDER`, `PI_MODEL` | Specialists, ask, describe, triage, verification, CI-summary authoring |
-| Orchestrator (optional) | `PI_ORCHESTRATOR_PROVIDER`, `PI_ORCHESTRATOR_MODEL` | Review orchestrator session; empty means inherit general primary |
-| Fallback (optional) | `PI_FALLBACK_PROVIDER`, `PI_FALLBACK_MODEL` | Availability failures only; both must be set to enable |
+| What                    | Env vars                                            | Used for                                                               |
+| ----------------------- | --------------------------------------------------- | ---------------------------------------------------------------------- |
+| General primary         | `PI_PROVIDER`, `PI_MODEL`                           | Specialists, ask, describe, triage, verification, CI-summary authoring |
+| Orchestrator (optional) | `PI_ORCHESTRATOR_PROVIDER`, `PI_ORCHESTRATOR_MODEL` | Review orchestrator session; empty means inherit general primary       |
+| Fallback (optional)     | `PI_FALLBACK_PROVIDER`, `PI_FALLBACK_MODEL`         | Availability failures only; both must be set to enable                 |
 
 Minimal OpenAI example:
 
@@ -177,12 +177,12 @@ Worker readiness (consumers registered + Postgres/pg-boss) is checked inside the
 
 Then open a small PR on an installed repo, or comment `/help` on an existing PR.
 
-| Expect | Where |
-| ------ | ----- |
-| Eyes reaction soon after intake | PR or triggering comment |
-| `## PR Agent Review` progress comment | PR conversation (auto review or `/review`) |
-| Inline findings on the Files tab | When the bot can anchor them |
-| Final summary replaces the progress comment | Same conversation comment |
+| Expect                                      | Where                                      |
+| ------------------------------------------- | ------------------------------------------ |
+| Eyes reaction soon after intake             | PR or triggering comment                   |
+| `## PR Agent Review` progress comment       | PR conversation (auto review or `/review`) |
+| Inline findings on the Files tab            | When the bot can anchor them               |
+| Final summary replaces the progress comment | Same conversation comment                  |
 
 If webhooks return 200 but the PR stays quiet, the worker is down, misconfigured, or failing on the provider key. Check `docker compose logs -f pr-agent-worker` and the queue runbook: [docs/agent-work-ops.md](docs/agent-work-ops.md).
 
@@ -190,14 +190,14 @@ If webhooks return 200 but the PR stays quiet, the worker is down, misconfigured
 
 Defaults match [`.env.example`](.env.example) and [docs/features.md](docs/features.md).
 
-| Capability | When it runs | Command |
-| ---------- | ------------ | ------- |
-| Orchestrated review | PR `opened` when `FEATURE_REVIEW=auto` | `/review` always |
-| PR description | PR `opened` when `FEATURE_DESCRIBE=auto` | `/describe` |
-| Verification | PR `synchronize` when `FEATURE_VERIFICATION=auto` | (no slash) |
-| Ask | On demand when `FEATURE_ASK=manual` | `/ask …` or `@bot …` |
-| Triage autofix | On demand when `FEATURE_TRIAGE=manual` | `/triage` |
-| Help | On demand | `/help` |
+| Capability          | When it runs                                      | Command              |
+| ------------------- | ------------------------------------------------- | -------------------- |
+| Orchestrated review | PR `opened` when `FEATURE_REVIEW=auto`            | `/review` always     |
+| PR description      | PR `opened` when `FEATURE_DESCRIBE=auto`          | `/describe`          |
+| Verification        | PR `synchronize` when `FEATURE_VERIFICATION=auto` | (no slash)           |
+| Ask                 | On demand when `FEATURE_ASK=manual`               | `/ask …` or `@bot …` |
+| Triage autofix      | On demand when `FEATURE_TRIAGE=manual`            | `/triage`            |
+| Help                | On demand                                         | `/help`              |
 
 Review runs four specialists (correctness, security, quality, tests) under one orchestrator and posts one `## PR Agent Review` summary. P0-P2 findings fail the review check run; P3 does not. Docs-only trivial PRs can take a short auto path instead of a full orchestrated run ([ADR 0014](docs/adr/0014-lightweight-review-completion.md)).
 

--- a/docs/adr/0009-durable-agent-work.md
+++ b/docs/adr/0009-durable-agent-work.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted. Operator-facing summary: [README.md](../../README.md) (How It Works, Getting Started). Runbooks: [docs/agent-work-ops.md](../agent-work-ops.md).
+Accepted. Operator-facing summary: [README.md](../../README.md) (How it works, Host with Docker Compose). Runbooks: [docs/agent-work-ops.md](../agent-work-ops.md).
 
 ## Context
 

--- a/docs/agent-work-ops.md
+++ b/docs/agent-work-ops.md
@@ -39,7 +39,7 @@ Worker readiness is distinct from web probes: `GET /ready` on the worker process
 
 For end-to-end behavior (reviews, descriptions, asks, triage, and verification), run the full stack: `docker compose up` (postgres + `pr-agent-web` + `pr-agent-worker`). Web-only accepts webhooks but does not execute agent work.
 
-Host processes against Compose Postgres: see [README.md](../README.md#getting-started) and [operations.md](operations.md#local-development-edge-cases).
+Host processes against Compose Postgres: see [README.md](../README.md#host-with-docker-compose) and [operations.md](operations.md#local-development-edge-cases).
 
 ## `/ask` red-team checklist (manual)
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -102,7 +102,7 @@ PR_AGENT_ENV_FILE=/abs/path/to/.env docker compose up
 - **Vercel** site deploys keep the platform installer (pnpm via [`site/vercel.json`](../site/vercel.json)). Add `@nubjs/nub` as a devDependency only if site scripts need the `nub` binary.
 - **Docker image** installs with Nub only (`nub ci` for build deps; `nub prune --prod` for the runtime tree). No `corepack` / `pnpm deploy` in the Dockerfile. [`.dockerignore`](../.dockerignore) keeps `site/package.json` in the build context so the workspace lockfile stays valid under frozen installs; the rest of `site/` stays excluded.
 
-Canonical quick start steps live in [README.md](../README.md) **Getting Started**.
+Canonical quick start steps live in [README.md](../README.md) **Host with Docker Compose**.
 
 ## Development
 

--- a/site/components/quickstart.tsx
+++ b/site/components/quickstart.tsx
@@ -110,7 +110,7 @@ export function Quickstart() {
                 rel="noopener noreferrer"
                 className="text-ink-soft underline decoration-edge-strong hover:text-ink"
               >
-                README Getting Started
+                README Host with Docker Compose
               </a>
               .
             </p>

--- a/site/lib/site.ts
+++ b/site/lib/site.ts
@@ -23,5 +23,5 @@ function resolveSiteOrigin(): string {
 export const SITE_ORIGIN = resolveSiteOrigin();
 
 export const REPO_URL = "https://github.com/prathamdby/pr-agent";
-export const DOCS_URL = `${REPO_URL}#getting-started`;
+export const DOCS_URL = `${REPO_URL}#host-with-docker-compose`;
 export const LICENSE_URL = `${REPO_URL}/blob/main/LICENSE`;

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -8,7 +8,7 @@ You keep model keys and review traffic in your own environment. Supported backen
 
 ## Docs
 
-- [Getting started](https://github.com/prathamdby/pr-agent#getting-started): GitHub App setup and Docker Compose deploy
+- [Host with Docker Compose](https://github.com/prathamdby/pr-agent#host-with-docker-compose): GitHub App setup and Docker Compose deploy
 - [Features](https://github.com/prathamdby/pr-agent/blob/main/docs/features.md): FEATURE_* catalog and capability modes (off, manual, auto)
 - [Configuration](https://github.com/prathamdby/pr-agent/blob/main/docs/configuration.md): Environment variables and knobs
 - [Operations](https://github.com/prathamdby/pr-agent/blob/main/docs/operations.md): Deploy steps, runtime behaviour, and scripts


### PR DESCRIPTION
## Summary
- Lead the README with Docker Compose host path, required env, and smoke checks
- Split GitHub App, public webhook URL, and LLM provider setup into separate steps
- Move local development after the host path and drop the marketing why-use section
- Retarget site and docs links to the host-with-docker-compose anchor