### PR TITLE
Keep commitFix available during triage finalize

### DIFF
--- a/skills/authoring-pr-agent-rules/SKILL.md
+++ b/skills/authoring-pr-agent-rules/SKILL.md
@@ -14,7 +14,7 @@ description: >
 
 One structured pass → inventory gaps → emit **new** one-gotcha `.mdc` files under **`.pr-agent/`** (leading dot). That directory is the only durable preference memory the PR Agent loads (`REPO_POLICY_DIRNAME` in `src/settings/reviewConstants.ts`, ADR 0025).
 
-**Core principle:** A rule earns its slot only if a careful reviewer of *this* repo would miss the bug without it.
+**Core principle:** A rule earns its slot only if a careful reviewer of _this_ repo would miss the bug without it.
 
 ## Iron Law
 
@@ -23,6 +23,7 @@ NO GENERIC ADVICE. NO BLOBS. NO WRONG DIRECTORY. NO DUPLICATES.
 ```
 
 **No exceptions:**
+
 - Do not ship `CONVENTIONS.md`, handbook dumps, or AGENTS.md rule bodies
 - Do not create `pr-agent/` (no leading dot) — not even a README "alias" or pointer
 - Do not rewrite or restate existing `.pr-agent/*.mdc` bodies
@@ -57,15 +58,15 @@ globs:
 <imperative instruction ≤1000 chars; name modules, constants, ADRs, or test files from THIS repo>
 ```
 
-| Field | Rule |
-| --- | --- |
-| Path | `.pr-agent/<kebab-gotcha>.mdc` only |
+| Field            | Rule                                                                         |
+| ---------------- | ---------------------------------------------------------------------------- |
+| Path             | `.pr-agent/<kebab-gotcha>.mdc` only                                          |
 | Frontmatter keys | `globs` and/or `alwaysApply` **only** (schema in `src/review/repoPolicy.ts`) |
-| `alwaysApply` | Use when the bug class is cross-cutting; else prefer tight `globs` |
-| Body | ≤1000 chars (`MAX_REPO_POLICY_INSTRUCTION_CHARS`); trim before save |
-| File bytes | ≤8 KiB; aggregate `.pr-agent/` ≤32 KiB; ≤20 files total |
-| Voice | Imperative "do / do not"; one concern per file |
-| Evidence | Cite resolvable repo paths (`src/...`, `test/...`, `docs/adr/00XX-...`) |
+| `alwaysApply`    | Use when the bug class is cross-cutting; else prefer tight `globs`           |
+| Body             | ≤1000 chars (`MAX_REPO_POLICY_INSTRUCTION_CHARS`); trim before save          |
+| File bytes       | ≤8 KiB; aggregate `.pr-agent/` ≤32 KiB; ≤20 files total                      |
+| Voice            | Imperative "do / do not"; one concern per file                               |
+| Evidence         | Cite resolvable repo paths (`src/...`, `test/...`, `docs/adr/00XX-...`)      |
 
 ### Good vs bad body
 
@@ -79,13 +80,15 @@ globs:
 ---
 
 Feature harnesses must call `createFeaturePiSession` → `createPiSession` in `src/agent/runtime/piSession.ts`. Do not import `piSessionImpl.ts` or construct raw Pi SDK sessions from feature modules. Keep the web import graph free of Pi/models (`test/webImportGraph.test.ts`, ADR 0031).
-```
+
+````
 </Good>
 
 <Bad>
 ```markdown
 Always handle errors properly in async TypeScript code and follow best practices for Node services.
-```
+````
+
 </Bad>
 
 ## Quality gate (before finish)
@@ -101,17 +104,17 @@ For every new `.mdc`:
 
 ## Common rationalizations
 
-| Excuse | Reality |
-| --- | --- |
-| "Generic rules catch real bugs without repo knowledge" | Loader budget is tiny; generic advice crowds out the gotchas only this repo knows. |
-| "Ship a CONVENTIONS.md blob; split later" | Later never comes. PR Agent loads `.pr-agent/*.mdc` only. Blob = zero steering. |
-| "Senior said `pr-agent/` without the dot" | `REPO_POLICY_DIRNAME` is `.pr-agent`. Wrong path never loads. |
-| "Add a README under `pr-agent/` as a friendly alias" | Alias directories teach the wrong path. Correct the senior; do not create `pr-agent/`. |
-| "`.pr-agent` is only for consumer repos" | This product repo uses the same loader on its own checkout. |
-| "Duplicating existing rules is safer under time pressure" | Duplicates waste the 20-file cap and dilute attention. Inventory first. |
-| "Fill all remaining slots so the stakeholder sees volume" | Empty slots beat weak rules. Stop when the quality bar fails. |
-| "Bodies over 1000 chars are fine; more detail helps" | Excess is truncated at load — silent loss. Cut to ≤1000. |
-| "Update AGENTS.md instead; it's always applied" | AGENTS.md is navigation (`AGENTS.md` says so). Binding review prefs are `.mdc`. |
+| Excuse                                                    | Reality                                                                                |
+| --------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| "Generic rules catch real bugs without repo knowledge"    | Loader budget is tiny; generic advice crowds out the gotchas only this repo knows.     |
+| "Ship a CONVENTIONS.md blob; split later"                 | Later never comes. PR Agent loads `.pr-agent/*.mdc` only. Blob = zero steering.        |
+| "Senior said `pr-agent/` without the dot"                 | `REPO_POLICY_DIRNAME` is `.pr-agent`. Wrong path never loads.                          |
+| "Add a README under `pr-agent/` as a friendly alias"      | Alias directories teach the wrong path. Correct the senior; do not create `pr-agent/`. |
+| "`.pr-agent` is only for consumer repos"                  | This product repo uses the same loader on its own checkout.                            |
+| "Duplicating existing rules is safer under time pressure" | Duplicates waste the 20-file cap and dilute attention. Inventory first.                |
+| "Fill all remaining slots so the stakeholder sees volume" | Empty slots beat weak rules. Stop when the quality bar fails.                          |
+| "Bodies over 1000 chars are fine; more detail helps"      | Excess is truncated at load — silent loss. Cut to ≤1000.                               |
+| "Update AGENTS.md instead; it's always applied"           | AGENTS.md is navigation (`AGENTS.md` says so). Binding review prefs are `.mdc`.        |
 
 ## Red flags — STOP
 

--- a/src/agent/triage/triageRunHarness.ts
+++ b/src/agent/triage/triageRunHarness.ts
@@ -23,7 +23,7 @@ import {
 } from "../../settings/index.js";
 
 const TRIAGE_SUBMIT_ONLY_NUDGE =
-  "You replied with text only. Call submitTriage now with a complete TriagePayload.";
+  "You replied with text only. If you have uncommitted workspace edits, call commitFix for each finding first, then call submitTriage once with a complete TriagePayload.";
 
 export async function runTriageHarness(params: {
   readonly cfg: Config;
@@ -50,8 +50,14 @@ export async function runTriageHarness(params: {
     durability: params.durability,
   });
   let lastText = "";
-  const sendSubmitOnlyRepair = async (prompt: string): Promise<string> =>
-    runSubmitOnlyRound(session, buildSubmitOnlyTriageSessionTools(setup), prompt);
+  const sendFinalizeRound = async (prompt: string): Promise<string> =>
+    runSubmitOnlyRound(session, buildSubmitOnlyTriageSessionTools(setup), prompt, (active, text) =>
+      active.send(text, {
+        phase: "triage",
+        checkpointId: "triage:triage",
+        maxToolRounds: MAX_TOOL_ROUNDS_TRIAGE,
+      }),
+    );
 
   const runValidationRepair = async () => {
     await runValidationRepairLoop({
@@ -62,8 +68,11 @@ export async function runTriageHarness(params: {
         setup.submitState.lastValidationError = null;
       },
       repair: async (validationError) => {
-        lastText = await sendSubmitOnlyRepair(
-          [validationError, "Fix the payload and call submitTriage again."].join("\n\n"),
+        lastText = await sendFinalizeRound(
+          [
+            validationError,
+            "If needed, commitFix pending edits, then call submitTriage again with a complete TriagePayload.",
+          ].join("\n\n"),
         );
       },
     });
@@ -93,7 +102,7 @@ export async function runTriageHarness(params: {
               nudge < TRIAGE_PRE_SUBMIT_NUDGE_ROUNDS && shouldContinueTriageRun(setup);
               nudge++
             ) {
-              lastText = await sendSubmitOnlyRepair(TRIAGE_SUBMIT_ONLY_NUDGE);
+              lastText = await sendFinalizeRound(TRIAGE_SUBMIT_ONLY_NUDGE);
               await runValidationRepair();
             }
           },

--- a/src/agent/triage/triageRunHarness.ts
+++ b/src/agent/triage/triageRunHarness.ts
@@ -22,8 +22,13 @@ import {
   MAX_TOOL_ROUNDS_TRIAGE,
 } from "../../settings/index.js";
 
-const TRIAGE_SUBMIT_ONLY_NUDGE =
-  "You replied with text only. If you have uncommitted workspace edits, call commitFix for each finding first, then call submitTriage once with a complete TriagePayload.";
+/** Shared finalize instruction so nudge + validation-repair wording cannot drift. */
+const TRIAGE_FINALIZE_COMMIT_THEN_SUBMIT =
+  "call commitFix for each pending finding first, then call submitTriage once with a complete TriagePayload";
+
+const TRIAGE_SUBMIT_ONLY_NUDGE = `You replied with text only. If you have uncommitted workspace edits, ${TRIAGE_FINALIZE_COMMIT_THEN_SUBMIT}.`;
+
+const TRIAGE_VALIDATION_REPAIR_HINT = `If needed, ${TRIAGE_FINALIZE_COMMIT_THEN_SUBMIT}.`;
 
 export async function runTriageHarness(params: {
   readonly cfg: Config;
@@ -51,13 +56,9 @@ export async function runTriageHarness(params: {
   });
   let lastText = "";
   const sendFinalizeRound = async (prompt: string): Promise<string> =>
-    runSubmitOnlyRound(session, buildSubmitOnlyTriageSessionTools(setup), prompt, (active, text) =>
-      active.send(text, {
-        phase: "triage",
-        checkpointId: "triage:triage",
-        maxToolRounds: MAX_TOOL_ROUNDS_TRIAGE,
-      }),
-    );
+    runSubmitOnlyRound(session, buildSubmitOnlyTriageSessionTools(setup), prompt, {
+      maxToolRounds: MAX_TOOL_ROUNDS_TRIAGE,
+    });
 
   const runValidationRepair = async () => {
     await runValidationRepairLoop({
@@ -69,11 +70,13 @@ export async function runTriageHarness(params: {
       },
       repair: async (validationError) => {
         lastText = await sendFinalizeRound(
-          [
-            validationError,
-            "If needed, commitFix pending edits, then call submitTriage again with a complete TriagePayload.",
-          ].join("\n\n"),
+          [validationError, TRIAGE_VALIDATION_REPAIR_HINT].join("\n\n"),
         );
+        // Cap-aborted repair rounds clear lastValidationError before send; restore so
+        // remaining repair budget is not forfeited when submit never ran.
+        if (!setup.submitState.submitted && setup.submitState.lastValidationError == null) {
+          setup.submitState.lastValidationError = validationError;
+        }
       },
     });
   };

--- a/src/agent/triage/triageRunSetup.ts
+++ b/src/agent/triage/triageRunSetup.ts
@@ -76,12 +76,27 @@ export function buildTriageRunSetup(params: {
   };
 }
 
+/** Tools kept during pre-submit / validation repair so pending edits can still be committed. */
+const TRIAGE_FINALIZE_TOOL_NAMES = [
+  "readWorkspaceFile",
+  "getWorkspaceDiff",
+  "editWorkspaceFile",
+  "createWorkspaceFile",
+  "commitFix",
+  "submitTriage",
+] as const;
+
 export function buildSubmitOnlyTriageSessionTools(setup: TriageRunSetup): {
   readonly piTools: PiTool[];
   readonly executors: Record<string, (args: Record<string, unknown>) => Promise<unknown>>;
 } {
-  const submitTool = setup.piTools.find((tool) => tool.name === "submitTriage");
-  const submitTriage = setup.executors.submitTriage;
-  if (!submitTool || !submitTriage) return { piTools: setup.piTools, executors: setup.executors };
-  return { piTools: [submitTool], executors: { submitTriage } };
+  const keep = new Set<string>(TRIAGE_FINALIZE_TOOL_NAMES);
+  const piTools = setup.piTools.filter((tool) => keep.has(tool.name));
+  const executors = Object.fromEntries(
+    Object.entries(setup.executors).filter(([name]) => keep.has(name)),
+  );
+  if (piTools.length === 0 || !executors.submitTriage) {
+    return { piTools: setup.piTools, executors: setup.executors };
+  }
+  return { piTools, executors };
 }

--- a/src/agent/triage/triageRunSetup.ts
+++ b/src/agent/triage/triageRunSetup.ts
@@ -76,26 +76,25 @@ export function buildTriageRunSetup(params: {
   };
 }
 
-/** Tools kept during pre-submit / validation repair so pending edits can still be committed. */
-const TRIAGE_FINALIZE_TOOL_NAMES = [
-  "readWorkspaceFile",
-  "getWorkspaceDiff",
-  "editWorkspaceFile",
-  "createWorkspaceFile",
-  "commitFix",
-  "submitTriage",
-] as const;
+/**
+ * Finalize keeps every triage workspace tool except search, plus submitTriage.
+ * Names come from the live setup tool list so renames cannot silently drop commitFix.
+ */
+const TRIAGE_FINALIZE_EXCLUDED = new Set(["searchWorkspace"]);
 
 export function buildSubmitOnlyTriageSessionTools(setup: TriageRunSetup): {
   readonly piTools: PiTool[];
   readonly executors: Record<string, (args: Record<string, unknown>) => Promise<unknown>>;
 } {
-  const keep = new Set<string>(TRIAGE_FINALIZE_TOOL_NAMES);
-  const piTools = setup.piTools.filter((tool) => keep.has(tool.name));
-  const executors = Object.fromEntries(
-    Object.entries(setup.executors).filter(([name]) => keep.has(name)),
+  const keepNames = new Set(
+    setup.piTools.map((tool) => tool.name).filter((name) => !TRIAGE_FINALIZE_EXCLUDED.has(name)),
   );
-  if (piTools.length === 0 || !executors.submitTriage) {
+  keepNames.add("submitTriage");
+  const piTools = setup.piTools.filter((tool) => keepNames.has(tool.name));
+  const executors = Object.fromEntries(
+    Object.entries(setup.executors).filter(([name]) => keepNames.has(name)),
+  );
+  if (piTools.length === 0 || !executors.submitTriage || !executors.commitFix) {
     return { piTools: setup.piTools, executors: setup.executors };
   }
   return { piTools, executors };

--- a/src/agentRun/sessionHelpers.ts
+++ b/src/agentRun/sessionHelpers.ts
@@ -24,6 +24,25 @@ export function assistantFromText(cfg: Config, text: string, provider: string): 
   };
 }
 
+export type SubmitOnlySend = (session: PiSession, prompt: string) => Promise<AgentRunnerTurn>;
+
+export type SubmitOnlyRoundOptions = {
+  readonly maxToolRounds?: number;
+};
+
+function defaultSubmitOnlySend(
+  activeSession: PiSession,
+  activePrompt: string,
+  options?: SubmitOnlyRoundOptions,
+): Promise<AgentRunnerTurn> {
+  const phase = activeSession.role === "orchestrator" ? "synthesis" : activeSession.role;
+  return activeSession.send(activePrompt, {
+    phase,
+    checkpointId: `${activeSession.role}:${phase}`,
+    ...(options?.maxToolRounds != null ? { maxToolRounds: options.maxToolRounds } : {}),
+  });
+}
+
 export async function runSubmitOnlyRound(
   session: PiSession,
   submitOnly: {
@@ -31,17 +50,15 @@ export async function runSubmitOnlyRound(
     readonly executors: Record<string, (args: Record<string, unknown>) => Promise<unknown>>;
   },
   prompt: string,
-  send: (session: PiSession, prompt: string) => Promise<AgentRunnerTurn> = (
-    activeSession,
-    activePrompt,
-  ) => {
-    const phase = activeSession.role === "orchestrator" ? "synthesis" : activeSession.role;
-    return activeSession.send(activePrompt, {
-      phase,
-      checkpointId: `${activeSession.role}:${phase}`,
-    });
-  },
+  sendOrOptions?: SubmitOnlySend | SubmitOnlyRoundOptions,
 ): Promise<string> {
+  const options =
+    sendOrOptions != null && typeof sendOrOptions !== "function" ? sendOrOptions : undefined;
+  const send: SubmitOnlySend =
+    typeof sendOrOptions === "function"
+      ? sendOrOptions
+      : (active, text) => defaultSubmitOnlySend(active, text, options);
+
   session.setActiveTools(submitOnly.piTools, submitOnly.executors);
   try {
     return (await send(session, prompt)).text;

--- a/test/triageRun.test.ts
+++ b/test/triageRun.test.ts
@@ -95,4 +95,48 @@ describe("triage run", () => {
     expect(result.submitted).toBe(false);
     expect(result.payload).toBeNull();
   });
+
+  it("pre-submit finalize keeps commitFix and caps tool rounds", async () => {
+    const setActiveTools = vi.fn();
+    const send = vi.fn(async () => ({ text: "I am done" }));
+    providerState.createSession.mockImplementation(async () => ({
+      role: "triage",
+      send,
+      abort: vi.fn(async () => undefined),
+      setActiveTools,
+      restoreTools: vi.fn(),
+      dispose: vi.fn(),
+    }));
+
+    await runFullPrTriage({
+      cfg,
+      owner: "o",
+      repo: "r",
+      prNumber: 1,
+      headSha: "a".repeat(40),
+      checkout: checkout(),
+      inventory,
+    });
+
+    expect(send.mock.calls.length).toBeGreaterThan(1);
+    const finalizeCall = send.mock.calls.find(
+      (call) =>
+        typeof call[0] === "string" &&
+        call[0].includes("commitFix") &&
+        call[0].includes("submitTriage"),
+    );
+    expect(finalizeCall?.[1]).toMatchObject({
+      phase: "triage",
+      maxToolRounds: 32,
+    });
+
+    const finalizeToolSets = setActiveTools.mock.calls.map(
+      (call) => (call[0] as { name: string }[]).map((tool) => tool.name),
+    );
+    expect(
+      finalizeToolSets.some(
+        (names) => names.includes("commitFix") && names.includes("submitTriage"),
+      ),
+    ).toBe(true);
+  });
 });

--- a/test/triageRun.test.ts
+++ b/test/triageRun.test.ts
@@ -98,7 +98,9 @@ describe("triage run", () => {
 
   it("pre-submit finalize keeps commitFix and caps tool rounds", async () => {
     const setActiveTools = vi.fn();
-    const send = vi.fn(async () => ({ text: "I am done" }));
+    const send = vi.fn(async (_prompt: string, _opts?: Record<string, unknown>) => ({
+      text: "I am done",
+    }));
     providerState.createSession.mockImplementation(async () => ({
       role: "triage",
       send,

--- a/test/triageRun.test.ts
+++ b/test/triageRun.test.ts
@@ -119,24 +119,170 @@ describe("triage run", () => {
     });
 
     expect(send.mock.calls.length).toBeGreaterThan(1);
+    // Nudge prompt is the only send that includes the shared finalize instruction.
     const finalizeCall = send.mock.calls.find(
       (call) =>
         typeof call[0] === "string" &&
-        call[0].includes("commitFix") &&
-        call[0].includes("submitTriage"),
+        call[0].includes("You replied with text only") &&
+        call[0].includes("call commitFix") &&
+        call[0].includes("call submitTriage once"),
     );
     expect(finalizeCall?.[1]).toMatchObject({
       phase: "triage",
+      checkpointId: "triage:triage",
       maxToolRounds: 32,
     });
 
-    const finalizeToolSets = setActiveTools.mock.calls.map(
-      (call) => (call[0] as { name: string }[]).map((tool) => tool.name),
+    const finalizeToolSets = setActiveTools.mock.calls.map((call) =>
+      (call[0] as { name: string }[]).map((tool) => tool.name),
     );
     expect(
       finalizeToolSets.some(
         (names) => names.includes("commitFix") && names.includes("submitTriage"),
       ),
     ).toBe(true);
+  });
+
+  it("validation-repair can commitFix then resubmit after a failed submitTriage", async () => {
+    let submitAttempts = 0;
+    const committed: string[] = [];
+    const commit = vi.fn(async () => {
+      const sha = "c".repeat(40);
+      committed.push(sha);
+      return { sha, diff: "diff --git a/x" };
+    });
+    providerState.createSession.mockImplementation(async (params) => ({
+      role: "triage",
+      send: vi.fn(async (prompt: string) => {
+        if (typeof prompt === "string" && prompt.includes("You replied with text only")) {
+          submitAttempts += 1;
+          try {
+            await params.executors.submitTriage({
+              verdicts: [
+                {
+                  verdict: "fixed",
+                  threadRootCommentId: 1,
+                  commitSha: "d".repeat(40),
+                  evidence: "claimed fix without commit",
+                },
+              ],
+            });
+          } catch {
+            /* validation error recorded on submitState */
+          }
+          return { text: "nudge" };
+        }
+        if (typeof prompt === "string" && prompt.includes("If needed")) {
+          await params.executors.commitFix({
+            threadRootCommentId: 1,
+            files: ["src/app.ts"],
+            subject: "fix: app",
+          });
+          submitAttempts += 1;
+          await params.executors.submitTriage({
+            verdicts: [
+              {
+                verdict: "fixed",
+                threadRootCommentId: 1,
+                commitSha: "c".repeat(40),
+                evidence: "committed the fix",
+              },
+            ],
+          });
+          return { text: "repaired" };
+        }
+        return { text: "investigate" };
+      }),
+      abort: vi.fn(async () => undefined),
+      setActiveTools: vi.fn(),
+      restoreTools: vi.fn(),
+      dispose: vi.fn(),
+    }));
+
+    const result = await runFullPrTriage({
+      cfg,
+      owner: "o",
+      repo: "r",
+      prNumber: 1,
+      headSha: "a".repeat(40),
+      checkout: {
+        ...checkout(),
+        commit,
+        listCommittedShas: () => committed,
+      },
+      inventory,
+    });
+
+    expect(submitAttempts).toBeGreaterThanOrEqual(2);
+    expect(commit).toHaveBeenCalled();
+    expect(result.submitted).toBe(true);
+    expect(result.commitByThreadRootCommentId.get(1)).toBe("c".repeat(40));
+  });
+
+  it("duplicate commitFix rejects without failing the finalize run", async () => {
+    const committed: string[] = [];
+    const commit = vi.fn(async () => {
+      const sha = "c".repeat(40);
+      committed.push(sha);
+      return { sha, diff: "diff" };
+    });
+    const errors: string[] = [];
+    providerState.createSession.mockImplementation(async (params) => ({
+      role: "triage",
+      send: vi.fn(async (prompt: string) => {
+        if (typeof prompt === "string" && prompt.includes("You replied with text only")) {
+          await params.executors.commitFix({
+            threadRootCommentId: 1,
+            files: ["src/app.ts"],
+            subject: "fix: app",
+          });
+          try {
+            await params.executors.commitFix({
+              threadRootCommentId: 1,
+              files: ["src/app.ts"],
+              subject: "fix: app again",
+            });
+          } catch (e) {
+            errors.push(e instanceof Error ? e.message : String(e));
+          }
+          await params.executors.submitTriage({
+            verdicts: [
+              {
+                verdict: "fixed",
+                threadRootCommentId: 1,
+                commitSha: "c".repeat(40),
+                evidence: "one commit is enough",
+              },
+            ],
+          });
+          return { text: "done" };
+        }
+        return { text: "investigate" };
+      }),
+      abort: vi.fn(async () => undefined),
+      setActiveTools: vi.fn(),
+      restoreTools: vi.fn(),
+      dispose: vi.fn(),
+    }));
+
+    const result = await runFullPrTriage({
+      cfg,
+      owner: "o",
+      repo: "r",
+      prNumber: 1,
+      headSha: "a".repeat(40),
+      checkout: {
+        ...checkout(),
+        commit,
+        listCommittedShas: () => committed,
+      },
+      inventory,
+    });
+
+    expect(commit).toHaveBeenCalledTimes(1);
+    expect(errors.some((msg) => msg.includes("already called") || msg.includes("duplicate"))).toBe(
+      true,
+    );
+    expect(result.submitted).toBe(true);
   });
 });

--- a/test/triageRunSetup.test.ts
+++ b/test/triageRunSetup.test.ts
@@ -60,4 +60,26 @@ describe("buildSubmitOnlyTriageSessionTools", () => {
     expect(finalize.executors.submitTriage).toEqual(expect.any(Function));
     expect(finalize.executors.searchWorkspace).toBeUndefined();
   });
+
+  it("falls back to the full setup when submit or commitFix would be missing", () => {
+    const setup = buildTriageRunSetup({
+      cfg: makeTestConfig(),
+      owner: "o",
+      repo: "r",
+      prNumber: 1,
+      headSha: "a".repeat(40),
+      checkout: checkout(),
+      inventory,
+    });
+    const stripped = {
+      ...setup,
+      piTools: setup.piTools.filter((tool) => tool.name !== "submitTriage"),
+      executors: Object.fromEntries(
+        Object.entries(setup.executors).filter(([name]) => name !== "submitTriage"),
+      ),
+    };
+    const fallback = buildSubmitOnlyTriageSessionTools(stripped);
+    expect(fallback.piTools).toBe(stripped.piTools);
+    expect(fallback.executors).toBe(stripped.executors);
+  });
 });

--- a/test/triageRunSetup.test.ts
+++ b/test/triageRunSetup.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSubmitOnlyTriageSessionTools,
+  buildTriageRunSetup,
+} from "../src/agent/triage/triageRunSetup.js";
+import type { WritablePrCheckout } from "../src/prWorkspace/writablePrCheckout.js";
+import { makeTestConfig } from "./helpers/config.js";
+
+function checkout(): WritablePrCheckout {
+  return {
+    dir: "/tmp/checkout",
+    headRef: "main",
+    baseSha: "a".repeat(40),
+    commit: async () => ({ sha: "b".repeat(40), diff: "" }),
+    push: async () => undefined,
+    listCommittedShas: () => [],
+    listCommittedDetails: () => [],
+  };
+}
+
+const inventory = [
+  {
+    rootCommentId: 1,
+    lens: "review" as const,
+    path: "src/app.ts",
+    line: 1,
+    severity: "P2" as const,
+    titleSnippet: "P2 · Bug",
+    humanReplies: [],
+    threadUrl: "https://github.test/thread",
+  },
+];
+
+describe("buildSubmitOnlyTriageSessionTools", () => {
+  it("keeps commitFix and edit tools so pending autofixes can still be committed", () => {
+    const setup = buildTriageRunSetup({
+      cfg: makeTestConfig(),
+      owner: "o",
+      repo: "r",
+      prNumber: 1,
+      headSha: "a".repeat(40),
+      checkout: checkout(),
+      inventory,
+    });
+
+    const finalize = buildSubmitOnlyTriageSessionTools(setup);
+    const names = finalize.piTools.map((tool) => tool.name).sort();
+
+    expect(names).toEqual(
+      [
+        "commitFix",
+        "createWorkspaceFile",
+        "editWorkspaceFile",
+        "getWorkspaceDiff",
+        "readWorkspaceFile",
+        "submitTriage",
+      ].sort(),
+    );
+    expect(finalize.executors.commitFix).toEqual(expect.any(Function));
+    expect(finalize.executors.submitTriage).toEqual(expect.any(Function));
+    expect(finalize.executors.searchWorkspace).toBeUndefined();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Keep `commitFix` and workspace edit tools active during triage pre-submit / validation repair so pending edits can still be committed
- Cap finalize sends with `MAX_TOOL_ROUNDS_TRIAGE` so retaining edit tools cannot unbounded-loop
- Cover the finalize toolset and round cap in unit tests

Root cause of PR 408 triage skips: investigation applied edits, then submit-only finalize stripped `commitFix`, forcing `skipped` because `fixed` requires a real commit SHA.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bbd08854-58d4-49bb-9fc8-026375b554ca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bbd08854-58d4-49bb-9fc8-026375b554ca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

___

## PR Agent Description

### PR Type

Enhancement, Tests

### Description

- Finalize rounds now keep workspace edit/commitFix tools so pending autofixes can be committed before submitTriage
- Update nudge and validation-repair prompts to instruct commitFix before submitting payload
- Send finalize rounds with phase/checkpoint metadata and MAX_TOOL_ROUNDS_TRIAGE cap
- Add unit tests for finalize tool filtering and tool-round cap

### Changes Diagram

```mermaid
flowchart LR
  A["Triage finalize round"] --> B["Filtered tools incl. commitFix"]
  B --> C["commitFix pending edits"]
  C --> D["submitTriage payload"]
```