### PR TITLE
Create code-index-build queue at worker boot

### DIFF
--- a/src/agentWork/boss.ts
+++ b/src/agentWork/boss.ts
@@ -8,6 +8,7 @@ import {
   ASK_QUEUE,
   CI_REFRESH_DEAD_LETTER_QUEUE,
   CI_REFRESH_QUEUE,
+  CODE_INDEX_BUILD_QUEUE,
   DESCRIPTION_DEAD_LETTER_QUEUE,
   DESCRIPTION_QUEUE,
   REVIEW_DEAD_LETTER_QUEUE,
@@ -111,6 +112,12 @@ export async function ensureAgentQueues(boss: PgBoss, cfg: QueueConfig): Promise
       }),
     ),
   );
+
+  // No DLQ; created at boot so work()/diagnostics never hit a missing queue.
+  await boss.createQueue(CODE_INDEX_BUILD_QUEUE, {
+    ...defaults,
+    policy: "standard",
+  });
 }
 
 export async function stopBoss(boss: PgBoss, drainTimeoutMs: number): Promise<void> {

--- a/test/agentWorkBoss.test.ts
+++ b/test/agentWorkBoss.test.ts
@@ -8,6 +8,7 @@ import {
   ASK_QUEUE,
   CI_REFRESH_DEAD_LETTER_QUEUE,
   CI_REFRESH_QUEUE,
+  CODE_INDEX_BUILD_QUEUE,
   DESCRIPTION_DEAD_LETTER_QUEUE,
   DESCRIPTION_QUEUE,
   REVIEW_DEAD_LETTER_QUEUE,
@@ -112,6 +113,16 @@ describe("ensureAgentQueues", () => {
     for (const entry of parentStarted) {
       entry.resolve();
     }
+
+    await vi.waitFor(() =>
+      expect(started).toHaveLength(deadLetterQueues.length + parentQueues.length + 1),
+    );
+    const codeIndexStarted = started[deadLetterQueues.length + parentQueues.length]!;
+    expect(codeIndexStarted.name).toBe(CODE_INDEX_BUILD_QUEUE);
+    expect(codeIndexStarted.options).toEqual(expect.objectContaining({ policy: "standard" }));
+    expect(codeIndexStarted.options).not.toHaveProperty("deadLetter");
+    codeIndexStarted.resolve();
+
     await ensurePromise;
   });
 });


### PR DESCRIPTION
## Summary
- Create `code-index-build` in `ensureAgentQueues` with standard policy and no DLQ
- Assert create order in the `ensureAgentQueues` unit test

___

## PR Agent Description

### PR Type

Enhancement, Tests

### Description

- Create CODE_INDEX_BUILD_QUEUE at boot in ensureAgentQueues with standard policy.
- No DLQ so worker readiness and diagnostics avoid missing-queue errors.
- Add test asserting the queue is created with standard policy and no deadLetter.

### File Walkthrough

<details>
<summary>Enhancement (1 file)</summary>

<details>
<summary>Ensure code-index queue exists at boot</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/374/files#diff-ba3d3f8f52f49cc2621ee5b514d7b5a74277a140f724faea7097ced21d8fa835"><code>src/agentWork/boss.ts</code></a>

- Creates CODE_INDEX_BUILD_QUEUE in ensureAgentQueues with standard policy and no DLQ, so worker readiness and diagnostics never hit a missing queue.

</details>

</details>

<details>
<summary>Tests (1 file)</summary>

<details>
<summary>Assert code-index boot queue creation</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/374/files#diff-9cd070e3d17292ad1d65aac199227591a791ea47a1f21bc55553f84a5ec291ed"><code>test/agentWorkBoss.test.ts</code></a>

- Waits for the extra queue during ensureAgentQueues and asserts its name, standard policy, and absence of a deadLetter option.

</details>

</details>