### PR TITLE
Add triage tools and intent reconcile tests

### DIFF
--- a/src/agent/triage/triageWorkspaceTools.ts
+++ b/src/agent/triage/triageWorkspaceTools.ts
@@ -119,9 +119,10 @@ export function buildTriageWorkspaceTools(params: {
       maxResults: z.number().int().positive().optional().default(20),
     }),
     run: async ({ query, maxResults }) => {
+      // Avoid `git grep --max-count` (requires git ≥2.40); cap results after the fact.
       const stdout = await git(
         root,
-        ["grep", "-nF", "-I", `--max-count=${maxResults + 1}`, "-e", query, "--", "."],
+        ["grep", "-nF", "-I", "-e", query, "--", "."],
         LOCAL_WORKSPACE_FETCH_TIMEOUT_MS,
       ).catch((error: unknown) => {
         if (typeof error === "object" && error !== null && "code" in error && error.code === 1) {
@@ -129,20 +130,17 @@ export function buildTriageWorkspaceTools(params: {
         }
         throw error;
       });
-      const matches = stdout
-        .split("\n")
-        .filter(Boolean)
-        .slice(0, maxResults)
-        .map((line) => {
-          const first = line.indexOf(":");
-          const second = line.indexOf(":", first + 1);
-          return {
-            path: line.slice(0, first),
-            line: Number(line.slice(first + 1, second)),
-            text: line.slice(second + 1),
-          };
-        });
-      return { matches, truncated: stdout.split("\n").filter(Boolean).length > maxResults };
+      const lines = stdout.split("\n").filter(Boolean);
+      const matches = lines.slice(0, maxResults).map((line) => {
+        const first = line.indexOf(":");
+        const second = line.indexOf(":", first + 1);
+        return {
+          path: line.slice(0, first),
+          line: Number(line.slice(first + 1, second)),
+          text: line.slice(second + 1),
+        };
+      });
+      return { matches, truncated: lines.length > maxResults };
     },
   });
 

--- a/test/reconcilePendingIntents.test.ts
+++ b/test/reconcilePendingIntents.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Pool } from "pg";
+import { memoryOperationIntentStore } from "./setup/operationIntent-memory.js";
+
+vi.mock("../src/db/postgres.js", () => ({
+  queryOne: vi.fn(),
+}));
+
+vi.unmock("../src/agentWork/reconcilePendingIntents.js");
+
+const { queryOne } = await import("../src/db/postgres.js");
+const { reconcilePendingIntents, intentDetailMatchesPublishRecord } = await import(
+  "../src/agentWork/reconcilePendingIntents.js"
+);
+
+const pool = {} as Pool;
+
+describe("reconcilePendingIntents", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    memoryOperationIntentStore.reset();
+  });
+
+  it("reconciles a pending intent when a matching completed publish_record exists", async () => {
+    await memoryOperationIntentStore.persist(pool, {
+      workItemId: "wi-1",
+      operationKey: "review:summary:o/r#1",
+      mutationKind: "github.review_summary",
+      detail: { step: "review_summary", resourceKey: "o/r#1" },
+    });
+    vi.mocked(queryOne).mockResolvedValue({ id: "pub-42" });
+
+    const result = await reconcilePendingIntents(pool, "wi-1");
+
+    expect(result).toEqual({ reconciled: 1, stillPending: 0 });
+    expect(memoryOperationIntentStore.get("wi-1", "review:summary:o/r#1")).toMatchObject({
+      status: "reconciled",
+      publishRecordId: "pub-42",
+      detail: expect.objectContaining({
+        step: "review_summary",
+        reconciledFromPublishRecord: true,
+      }),
+    });
+    expect(queryOne).toHaveBeenCalledWith(
+      pool,
+      expect.stringContaining("FROM publish_records"),
+      ["wi-1", "review_summary", "o/r#1"],
+    );
+  });
+
+  it("leaves intents pending when no completed publish_record matches", async () => {
+    await memoryOperationIntentStore.persist(pool, {
+      workItemId: "wi-1",
+      operationKey: "review:inline:batch-1",
+      mutationKind: "github.review_inline",
+      detail: { step: "review_inline", batchId: "batch-1" },
+    });
+    vi.mocked(queryOne).mockResolvedValue(null);
+
+    const result = await reconcilePendingIntents(pool, "wi-1");
+
+    expect(result).toEqual({ reconciled: 0, stillPending: 1 });
+    expect(memoryOperationIntentStore.get("wi-1", "review:inline:batch-1")).toMatchObject({
+      status: "pending",
+      publishRecordId: null,
+    });
+  });
+
+  it("skips intents whose detail has no string step", async () => {
+    await memoryOperationIntentStore.persist(pool, {
+      workItemId: "wi-1",
+      operationKey: "broken:key",
+      mutationKind: "github.review_summary",
+      detail: { step: 12 },
+    });
+
+    const result = await reconcilePendingIntents(pool, "wi-1");
+
+    expect(result).toEqual({ reconciled: 0, stillPending: 1 });
+    expect(queryOne).not.toHaveBeenCalled();
+  });
+
+  it("includes batchId and threadRootCommentId filters when present on the intent", async () => {
+    await memoryOperationIntentStore.persist(pool, {
+      workItemId: "wi-2",
+      operationKey: "review:inline:t-9",
+      mutationKind: "github.review_inline",
+      detail: {
+        step: "review_inline",
+        reviewLens: "correctness",
+        batchId: "b-9",
+        threadRootCommentId: 55,
+      },
+    });
+    vi.mocked(queryOne).mockResolvedValue({ id: "pub-9" });
+
+    await reconcilePendingIntents(pool, "wi-2");
+
+    expect(queryOne).toHaveBeenCalledWith(
+      pool,
+      expect.stringMatching(/review_lens[\s\S]*batches[\s\S]*actedThreadIds/),
+      ["wi-2", "review_inline", "correctness", "b-9", "55"],
+    );
+  });
+
+  it("does not double-count already-reconciled intents", async () => {
+    await memoryOperationIntentStore.persist(pool, {
+      workItemId: "wi-1",
+      operationKey: "review:summary:o/r#1",
+      mutationKind: "github.review_summary",
+      detail: { step: "review_summary" },
+    });
+    await memoryOperationIntentStore.reconcile(pool, {
+      workItemId: "wi-1",
+      operationKey: "review:summary:o/r#1",
+      status: "reconciled",
+      publishRecordId: "pub-old",
+    });
+    await memoryOperationIntentStore.persist(pool, {
+      workItemId: "wi-1",
+      operationKey: "review:inline:batch-2",
+      mutationKind: "github.review_inline",
+      detail: { step: "review_inline", batchId: "batch-2" },
+    });
+    vi.mocked(queryOne).mockResolvedValue({ id: "pub-new" });
+
+    const result = await reconcilePendingIntents(pool, "wi-1");
+
+    expect(result).toEqual({ reconciled: 1, stillPending: 0 });
+    expect(queryOne).toHaveBeenCalledTimes(1);
+    expect(memoryOperationIntentStore.get("wi-1", "review:summary:o/r#1")).toMatchObject({
+      status: "reconciled",
+      publishRecordId: "pub-old",
+    });
+    expect(memoryOperationIntentStore.get("wi-1", "review:inline:batch-2")).toMatchObject({
+      status: "reconciled",
+      publishRecordId: "pub-new",
+    });
+  });
+});
+
+describe("intentDetailMatchesPublishRecord", () => {
+  it("returns false for non-object publish detail", () => {
+    expect(intentDetailMatchesPublishRecord({ batchId: "b1" }, null)).toBe(false);
+    expect(intentDetailMatchesPublishRecord({ batchId: "b1" }, "x")).toBe(false);
+  });
+
+  it("requires a matching batchId entry when intent carries batchId", () => {
+    expect(
+      intentDetailMatchesPublishRecord(
+        { batchId: "b1" },
+        { batches: [{ batchId: "other" }, { batchId: "b1" }] },
+      ),
+    ).toBe(true);
+    expect(
+      intentDetailMatchesPublishRecord({ batchId: "b1" }, { batches: [{ batchId: "other" }] }),
+    ).toBe(false);
+    expect(intentDetailMatchesPublishRecord({ batchId: "b1" }, { batches: "not-array" })).toBe(
+      false,
+    );
+  });
+
+  it("returns true when intent has no batchId constraint", () => {
+    expect(intentDetailMatchesPublishRecord({ step: "review_summary" }, {})).toBe(true);
+  });
+});

--- a/test/reconcilePendingIntents.test.ts
+++ b/test/reconcilePendingIntents.test.ts
@@ -9,9 +9,8 @@ vi.mock("../src/db/postgres.js", () => ({
 vi.unmock("../src/agentWork/reconcilePendingIntents.js");
 
 const { queryOne } = await import("../src/db/postgres.js");
-const { reconcilePendingIntents, intentDetailMatchesPublishRecord } = await import(
-  "../src/agentWork/reconcilePendingIntents.js"
-);
+const { reconcilePendingIntents, intentDetailMatchesPublishRecord } =
+  await import("../src/agentWork/reconcilePendingIntents.js");
 
 const pool = {} as Pool;
 
@@ -41,11 +40,11 @@ describe("reconcilePendingIntents", () => {
         reconciledFromPublishRecord: true,
       }),
     });
-    expect(queryOne).toHaveBeenCalledWith(
-      pool,
-      expect.stringContaining("FROM publish_records"),
-      ["wi-1", "review_summary", "o/r#1"],
-    );
+    expect(queryOne).toHaveBeenCalledWith(pool, expect.stringContaining("FROM publish_records"), [
+      "wi-1",
+      "review_summary",
+      "o/r#1",
+    ]);
   });
 
   it("leaves intents pending when no completed publish_record matches", async () => {

--- a/test/triageWorkspaceTools.test.ts
+++ b/test/triageWorkspaceTools.test.ts
@@ -29,10 +29,7 @@ function findingThread(overrides: Partial<BotFindingThread> = {}): BotFindingThr
   };
 }
 
-function mockCheckout(
-  dir: string,
-  commitImpl?: WritablePrCheckout["commit"],
-): WritablePrCheckout {
+function mockCheckout(dir: string, commitImpl?: WritablePrCheckout["commit"]): WritablePrCheckout {
   return {
     dir,
     headRef: "feature",

--- a/test/triageWorkspaceTools.test.ts
+++ b/test/triageWorkspaceTools.test.ts
@@ -1,0 +1,259 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildTriageWorkspaceTools,
+  createTriageWorkspaceToolState,
+} from "../src/agent/triage/triageWorkspaceTools.js";
+import type { WritablePrCheckout } from "../src/prWorkspace/writablePrCheckout.js";
+import type { BotFindingThread } from "../src/review/run/reviewPriorFeedback.js";
+import { MAX_TRIAGE_FIXES_PER_RUN } from "../src/settings/index.js";
+import { makeTestConfig } from "./helpers/config.js";
+
+const exec = promisify(execFile);
+
+function findingThread(overrides: Partial<BotFindingThread> = {}): BotFindingThread {
+  return {
+    rootCommentId: 101,
+    lens: "correctness",
+    path: "src/app.ts",
+    line: 1,
+    severity: "P1",
+    titleSnippet: "P1 · bug",
+    humanReplies: [],
+    threadUrl: "https://example.test/thread/101",
+    ...overrides,
+  };
+}
+
+function mockCheckout(
+  dir: string,
+  commitImpl?: WritablePrCheckout["commit"],
+): WritablePrCheckout {
+  return {
+    dir,
+    headRef: "feature",
+    baseSha: "a".repeat(40),
+    commit:
+      commitImpl ??
+      (async ({ files, subject }) => ({
+        sha: "b".repeat(40),
+        diff: `diff for ${files.join(",")} (${subject})`,
+      })),
+    push: async () => {},
+    listCommittedShas: () => [],
+    listCommittedDetails: () => [],
+  };
+}
+
+async function initCheckout(files: Readonly<Record<string, string>>): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "triage-ws-tools-"));
+  for (const [path, content] of Object.entries(files)) {
+    await mkdir(dirname(join(root, path)), { recursive: true });
+    await writeFile(join(root, path), content);
+  }
+  await exec("git", ["init"], { cwd: root });
+  await exec("git", ["config", "user.email", "test@example.com"], { cwd: root });
+  await exec("git", ["config", "user.name", "Test"], { cwd: root });
+  await exec("git", ["add", "."], { cwd: root });
+  await exec("git", ["commit", "-m", "seed"], { cwd: root });
+  return root;
+}
+
+describe("buildTriageWorkspaceTools", () => {
+  const roots: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+  });
+
+  async function setup(params?: {
+    files?: Readonly<Record<string, string>>;
+    inventory?: readonly BotFindingThread[];
+    commit?: WritablePrCheckout["commit"];
+  }) {
+    const root = await initCheckout(
+      params?.files ?? {
+        "src/app.ts": "const value = 1;\n",
+        "package.json": '{"name":"app"}\n',
+      },
+    );
+    roots.push(root);
+    const inventory = params?.inventory ?? [findingThread()];
+    const state = createTriageWorkspaceToolState();
+    const { executors } = buildTriageWorkspaceTools({
+      cfg: makeTestConfig(),
+      checkout: mockCheckout(root, params?.commit),
+      inventory,
+      state,
+    });
+    return { root, executors, state, inventory };
+  }
+
+  it("blocks read of control-plane paths", async () => {
+    const { executors } = await setup();
+    await expect(executors.readWorkspaceFile({ path: "package.json" })).rejects.toMatchObject({
+      code: "triage.sensitive_path_blocked",
+    });
+  });
+
+  it("blocks read through absolute symlink escapes", async () => {
+    const outside = await mkdtemp(join(tmpdir(), "triage-ws-outside-"));
+    roots.push(outside);
+    await writeFile(join(outside, "secret.env"), "TOKEN=leak\n");
+    const root = await initCheckout({ "src/app.ts": "export {};\n" });
+    roots.push(root);
+    await mkdir(join(root, "docs"), { recursive: true });
+    await symlink(join(outside, "secret.env"), join(root, "docs/notes.md"));
+
+    const { executors } = buildTriageWorkspaceTools({
+      cfg: makeTestConfig(),
+      checkout: mockCheckout(root),
+      inventory: [findingThread()],
+      state: createTriageWorkspaceToolState(),
+    });
+
+    await expect(executors.readWorkspaceFile({ path: "docs/notes.md" })).rejects.toMatchObject({
+      code: "pr_workspace.symlink_escape",
+    });
+  });
+
+  it("blocks edit of control-plane paths even when implicated", async () => {
+    const { executors } = await setup({
+      inventory: [findingThread({ path: "package.json" })],
+    });
+    await expect(
+      executors.editWorkspaceFile({
+        path: "package.json",
+        oldText: '{"name":"app"}',
+        newText: '{"name":"evil"}',
+      }),
+    ).rejects.toMatchObject({ code: "triage.control_path_blocked" });
+  });
+
+  it("rejects edit when oldText is missing", async () => {
+    const { executors } = await setup();
+    await expect(
+      executors.editWorkspaceFile({
+        path: "src/app.ts",
+        oldText: "does-not-exist",
+        newText: "x",
+      }),
+    ).rejects.toMatchObject({ code: "triage.old_text_not_found" });
+  });
+
+  it("rejects edit when oldText matches more than once", async () => {
+    const { executors } = await setup({
+      files: {
+        "src/app.ts": "const x = 1;\nconst y = 1;\n",
+        "package.json": "{}\n",
+      },
+    });
+    await expect(
+      executors.editWorkspaceFile({
+        path: "src/app.ts",
+        oldText: "1",
+        newText: "2",
+      }),
+    ).rejects.toMatchObject({ code: "triage.old_text_ambiguous" });
+  });
+
+  it("edits an implicated file when oldText is unique", async () => {
+    const { root, executors } = await setup();
+    const out = await executors.editWorkspaceFile({
+      path: "src/app.ts",
+      oldText: "const value = 1;",
+      newText: "const value = 2;",
+    });
+    expect(out).toEqual({ ok: true, path: "src/app.ts" });
+    expect(await readFile(join(root, "src/app.ts"), "utf8")).toBe("const value = 2;\n");
+  });
+
+  it("blocks create of control-plane workflow files", async () => {
+    const { executors } = await setup();
+    await expect(
+      executors.createWorkspaceFile({
+        path: ".github/workflows/evil.yml",
+        content: "name: evil\n",
+      }),
+    ).rejects.toMatchObject({ code: "triage.control_path_blocked" });
+  });
+
+  it("rejects commitFix for an unknown inventory thread", async () => {
+    const { executors } = await setup();
+    await expect(
+      executors.commitFix({
+        threadRootCommentId: 999,
+        files: ["src/app.ts"],
+        subject: "fix: unknown thread",
+      }),
+    ).rejects.toMatchObject({ code: "triage.unknown_thread" });
+  });
+
+  it("rejects duplicate commitFix for the same thread", async () => {
+    const commit = vi.fn(async () => ({ sha: "c".repeat(40), diff: "d" }));
+    const { executors, state } = await setup({ commit });
+    await executors.commitFix({
+      threadRootCommentId: 101,
+      files: ["src/app.ts"],
+      subject: "fix: once",
+    });
+    expect(state.commitByThreadRootCommentId.get(101)).toBe("c".repeat(40));
+
+    await expect(
+      executors.commitFix({
+        threadRootCommentId: 101,
+        files: ["src/app.ts"],
+        subject: "fix: twice",
+      }),
+    ).rejects.toMatchObject({ code: "triage.commit_fix_duplicate" });
+    expect(commit).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects commitFix after the per-run fix budget is exhausted", async () => {
+    const commit = vi.fn(async () => ({ sha: "d".repeat(40), diff: "d" }));
+    const inventory = Array.from({ length: MAX_TRIAGE_FIXES_PER_RUN + 1 }, (_, i) =>
+      findingThread({ rootCommentId: i + 1, path: "src/app.ts" }),
+    );
+    const { executors, state } = await setup({ inventory, commit });
+    for (let i = 1; i <= MAX_TRIAGE_FIXES_PER_RUN; i++) {
+      state.commitByThreadRootCommentId.set(i, "e".repeat(40));
+    }
+
+    await expect(
+      executors.commitFix({
+        threadRootCommentId: MAX_TRIAGE_FIXES_PER_RUN + 1,
+        files: ["src/app.ts"],
+        subject: "fix: over budget",
+      }),
+    ).rejects.toMatchObject({ code: "triage.fix_budget_reached" });
+    expect(commit).not.toHaveBeenCalled();
+  });
+
+  it("commitFix returns checkout sha and records the thread mapping", async () => {
+    const commit = vi.fn(async ({ files, subject }) => ({
+      sha: "f".repeat(40),
+      diff: `files=${files.join("|")} subject=${subject}`,
+    }));
+    const { executors, state } = await setup({ commit });
+    const out = await executors.commitFix({
+      threadRootCommentId: 101,
+      files: ["src/app.ts"],
+      subject: "fix: app value",
+      body: ["unique oldText match"],
+    });
+    expect(out).toEqual({
+      sha: "f".repeat(40),
+      diff: "files=src/app.ts subject=fix: app value",
+    });
+    expect(state.commitByThreadRootCommentId.get(101)).toBe("f".repeat(40));
+    expect(commit).toHaveBeenCalledWith({
+      files: ["src/app.ts"],
+      subject: "fix: app value",
+      body: ["unique oldText match"],
+    });
+  });
+});

--- a/test/triageWorkspaceTools.test.ts
+++ b/test/triageWorkspaceTools.test.ts
@@ -18,7 +18,7 @@ const exec = promisify(execFile);
 function findingThread(overrides: Partial<BotFindingThread> = {}): BotFindingThread {
   return {
     rootCommentId: 101,
-    lens: "correctness",
+    lens: "review",
     path: "src/app.ts",
     line: 1,
     severity: "P1",
@@ -121,6 +121,68 @@ describe("buildTriageWorkspaceTools", () => {
     });
   });
 
+  it("returns empty matches when searchWorkspace finds nothing", async () => {
+    const { executors } = await setup();
+    const out = await executors.searchWorkspace({ query: "no-such-token-xyz" });
+    expect(out).toEqual({ matches: [], truncated: false });
+  });
+
+  it("returns a unified diff for an edited workspace path", async () => {
+    const { executors } = await setup();
+    await executors.editWorkspaceFile({
+      path: "src/app.ts",
+      oldText: "const value = 1;",
+      newText: "const value = 2;",
+    });
+    const out = await executors.getWorkspaceDiff({ path: "src/app.ts" });
+    expect(out).toMatchObject({
+      path: "src/app.ts",
+      diff: expect.stringContaining("const value = 2;"),
+    });
+  });
+
+  it("blocks edit through a symlink escaping the checkout", async () => {
+    const outside = await mkdtemp(join(tmpdir(), "triage-ws-outside-edit-"));
+    roots.push(outside);
+    await writeFile(join(outside, "secret.env"), "TOKEN=leak\n");
+    const root = await initCheckout({ "src/app.ts": "export {};\n" });
+    roots.push(root);
+    await mkdir(join(root, "docs"), { recursive: true });
+    await symlink(join(outside, "secret.env"), join(root, "docs/notes.md"));
+
+    const { executors } = buildTriageWorkspaceTools({
+      cfg: makeTestConfig(),
+      checkout: mockCheckout(root),
+      inventory: [findingThread({ path: "docs/notes.md" })],
+      state: createTriageWorkspaceToolState(),
+    });
+
+    await expect(
+      executors.editWorkspaceFile({
+        path: "docs/notes.md",
+        oldText: "TOKEN=leak",
+        newText: "x",
+      }),
+    ).rejects.toMatchObject({ code: "triage.symlink_escape_blocked" });
+  });
+
+  it("rejects edit of files not in the finding inventory", async () => {
+    const { executors } = await setup({
+      files: {
+        "src/app.ts": "const value = 1;\n",
+        "src/util.ts": "export const util = 1;\n",
+        "package.json": '{"name":"app"}\n',
+      },
+    });
+    await expect(
+      executors.editWorkspaceFile({
+        path: "src/util.ts",
+        oldText: "1",
+        newText: "2",
+      }),
+    ).rejects.toMatchObject({ code: "triage.path_not_implicated" });
+  });
+
   it("blocks edit of control-plane paths even when implicated", async () => {
     const { executors } = await setup({
       inventory: [findingThread({ path: "package.json" })],
@@ -182,6 +244,33 @@ describe("buildTriageWorkspaceTools", () => {
     ).rejects.toMatchObject({ code: "triage.control_path_blocked" });
   });
 
+  it("rejects create of non-safe, non-control new files", async () => {
+    const { executors } = await setup();
+    await expect(
+      executors.createWorkspaceFile({
+        path: "src/helper.ts",
+        content: "export {};\n",
+      }),
+    ).rejects.toMatchObject({ code: "triage.unsafe_new_file_blocked" });
+  });
+
+  it("creates a safe new file and rejects a duplicate create", async () => {
+    const { root, executors } = await setup();
+    const out = await executors.createWorkspaceFile({
+      path: "docs/notes.md",
+      content: "# n\n",
+    });
+    expect(out).toEqual({ ok: true, path: "docs/notes.md" });
+    expect(await readFile(join(root, "docs/notes.md"), "utf8")).toBe("# n\n");
+
+    await expect(
+      executors.createWorkspaceFile({
+        path: "docs/notes.md",
+        content: "x",
+      }),
+    ).rejects.toMatchObject({ code: "triage.path_exists" });
+  });
+
   it("rejects commitFix for an unknown inventory thread", async () => {
     const { executors } = await setup();
     await expect(
@@ -191,6 +280,26 @@ describe("buildTriageWorkspaceTools", () => {
         subject: "fix: unknown thread",
       }),
     ).rejects.toMatchObject({ code: "triage.unknown_thread" });
+  });
+
+  it("rejects commitFix staging files not in the finding inventory", async () => {
+    const commit = vi.fn(async () => ({ sha: "c".repeat(40), diff: "d" }));
+    const { executors } = await setup({
+      files: {
+        "src/app.ts": "const value = 1;\n",
+        "src/util.ts": "export const util = 1;\n",
+        "package.json": '{"name":"app"}\n',
+      },
+      commit,
+    });
+    await expect(
+      executors.commitFix({
+        threadRootCommentId: 101,
+        files: ["src/util.ts"],
+        subject: "fix: un-implicated",
+      }),
+    ).rejects.toMatchObject({ code: "triage.path_not_implicated" });
+    expect(commit).not.toHaveBeenCalled();
   });
 
   it("rejects duplicate commitFix for the same thread", async () => {


### PR DESCRIPTION
## Summary
- Add unit tests for triage workspace tool control paths, symlink escape, and commitFix budget
- Add unit tests for reconciling pending operation intents to completed publish records

___

## PR Agent Description

### PR Type

Tests

### Description

- Cover reconcilePendingIntents matching against completed publish_records
- Cover intentDetailMatchesPublishRecord batchId constraint logic
- Cover triage workspace guards, symlink escapes, and commitFix budget

### File Walkthrough

<details>
<summary>Tests (2 files)</summary>

<details>
<summary>Tests for reconcilePendingIntents</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/381/files#diff-6dcced42cba032fb3857f6b82bad32b51791ff89e755e89275bf5856a389e8a6"><code>test/reconcilePendingIntents.test.ts</code></a>

- Reconciles pending intents when a publish_record matches; leaves intents pending and skips non-string steps; verifies batchId/threadRootCommentId SQL filters.

</details>

<details>
<summary>Tests for buildTriageWorkspaceTools</summary>

<a href="https://github.com/prathamdby/pr-agent/pull/381/files#diff-25b16eb03dce082f44b457b1fbbba4b29d1d30140877da9e8488e012e28e0741"><code>test/triageWorkspaceTools.test.ts</code></a>

- Blocks sensitive path reads and symlink escapes; validates edit/create guards and commitFix duplicates; enforces per-run fix budget and thread mappings.

</details>

</details>