### PR TITLE
Strip triage checkout symlinks before agent tools

### DIFF
--- a/src/agent/triage/triageWorkspaceTools.ts
+++ b/src/agent/triage/triageWorkspaceTools.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
 import type { Config } from "../../config.js";
 import { AppError } from "../../errors/appError.js";
 import type { WritablePrCheckout } from "../../prWorkspace/writablePrCheckout.js";
-import { assertWorkspacePath } from "../../prWorkspace/localPrWorkspace.js";
+import { assertContainedWorkspacePath } from "../../prWorkspace/localPrWorkspace.js";
 import {
   SENSITIVE_PATH_PATTERNS,
   TRIAGE_COMMIT_BODY_MAX_BULLETS,
@@ -35,7 +35,7 @@ function isSensitivePath(path: string): boolean {
   return SENSITIVE_PATH_PATTERNS.some((pattern) => pattern.test(path));
 }
 
-function safeReadPath(root: string, path: string): string {
+async function safeReadPath(root: string, path: string): Promise<string> {
   const normalized = normalizeRepoRelativePath(path);
   if (isSensitivePath(normalized) || isTriageControlPath(normalized)) {
     throw new AppError({
@@ -44,7 +44,7 @@ function safeReadPath(root: string, path: string): string {
       context: { path: normalized },
     });
   }
-  return assertWorkspacePath(root, normalized);
+  return assertContainedWorkspacePath(root, normalized);
 }
 
 function relativePath(root: string, fullPath: string): string {
@@ -52,7 +52,7 @@ function relativePath(root: string, fullPath: string): string {
 }
 
 async function readTextFile(root: string, path: string, maxBytes: number) {
-  const fullPath = safeReadPath(root, path);
+  const fullPath = await safeReadPath(root, path);
   const info = await stat(fullPath).catch(() => null);
   if (!info?.isFile()) return { path, refused: true, reason: "Path is missing from checkout" };
   if (info.size > maxBytes) return { path, refused: true, reason: "File exceeds read limit" };
@@ -151,7 +151,7 @@ export function buildTriageWorkspaceTools(params: {
       "Return the current unified diff for a repo-relative path in the writable checkout.",
     schema: z.object({ path: z.string().min(1) }),
     run: async ({ path }) => {
-      const fullPath = safeReadPath(root, path);
+      const fullPath = await safeReadPath(root, path);
       const rel = relativePath(root, fullPath);
       const diff = await git(root, ["diff", "HEAD", "--", rel], LOCAL_WORKSPACE_FETCH_TIMEOUT_MS);
       return { path: rel, diff };

--- a/src/agent/verification/verificationWorkspaceTools.ts
+++ b/src/agent/verification/verificationWorkspaceTools.ts
@@ -6,7 +6,7 @@ import type { Tool as PiTool } from "@earendil-works/pi-ai";
 import { z } from "zod";
 import type { Config } from "../../config.js";
 import { AppError } from "../../errors/appError.js";
-import { assertWorkspacePath } from "../../prWorkspace/localPrWorkspace.js";
+import { assertContainedWorkspacePath } from "../../prWorkspace/localPrWorkspace.js";
 import {
   SENSITIVE_PATH_PATTERNS,
   LOCAL_WORKSPACE_FETCH_TIMEOUT_MS,
@@ -20,7 +20,7 @@ function isSensitivePath(path: string): boolean {
   return SENSITIVE_PATH_PATTERNS.some((pattern) => pattern.test(path));
 }
 
-function safePath(root: string, path: string): string {
+async function safePath(root: string, path: string): Promise<string> {
   const normalized = path.replace(/\\/g, "/");
   if (isSensitivePath(normalized)) {
     throw new AppError({
@@ -29,7 +29,7 @@ function safePath(root: string, path: string): string {
       context: { path: normalized },
     });
   }
-  return assertWorkspacePath(root, normalized);
+  return assertContainedWorkspacePath(root, normalized);
 }
 
 function relativePath(root: string, fullPath: string): string {
@@ -37,7 +37,7 @@ function relativePath(root: string, fullPath: string): string {
 }
 
 async function readTextFile(root: string, path: string, maxBytes: number) {
-  const fullPath = safePath(root, path);
+  const fullPath = await safePath(root, path);
   const info = await stat(fullPath).catch(() => null);
   if (!info?.isFile()) return { path, refused: true, reason: "Path is missing from checkout" };
   if (info.size > maxBytes) return { path, refused: true, reason: "File exceeds read limit" };
@@ -114,7 +114,7 @@ export function buildVerificationWorkspaceTools(params: {
       "Return the current unified diff for a repo-relative path in the PR repository view.",
     schema: z.object({ path: z.string().min(1) }),
     run: async ({ path }) => {
-      const fullPath = safePath(root, path);
+      const fullPath = await safePath(root, path);
       const rel = relativePath(root, fullPath);
       const diff = await git(root, ["diff", "HEAD", "--", rel], LOCAL_WORKSPACE_FETCH_TIMEOUT_MS);
       return { path: rel, diff };

--- a/src/prWorkspace/localPrWorkspace.ts
+++ b/src/prWorkspace/localPrWorkspace.ts
@@ -1,10 +1,12 @@
 import { execFile } from "node:child_process";
 import {
   chmod,
+  lstat,
   mkdir,
   mkdtemp,
   readFile,
   readdir,
+  realpath,
   rm,
   stat,
   statfs,
@@ -198,6 +200,59 @@ export function assertWorkspacePath(root: string, requestedPath: string): string
     });
   }
   return resolved;
+}
+
+/**
+ * Ensure a repo-relative path stays inside root after symlink resolution.
+ * Missing paths are allowed (caller decides); existing symlinks and escapes are denied.
+ */
+export async function assertContainedWorkspacePath(
+  root: string,
+  requestedPath: string,
+): Promise<string> {
+  const fullPath = assertWorkspacePath(root, requestedPath);
+  const entry = await lstat(fullPath).catch((error: unknown) => {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return null;
+    throw error;
+  });
+  if (entry == null) return fullPath;
+  if (entry.isSymbolicLink()) {
+    throw new AppError({
+      code: "pr_workspace.symlink_escape",
+      message: `Symlink escape blocked: ${requestedPath}`,
+      context: { path: requestedPath },
+    });
+  }
+  const realRoot = await realpath(root);
+  const realCandidate = await realpath(fullPath);
+  if (realCandidate !== realRoot && !realCandidate.startsWith(realRoot + sep)) {
+    throw new AppError({
+      code: "pr_workspace.symlink_escape",
+      message: `Symlink escape blocked: ${requestedPath}`,
+      context: { path: requestedPath },
+    });
+  }
+  return fullPath;
+}
+
+/** Remove symbolic links under a checkout tree. Skips `.git` so object stores stay intact. */
+export async function stripWorkspaceSymlinks(dir: string): Promise<void> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (let i = 0; i < entries.length; i += LOCAL_WORKSPACE_TREE_WALK_CONCURRENCY) {
+    await Promise.all(
+      entries.slice(i, i + LOCAL_WORKSPACE_TREE_WALK_CONCURRENCY).map(async (entry) => {
+        if (entry.name === ".git") return;
+        const full = join(dir, entry.name);
+        if (entry.isSymbolicLink()) {
+          await rm(full, { force: true });
+          return;
+        }
+        if (entry.isDirectory()) {
+          await stripWorkspaceSymlinks(full);
+        }
+      }),
+    );
+  }
 }
 
 function mapGithubStatus(file: PullRequestFileEntry): LocalPrChangedFile {

--- a/src/prWorkspace/writablePrCheckout.ts
+++ b/src/prWorkspace/writablePrCheckout.ts
@@ -19,7 +19,7 @@ import {
 } from "../settings/index.js";
 import { isTriageControlPath } from "../agent/triage/triageWritePolicy.js";
 import { createGitCredentialFiles, makeDirectoriesWritable } from "./gitCredentials.js";
-import { assertWorkspacePath } from "./localPrWorkspace.js";
+import { assertWorkspacePath, stripWorkspaceSymlinks } from "./localPrWorkspace.js";
 
 const exec = promisify(execFile);
 const WORKSPACE_ROOT_PREFIX = "pr-agent-triage-";
@@ -322,6 +322,7 @@ export async function withWritablePrCheckout<T>(
         context: { fetchedHead: fetchedHead.trim(), headSha },
       });
     }
+    await stripWorkspaceSymlinks(dir);
     await git(["config", "user.name", botIdentity.login], LOCAL_WORKSPACE_CLONE_TIMEOUT_MS);
     await git(
       [

--- a/test/workspacePathContainment.test.ts
+++ b/test/workspacePathContainment.test.ts
@@ -1,0 +1,66 @@
+import { lstat, mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  assertContainedWorkspacePath,
+  stripWorkspaceSymlinks,
+} from "../src/prWorkspace/localPrWorkspace.js";
+
+describe("workspace path containment", () => {
+  const roots: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+  });
+
+  async function tempRoot(prefix: string): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), prefix));
+    roots.push(root);
+    return root;
+  }
+
+  it("allows ordinary files inside the root", async () => {
+    const root = await tempRoot("ws-contain-");
+    await mkdir(join(root, "src"), { recursive: true });
+    await writeFile(join(root, "src/app.ts"), "export {};\n");
+    const full = await assertContainedWorkspacePath(root, "src/app.ts");
+    expect(full).toBe(join(root, "src/app.ts"));
+  });
+
+  it("rejects absolute symlink escapes", async () => {
+    const root = await tempRoot("ws-contain-");
+    const outside = await tempRoot("ws-outside-");
+    await writeFile(join(outside, "secret.env"), "TOKEN=leak\n");
+    await mkdir(join(root, "docs"), { recursive: true });
+    await symlink(join(outside, "secret.env"), join(root, "docs/notes.md"));
+
+    await expect(assertContainedWorkspacePath(root, "docs/notes.md")).rejects.toMatchObject({
+      code: "pr_workspace.symlink_escape",
+    });
+  });
+
+  it("rejects relative symlink escapes to a sibling credential file", async () => {
+    const parent = await tempRoot("ws-parent-");
+    const root = join(parent, "checkout");
+    await mkdir(root, { recursive: true });
+    await writeFile(join(parent, "git-token"), "ghs_INSTALLATION_TOKEN_TESTVALUE0123456789");
+    await symlink("../git-token", join(root, "notes.md"));
+
+    await expect(assertContainedWorkspacePath(root, "notes.md")).rejects.toMatchObject({
+      code: "pr_workspace.symlink_escape",
+    });
+  });
+
+  it("stripWorkspaceSymlinks removes links and leaves regular files", async () => {
+    const root = await tempRoot("ws-strip-");
+    await mkdir(join(root, "docs"), { recursive: true });
+    await writeFile(join(root, "docs/ok.md"), "ok\n");
+    await symlink("/etc/passwd", join(root, "docs/bad.md"));
+    await stripWorkspaceSymlinks(root);
+    await expect(assertContainedWorkspacePath(root, "docs/ok.md")).resolves.toBe(
+      join(root, "docs/ok.md"),
+    );
+    await expect(lstat(join(root, "docs/bad.md"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});

--- a/test/writablePrCheckout.test.ts
+++ b/test/writablePrCheckout.test.ts
@@ -1,5 +1,15 @@
 import { execFile as execFileCb } from "node:child_process";
-import { lstat, mkdir, mkdtemp, readFile, rm, stat, symlink, utimes, writeFile } from "node:fs/promises";
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  symlink,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";

--- a/test/writablePrCheckout.test.ts
+++ b/test/writablePrCheckout.test.ts
@@ -1,5 +1,5 @@
 import { execFile as execFileCb } from "node:child_process";
-import { mkdir, mkdtemp, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, readFile, rm, stat, symlink, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -224,4 +224,47 @@ describe("writable PR checkout", () => {
       await rm(staleDir, { recursive: true, force: true });
     }
   });
+
+  it(
+    "strips attacker-controlled symlinks before exposing the checkout",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "writable-checkout-symlink-"));
+      const repo = join(root, "repo");
+      const remote = join(root, "remote.git");
+      try {
+        await git(root, ["init", repo]);
+        await git(repo, ["config", "user.email", "test@example.com"]);
+        await git(repo, ["config", "user.name", "Test"]);
+        await writeFile(join(repo, "src.txt"), "one\n");
+        await symlink("/etc/passwd", join(repo, "leak.md"));
+        await git(repo, ["add", "."]);
+        await git(repo, ["commit", "-m", "base with symlink"]);
+        await git(root, ["init", "--bare", remote]);
+        await git(repo, ["remote", "add", "origin", remote]);
+        await git(repo, ["push", "origin", "HEAD:refs/heads/main"]);
+        const headSha = await git(repo, ["rev-parse", "HEAD"]);
+
+        await withWritablePrCheckout(
+          {
+            owner: "owner",
+            repo: "repo",
+            headRef: "main",
+            headSha,
+            installationToken: "unused",
+            botIdentity: { userId: 123, login: "pr-agent[bot]" },
+            remoteUrlOverride: remote,
+          },
+          async (checkout) => {
+            await expect(lstat(join(checkout.dir, "leak.md"))).rejects.toMatchObject({
+              code: "ENOENT",
+            });
+            expect(await readFile(join(checkout.dir, "src.txt"), "utf8")).toContain("one");
+          },
+        );
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+    TEST_TIMEOUT_MS,
+  );
 });


### PR DESCRIPTION
## Summary
- Strip symbolic links from writable PR checkouts after materializing the head tree
- Reject workspace reads whose realpath leaves the checkout root
- Add regression coverage for absolute escapes, sibling `git-token` links, and checkout stripping

___

## PR Agent Description

### PR Type

Bug fix, Tests

### Description

- Block symlink escapes via new assertContainedWorkspacePath check
- Strip attacker-controlled symlinks from writable checkout trees
- Use containment check in triage and verification workspace tools

### Changes Diagram

```mermaid
flowchart LR
  A["Writable checkout clone"] --> B["stripWorkspaceSymlinks"]
  B --> C["Tool resolves path"]
  C --> D["assertContainedWorkspacePath"]
  D --> E["Reject symlink escape"]
```

### File Walkthrough

<details>
<summary>Bug fix (4 files)</summary>

<details>
<summary>Add symlink containment and strip helpers</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/379/files#diff-46db221b3cf2bb80b8d7983cd88cb8f4f108381a868fff3627a2c65bd339bb27"><code>src/prWorkspace/localPrWorkspace.ts</code></a>

- Add assertContainedWorkspacePath to deny symlink escapes; add stripWorkspaceSymlinks that skips .git.

</details>

<details>
<summary>Strip symlinks before exposing checkout</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/379/files#diff-827d6d463c5fd63731ebf38d8dbe9eb3d37b4e27b72cb0feaf93401b6c5c0941"><code>src/prWorkspace/writablePrCheckout.ts</code></a>

- Call stripWorkspaceSymlinks after the clone before exposing the checkout.

</details>

<details>
<summary>Use contained path check for reads</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/379/files#diff-460b47420d68c6ffe56009dffc7df032b5e1ae3bc2bb8fc2f186f2f115bd2e4d"><code>src/agent/triage/triageWorkspaceTools.ts</code></a>

- safeReadPath is now async and uses assertContainedWorkspacePath for symlink safety.

</details>

<details>
<summary>Use contained path check for reads</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/379/files#diff-a36d2d5c5316a2223a54721ee89caea63146f50add4ee78c46c602131d01f59a"><code>src/agent/verification/verificationWorkspaceTools.ts</code></a>

- safePath is now async and uses assertContainedWorkspacePath for symlink safety.

</details>

</details>

<details>
<summary>Tests (2 files)</summary>

<details>
<summary>Add symlink containment tests</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/379/files#diff-26b2f393d3fd3787f9b0aa4706363bc2ec67b2097a1fef3dd6165abfb5237173"><code>test/workspacePathContainment.test.ts</code></a>

- Cover absolute/relative symlink escape rejection and strip leaving regular files.

</details>

<details>
<summary>Add symlink strip in checkout test</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/379/files#diff-97900ff53f2426a083558ec32b1d2e92e07d80121e28131cc27207f624e89141"><code>test/writablePrCheckout.test.ts</code></a>

- Verify an attacker-controlled symlink is removed from the writable checkout.

</details>

</details>