### PR TITLE
refactor: share isRecord type guard

### DIFF
--- a/src/agent/ask/recoverAskReply.ts
+++ b/src/agent/ask/recoverAskReply.ts
@@ -1,14 +1,11 @@
 import type { ReplyTarget } from "../../commands/replyTarget.js";
 import { installationOctokit } from "../../github/appAuth.js";
+import { isRecord } from "../../util/typeGuards.js";
 import { redactOutboundSecrets } from "./askSafety.js";
 
 export type RecoveredAskReply = {
   readonly commentId: number;
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value != null;
-}
 
 /** Extract a stashed GitHub comment id from operation-intent detail. */
 export function askReplyCommentIdFromIntentDetail(

--- a/src/agent/runtime/lifecycleSanitizer.ts
+++ b/src/agent/runtime/lifecycleSanitizer.ts
@@ -1,5 +1,6 @@
 import { logWarn } from "../../evlog.js";
 import { sanitizeLogMessage } from "../../security/sanitizeLogMessage.js";
+import { isPlainObject } from "../../util/typeGuards.js";
 import { isAgentLifecycleEventKind, type AgentLifecycleEvent } from "./lifecycleEvents.js";
 import type { AgentSessionPhase, AgentSessionRole } from "./types.js";
 
@@ -29,10 +30,6 @@ const SESSION_PHASES = new Set<AgentSessionPhase>([
 
 const FORBIDDEN_KEY_RE =
   /prompt|message|text|reasoning|content|argument|result|payload|token|secret|key|authorization|cookie|body|diff|patch|errorMessage|stack|cause/i;
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function asString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;

--- a/src/agentWork/publishRecordRepository.ts
+++ b/src/agentWork/publishRecordRepository.ts
@@ -15,6 +15,7 @@ import {
   VERIFICATION_PUBLISH_LENS,
 } from "../settings/index.js";
 import type { AnyReviewLens } from "../settings/legacyReviewLenses.js";
+import { isRecord } from "../util/typeGuards.js";
 
 export type PublishLens =
   | AnyReviewLens
@@ -379,10 +380,6 @@ type StoredInlineBatchRef = {
     readonly canonicalFingerprint: string;
   }[];
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value != null;
-}
 
 function parseStoredPlacement(value: unknown): StoredInlineBatchRef["placements"][number] | null {
   if (!isRecord(value)) return null;

--- a/src/agentWork/reconcilePendingIntents.ts
+++ b/src/agentWork/reconcilePendingIntents.ts
@@ -1,6 +1,7 @@
 import type { Pool, PoolClient } from "pg";
 import { logInfo } from "../evlog.js";
 import { queryOne } from "../db/postgres.js";
+import { isRecord } from "../util/typeGuards.js";
 import {
   listPendingOperationIntents,
   reconcileOperationIntent,
@@ -11,10 +12,6 @@ type ReconcilePendingIntentsResult = {
   readonly reconciled: number;
   readonly stillPending: number;
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value != null;
-}
 
 export async function findCompletedPublishRecordId(
   client: Pool | PoolClient,

--- a/src/github/reviewThreadResolution.ts
+++ b/src/github/reviewThreadResolution.ts
@@ -1,5 +1,6 @@
 import { logWarn } from "../evlog.js";
 import { MAX_REVIEW_THREAD_PAGES } from "../settings/index.js";
+import { isRecord } from "../util/typeGuards.js";
 import { installationOctokit } from "./appAuth.js";
 import { classifyGithubError } from "./githubErrors.js";
 
@@ -79,7 +80,7 @@ function fullDatabaseId(value: unknown): number | null {
 }
 
 function isReviewThreadsPage(value: unknown): value is ReviewThreadsPage {
-  return typeof value === "object" && value != null;
+  return isRecord(value);
 }
 
 function ingestThreadsPage(

--- a/src/util/typeGuards.ts
+++ b/src/util/typeGuards.ts
@@ -1,0 +1,9 @@
+/** True for non-null objects, including arrays and boxed primitives. */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value != null;
+}
+
+/** True for non-null plain objects only (excludes arrays). */
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/test/helpers/promptCost.ts
+++ b/test/helpers/promptCost.ts
@@ -1,4 +1,5 @@
 import { Buffer } from "node:buffer";
+import { isPlainObject } from "../../src/util/typeGuards.js";
 
 export type PromptCost = {
   readonly bytes: number;
@@ -51,10 +52,6 @@ function assertDimension(
   }
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value != null && !Array.isArray(value);
-}
-
 function sortJson(value: unknown): unknown {
   if (
     typeof value === "object" &&
@@ -65,7 +62,7 @@ function sortJson(value: unknown): unknown {
     return sortJson(value.toJSON());
   }
   if (Array.isArray(value)) return value.map(sortJson);
-  if (!isRecord(value)) return value;
+  if (!isPlainObject(value)) return value;
   return Object.fromEntries(
     Object.keys(value)
       .toSorted()

--- a/test/promptCostBaselines.test.ts
+++ b/test/promptCostBaselines.test.ts
@@ -18,6 +18,7 @@ import {
   stableJson,
   type PromptCost,
 } from "./helpers/promptCost.js";
+import { isRecord } from "../src/util/typeGuards.js";
 import { makeTestConfig } from "./helpers/config.js";
 import { mockLocalPrWorkspace } from "./helpers/mockWorkspace.js";
 
@@ -259,5 +260,5 @@ function requiredFields(schema: unknown): string[] {
 }
 
 function isObjectSchema(value: unknown): value is { readonly required?: readonly unknown[] } {
-  return typeof value === "object" && value != null;
+  return isRecord(value);
 }


### PR DESCRIPTION
## Summary
Extract duplicated `isRecord` / plain-object type guards into one shared module. No behavior change.

## Shared module
`src/util/typeGuards.ts`
- `isRecord` — `typeof value === "object" && value != null` (includes arrays)
- `isPlainObject` — same plus `!Array.isArray(value)`

## Replaced call sites
### `isRecord`
1. `src/agent/ask/recoverAskReply.ts`
2. `src/agentWork/reconcilePendingIntents.ts`
3. `src/agentWork/publishRecordRepository.ts`
4. `src/github/reviewThreadResolution.ts` (`isReviewThreadsPage` body)
5. `test/promptCostBaselines.test.ts` (`isObjectSchema` body)

### `isPlainObject` (kept array-excluding semantics)
1. `src/agent/runtime/lifecycleSanitizer.ts`
2. `test/helpers/promptCost.ts` (was misnamed local `isRecord` that excluded arrays)

## Why promptCost did not use `isRecord`
Local helper body was `object && non-null && !Array.isArray`. Using shared `isRecord` would treat arrays as records and change `sortJson`. Mapped to `isPlainObject` instead.

## Follow-ups (not in this PR)
| Candidate | Why deferred |
|---|---|
| Local `isSensitivePath` in `triageWorkspaceTools.ts` / `verificationWorkspaceTools.ts` vs exported `askSafety.isSensitivePath` | Ask version normalizes path separators inside the helper; triage/verification assume pre-normalized input. Needs a deliberate shared API. |
| Inline `typeof error === "object" && error != null && "message" in error` in `githubErrors.ts` / `reviewErrors.ts` | Error-shaped predicate, not a general record guard. |
| `relativePath` helpers in triage/verification workspace tools | Tiny and colocated with path root handling; low win, easy to break path edge cases. |

## Verification (at `7b9225482fdc3c3c11e9cbf3509b55805c7ca68d`)
- `nub run check:code` — pass (typecheck + lint 0 errors + fmt)
- `nub run test` — 185 files / 1509 tests passed

Buzz channel: `a9f0fac9-1eee-4d7a-a00d-7d17131e4acf`

___

## PR Agent Description

### PR Type

Enhancement

### Description

- Add shared src/util/typeGuards.ts with isRecord and isPlainObject
- Replace five local copies of the same guards with imports
- Swap inline object checks in review threads and schema test
- No behavior change; guard semantics preserved per call site

### Changes Diagram

```mermaid
flowchart LR
  A["src/util/typeGuards.ts"] --> B["isRecord"]
  A --> C["isPlainObject"]
  B --> D["agentWork repository and reconcile"]
  B --> E["ask reply recovery"]
  B --> F["review thread resolution"]
  C --> G["lifecycle sanitizer"]
  C --> H["prompt cost test helper"]
```

### Review map

1. <a href="https://github.com/prathamdby/pr-agent/pull/394/files#diff-cfdc3ea29ee11041239073103e3f4e62b2f885b3cddb590eb71814c05e3456f3"><code>src/util/typeGuards.ts</code></a>: New shared module defining both guard semantics
2. <a href="https://github.com/prathamdby/pr-agent/pull/394/files#diff-a1f3d25ff90eebdc6aff9cf37b288c902a2137cafa676a9c7fa67d4044f7d3d6"><code>src/agent/runtime/lifecycleSanitizer.ts</code></a>: Sanitizer relies on array-excluding variant, verify correct import
3. <a href="https://github.com/prathamdby/pr-agent/pull/394/files#diff-e2481236fb1e8adc6c97e43f306cca792435624ff95cbe5fe0328846db111bc3"><code>src/github/reviewThreadResolution.ts</code></a>: Inline check replaced by shared guard on GraphQL page parsing
4. <a href="https://github.com/prathamdby/pr-agent/pull/394/files#diff-5dca760fcac90a2036e2df723f341fd502ba8863893b2b071cc6851039b40d21"><code>src/agentWork/publishRecordRepository.ts</code></a>: Persisted-record parsing now depends on external guard
5. <a href="https://github.com/prathamdby/pr-agent/pull/394/files#diff-34a3450a1c5c44865bf25ac529a0f1e6e958e3a746f73ccab6b2f6a0117cc062"><code>test/helpers/promptCost.ts</code></a>: Helper switched to isPlainObject to keep array handling intact