### PR TITLE
Add seven load-bearing .pr-agent policy rules

### DIFF
--- a/.pr-agent/agent-instruction-trust.mdc
+++ b/.pr-agent/agent-instruction-trust.mdc
@@ -1,0 +1,9 @@
+---
+globs:
+  - "src/review/agentInstructionFiles.ts"
+  - "src/agentWork/executors/reviewExecutor.ts"
+  - "src/review/prompts/**"
+  - "src/settings/reviewConstants.ts"
+---
+
+Load only root `AGENTS.md` / `CLAUDE.md` / `GEMINI.md` via `loadAgentInstructionFiles` on orchestrated review runs (ADR 0027, `AGENT_INSTRUCTION_FILENAMES`). Same-repo head → Trusted/binding; fork head → Untrusted context only (fence forged Trusted headers). Do not expand `@include`. Do not load these files for ask, describe, triage, or verification. Never treat author-writable fork instruction bodies as binding severity rules.

--- a/.pr-agent/ask-safety.mdc
+++ b/.pr-agent/ask-safety.mdc
@@ -1,0 +1,8 @@
+---
+globs:
+  - "src/agent/ask/**"
+  - "src/agentWork/executors/askExecutor.ts"
+  - "src/agentWork/intake/askIntake.ts"
+---
+
+Ask is explain-only: do not change finding severity, dismiss findings, or mutate review summaries (ADR 0008/0010). Keep ask defenses always on: `bot_meta` short-circuit without LLM; untrusted framing for question/anchors; `buildAskGithubTools` force owner/repo/PR and sensitive-path gate; `sanitizeAskAnswerText` / `redactOutboundSecrets` before post. Do not widen ask tools to unscoped GitHub or skip outbound redaction.

--- a/.pr-agent/ci-summary-ownership.mdc
+++ b/.pr-agent/ci-summary-ownership.mdc
@@ -1,0 +1,8 @@
+---
+globs:
+  - "src/review/ci/**"
+  - "src/agentWork/executors/ciRefreshExecutor.ts"
+  - "src/settings/reviewConstants.ts"
+---
+
+CI summary split (ADR 0026): server owns Checks/status facts, wait/poll, Actions log condense+redact, schema validation, and HTML table cell rendering. The model only fills structured `headline` / `reason` / `fixHint` fields (`authorCiSummary.ts`). Server must overwrite model-drifted `status` and check names from GitHub facts. Ack stays non-LLM. CI refresh edits the CI cell only — never a full re-review. Do not let the model emit table markup.

--- a/.pr-agent/description-body-merge.mdc
+++ b/.pr-agent/description-body-merge.mdc
@@ -1,0 +1,7 @@
+---
+globs:
+  - "src/agent/description/**"
+  - "src/agentWork/executors/descriptionExecutor.ts"
+---
+
+Description publish must merge only the `## PR Agent Description` agent block via `mergeDescriptionIntoPrBody` (`descriptionBodyMerge.ts`); never overwrite user-authored body above the header. Map mode is server-owned (`descriptionMapMode.ts`): `omit` strips the map; `read_first` caps at five files — enforce on `submitDescription`, do not trust the model alone. Title rewrite stays behind `FEATURE_TITLE_REWRITE`.

--- a/.pr-agent/operation-intent.mdc
+++ b/.pr-agent/operation-intent.mdc
@@ -1,0 +1,8 @@
+---
+globs:
+  - "src/agentWork/**"
+  - "src/review/publish/**"
+  - "src/agent/**/publish*.ts"
+---
+
+Persist an operation intent via `withOperationIntent` (`src/agentWork/withOperationIntent.ts`) before PR-surface GitHub mutations (inline batches, summary, ask replies, verification stubs). `publish_records` remain authoritative for what was posted. Resume snapshots may resume computation only — they must not replay, advance, or roll back publish state (ADR 0031). Do not dual-write mutations that bypass the intent/reconcile path on retries.

--- a/.pr-agent/pi-session-seam.mdc
+++ b/.pr-agent/pi-session-seam.mdc
@@ -1,0 +1,10 @@
+---
+globs:
+  - "src/agent/**"
+  - "src/review/orchestrator/**"
+  - "src/review/ci/**"
+  - "test/webImportGraph.test.ts"
+  - "test/createPiSession.test.ts"
+---
+
+Feature harnesses must call `createFeaturePiSession` → `createPiSession` (`src/agent/runtime/createFeatureSession.ts`, `piSession.ts`). Do not import `piSessionImpl.ts` or construct raw Pi SDK sessions from feature modules. Keep built-in shell/write/edit/filesystem tools disabled (`ToolPolicy.allowBuiltin: false` in `src/agent/runtime/types.ts`). Web import graph must stay free of Pi/models (`test/webImportGraph.test.ts`, ADR 0031).

--- a/.pr-agent/workspace-evidence.mdc
+++ b/.pr-agent/workspace-evidence.mdc
@@ -1,0 +1,9 @@
+---
+globs:
+  - "src/review/**"
+  - "src/prWorkspace/**"
+  - "src/codeIndex/**"
+  - "src/agent/tools/**"
+---
+
+Local PR workspace at the reviewed `headSha` is the sole publishable code authority (ADR 0032). Findings that cite a path/line range must pass `assertFindingsHaveEvidence` against the work-item `EvidenceLedger` (`src/review/findings/evidenceValidator.ts`) before inline or summary publish. Code index / FTS / symbol-index hits are navigation hints only — never publish authority without a following workspace read. Sparse checkout coverage must not be treated as full-repo certainty.


### PR DESCRIPTION
## Summary

- Add Pi session seam, workspace evidence, and operation-intent policy rules under `.pr-agent/`
- Add ask-safety, CI summary ownership, and description body-merge rules with path globs
- Add agent-instruction trust-boundary rule for fork vs same-repo heads (ADR 0027)

___

## PR Agent Description

### PR Type

Documentation

### Description

- Add seven .pr-agent/*.mdc repo-policy rule files
- Each rule glob-scoped to review, ask, description, CI, runtime
- Codify ADR 0026-0032: trust, evidence, session seam, ownership
- Docs only; no code or test changes

### Review map

1. <a href="https://github.com/prathamdby/pr-agent/pull/415/files#diff-9b62fce92b5fff1f26fa71c19a5e947e9a1fcf972f6edd66cc9cfaf685526b7e"><code>.pr-agent/agent-instruction-trust.mdc</code></a>: Trust boundary for root AGENTS.md handling (fork vs same-repo)
2. <a href="https://github.com/prathamdby/pr-agent/pull/415/files#diff-4a745f9c25856ebf379437c00aa2cdfd43cb50c5d93db6956223863625bfd0f2"><code>.pr-agent/ask-safety.mdc</code></a>: Safety invariants for the ask surface and outbound redaction
3. <a href="https://github.com/prathamdby/pr-agent/pull/415/files#diff-6dc2baaf65296277017ca6b34aa267ef53809ea5a6f88a9c54eac802edf195ec"><code>.pr-agent/description-body-merge.mdc</code></a>: Enforces agent-block-only merge and server-owned map mode
4. <a href="https://github.com/prathamdby/pr-agent/pull/415/files#diff-6993565fa4396b9999c0c206c19de0d9a9841e6091cf0bfeec78662ec033b3d5"><code>.pr-agent/pi-session-seam.mdc</code></a>: Session/tool-policy seam that feature code must not bypass
5. <a href="https://github.com/prathamdby/pr-agent/pull/415/files#diff-11dc7bbe3d79302ed8a20a748cc20d7d6f263ed50a3338b9623c9ddb14e04fac"><code>.pr-agent/workspace-evidence.mdc</code></a>: Grounds publishable findings in headSha workspace evidence