### PR TITLE
Resolve current progress comments before publishing

### DIFF
--- a/src/agentWork/executors/reviewExecutor.ts
+++ b/src/agentWork/executors/reviewExecutor.ts
@@ -512,7 +512,7 @@ async function runFullReviewAgainstRepositoryView(args: {
     shouldLinkToSummary,
     storedInlineFingerprints,
     resumedPlacements,
-    summaryCommentGithubId: summaryCommentIdHint,
+    progressCommentGithubId: progressCommentIdHint,
   } = publishContext;
 
   const priorInlineFeedbackResult = await priorInlineFeedback;
@@ -627,7 +627,7 @@ async function runFullReviewAgainstRepositoryView(args: {
     workspace: repositoryView.workspace,
     codeIndexSnapshotId: codeIndexStatus.available ? codeIndexStatus.snapshotId : undefined,
     shouldLinkToSummary,
-    summaryCommentIdHint,
+    progressCommentIdHint,
     hasDescriptionReviewMap: prBodyHasDescriptionReviewMap(
       (pullRequest as { body?: string | null } | undefined)?.body,
     ),

--- a/src/agentWork/publishRecordRepository.ts
+++ b/src/agentWork/publishRecordRepository.ts
@@ -499,7 +499,7 @@ export type ReviewExecutorPublishContext = {
   shouldLinkToSummary: boolean;
   storedInlineFingerprints: string[];
   resumedPlacements: AcceptedPlacement[];
-  summaryCommentGithubId: number | null;
+  progressCommentGithubId: number | null;
 };
 
 export async function loadReviewExecutorPublishContext(
@@ -514,7 +514,7 @@ export async function loadReviewExecutorPublishContext(
       | null;
     prior_summary_exists: boolean;
     fingerprint_details: { detail: Record<string, unknown> }[] | null;
-    latest_summary_github_id: string | null;
+    latest_progress_comment_github_id: string | null;
   }>(
     pool,
     `SELECT
@@ -560,21 +560,23 @@ export async function loadReviewExecutorPublishContext(
             AND github_id IS NOT NULL
           ORDER BY updated_at DESC
           LIMIT 1
-       ) AS latest_summary_github_id`,
+       ) AS latest_progress_comment_github_id`,
     [resourceKey, reviewLens, workItemId],
   );
   const currentPublish = row?.current_publish ?? [];
   const shouldLinkToSummary = row?.prior_summary_exists ?? false;
-  const summaryCommentGithubId =
-    row?.latest_summary_github_id != null ? Number(row.latest_summary_github_id) : null;
+  const progressCommentGithubId =
+    row?.latest_progress_comment_github_id != null
+      ? Number(row.latest_progress_comment_github_id)
+      : null;
   return {
     publishState: parseReviewPublishStateRows(currentPublish, workItemId),
     shouldLinkToSummary,
     storedInlineFingerprints: mergeStoredInlineFingerprints(row?.fingerprint_details ?? []),
     resumedPlacements: parseResumedPlacements(currentPublish, workItemId),
-    summaryCommentGithubId:
-      summaryCommentGithubId != null && Number.isFinite(summaryCommentGithubId)
-        ? summaryCommentGithubId
+    progressCommentGithubId:
+      progressCommentGithubId != null && Number.isFinite(progressCommentGithubId)
+        ? progressCommentGithubId
         : null,
   };
 }

--- a/src/review/orchestrator/orchestratorRun.ts
+++ b/src/review/orchestrator/orchestratorRun.ts
@@ -1,5 +1,6 @@
 import type { AssistantMessage, Tool as PiTool } from "@earendil-works/pi-ai";
 import { reviewCheckDetailsUrl } from "../../agentWork/reviewCheckRun.js";
+import { getSummaryCommentGithubId } from "../../agentWork/publishRecordRepository.js";
 import type { AgentRunnerToolExecutor } from "../../agent/providers/interface.js";
 import { createFeaturePiSession } from "../../agent/runtime/createFeatureSession.js";
 import { classifyFallbackEligibility } from "../../agent/runtime/fallbackClassification.js";
@@ -249,6 +250,17 @@ export async function runOrchestratedPrReview(
   const briefTool = buildSpecialistBriefTool();
   const state = initialState();
   const agentEvents = resolveAgentEventsContext(params.cfg, params.durability);
+  const progressCommentCoordination = params.recordPublishStep?.summaryCommentCoordination;
+  const resolveProgressCommentUrl = async (): Promise<string | undefined> => {
+    const commentId = progressCommentCoordination
+      ? await getSummaryCommentGithubId(
+          progressCommentCoordination.pool,
+          progressCommentCoordination.resourceKey,
+          reviewMode,
+        )
+      : params.progressCommentIdHint;
+    return reviewCheckDetailsUrl(params.owner, params.repo, params.prNumber, commentId);
+  };
   const publishThread = buildPublishThreadTool({
     ctx: {
       owner: params.owner,
@@ -258,12 +270,7 @@ export async function runOrchestratedPrReview(
       hasDescriptionReviewMap: params.hasDescriptionReviewMap ?? false,
     },
     workItemId: params.workItemId,
-    progressCommentUrl: reviewCheckDetailsUrl(
-      params.owner,
-      params.repo,
-      params.prNumber,
-      params.summaryCommentIdHint,
-    ),
+    resolveProgressCommentUrl,
     getToken: setup.getToken,
     getTokenExpiresAtTs: setup.getTokenExpiresAtTs,
     refreshLiveAuth: setup.refreshLiveAuth,
@@ -309,7 +316,7 @@ export async function runOrchestratedPrReview(
     mode: reviewMode,
     cachedDiffIndex: setup.cachedDiffIndex,
     shouldLinkToSummary: params.shouldLinkToSummary,
-    summaryCommentIdHint: params.summaryCommentIdHint,
+    progressCommentIdHint: params.progressCommentIdHint,
     recordPublishStep: params.recordPublishStep,
     shouldAbortPublish: params.shouldAbortPublish,
     publishAbortState: params.publishAbortState,
@@ -631,7 +638,7 @@ export async function runOrchestratedPrReview(
       getToken: setup.getToken,
       getTokenExpiresAtTs: setup.getTokenExpiresAtTs,
       refreshLiveAuth: setup.refreshLiveAuth,
-      hintCommentId: params.summaryCommentIdHint,
+      hintCommentId: params.progressCommentIdHint,
     });
   };
 
@@ -676,7 +683,7 @@ export async function runOrchestratedPrReview(
         getToken: setup.getToken,
         getTokenExpiresAtTs: setup.getTokenExpiresAtTs,
         refreshLiveAuth: setup.refreshLiveAuth,
-        hintCommentId: params.summaryCommentIdHint,
+        hintCommentId: params.progressCommentIdHint,
       });
       return;
     }
@@ -700,7 +707,7 @@ export async function runOrchestratedPrReview(
       getToken: setup.getToken,
       getTokenExpiresAtTs: setup.getTokenExpiresAtTs,
       refreshLiveAuth: setup.refreshLiveAuth,
-      hintCommentId: params.summaryCommentIdHint,
+      hintCommentId: params.progressCommentIdHint,
     });
   };
 
@@ -814,7 +821,7 @@ export async function runOrchestratedPrReview(
       mode: reviewMode,
       cachedDiffIndex: setup.cachedDiffIndex,
       shouldLinkToSummary: params.shouldLinkToSummary,
-      summaryCommentIdHint: params.summaryCommentIdHint,
+      progressCommentIdHint: params.progressCommentIdHint,
       recordPublishStep: params.recordPublishStep,
       coverage: coverage(state),
       shouldAbortPublish: params.shouldAbortPublish,

--- a/src/review/orchestrator/orchestratorRun.ts
+++ b/src/review/orchestrator/orchestratorRun.ts
@@ -252,13 +252,27 @@ export async function runOrchestratedPrReview(
   const agentEvents = resolveAgentEventsContext(params.cfg, params.durability);
   const progressCommentCoordination = params.recordPublishStep?.summaryCommentCoordination;
   const resolveProgressCommentUrl = async (): Promise<string | undefined> => {
-    const commentId = progressCommentCoordination
-      ? await getSummaryCommentGithubId(
+    let commentId: number | null | undefined;
+    if (progressCommentCoordination) {
+      try {
+        commentId = await getSummaryCommentGithubId(
           progressCommentCoordination.pool,
           progressCommentCoordination.resourceKey,
           reviewMode,
-        )
-      : params.progressCommentIdHint;
+        );
+        if (commentId == null) {
+          commentId = params.progressCommentIdHint;
+        }
+      } catch (error) {
+        const appError = toAppError(error, {
+          code: "review.progress_comment_lookup_failed",
+        });
+        logWarn("review_progress_comment_lookup_failed", errorLogFields(appError));
+        commentId = params.progressCommentIdHint;
+      }
+    } else {
+      commentId = params.progressCommentIdHint;
+    }
     return reviewCheckDetailsUrl(params.owner, params.repo, params.prNumber, commentId);
   };
   const publishThread = buildPublishThreadTool({

--- a/src/review/publish/publishFindingBatch.ts
+++ b/src/review/publish/publishFindingBatch.ts
@@ -75,8 +75,8 @@ export type FindingBatchContext = {
   readonly ctx: ReviewPublishContext;
   readonly source: FindingSource;
   readonly workItemId?: string;
-  /** URL of the review progress comment (progress stub / final summary). Required to publish. */
-  readonly progressCommentUrl?: string;
+  /** Resolves the current review progress comment (progress stub / final summary). */
+  readonly resolveProgressCommentUrl: () => Promise<string | undefined>;
   readonly getToken: () => string;
   readonly getTokenExpiresAtTs?: () => number | undefined;
   readonly refreshLiveAuth?: () => Promise<void>;
@@ -274,7 +274,7 @@ export async function publishFindingBatch(
     };
   }
 
-  const progressCommentUrl = context.progressCommentUrl?.trim();
+  const progressCommentUrl = (await context.resolveProgressCommentUrl())?.trim();
   if (!progressCommentUrl) {
     throw new AppError({
       code: "review.progress_comment_url_required",

--- a/src/review/publish/publishReview.ts
+++ b/src/review/publish/publishReview.ts
@@ -31,7 +31,7 @@ export async function publishReview(
     publishState: SubmitReviewState;
     cachedDiffIndex?: CachedPrDiffIndex;
     shouldLinkToSummary?: boolean;
-    summaryCommentIdHint?: number | null;
+    progressCommentIdHint?: number | null;
     staleReview?: boolean;
     recordPublishStep?: RecordPublishStepWithCoordination;
     storedInlineFingerprints?: readonly string[];
@@ -64,12 +64,13 @@ export async function publishReview(
           resourceKey: params.recordPublishStep.summaryCommentCoordination.resourceKey,
         }
       : undefined,
-    progressCommentUrl: reviewCheckDetailsUrl(
-      params.owner,
-      params.repo,
-      params.prNumber,
-      params.summaryCommentIdHint,
-    ),
+    resolveProgressCommentUrl: async () =>
+      reviewCheckDetailsUrl(
+        params.owner,
+        params.repo,
+        params.prNumber,
+        params.progressCommentIdHint,
+      ),
     getToken,
     getTokenExpiresAtTs,
     cachedDiffIndex: params.cachedDiffIndex ?? createCachedPrDiffIndex(),
@@ -97,7 +98,7 @@ export async function publishReview(
     mode: params.mode,
     cachedDiffIndex: params.cachedDiffIndex,
     shouldLinkToSummary: params.shouldLinkToSummary,
-    summaryCommentIdHint: params.summaryCommentIdHint,
+    progressCommentIdHint: params.progressCommentIdHint,
     staleReview: params.staleReview,
     recordPublishStep: params.recordPublishStep,
     ciAuthor: params.ciSummaryAuthor,

--- a/src/review/publish/publishSummaryOnly.ts
+++ b/src/review/publish/publishSummaryOnly.ts
@@ -424,7 +424,7 @@ export async function publishReviewSummaryOnly(params: {
   readonly mode?: AnyReviewLens;
   readonly cachedDiffIndex?: CachedPrDiffIndex;
   readonly shouldLinkToSummary?: boolean;
-  readonly summaryCommentIdHint?: number | null;
+  readonly progressCommentIdHint?: number | null;
   readonly staleReview?: boolean;
   readonly recordPublishStep?: RecordPublishStepWithCoordination;
   readonly ciAuthor?: CiSummaryAuthor;
@@ -556,7 +556,7 @@ export async function publishReviewSummaryOnly(params: {
       repo,
       prNumber,
       summarySentinel,
-      params.summaryCommentIdHint,
+      params.progressCommentIdHint,
       summaryTokenExpiresAtTs,
     );
     knownSummaryCommentRef = resolvedSummary
@@ -586,7 +586,7 @@ export async function publishReviewSummaryOnly(params: {
           body: summaryBody,
           sentinel: summarySentinel,
           expiresAtTs: summaryTokenExpiresAtTs,
-          hintCommentId: params.summaryCommentIdHint ?? knownSummaryCommentRef?.id,
+          hintCommentId: params.progressCommentIdHint ?? knownSummaryCommentRef?.id,
           progressRevision: 7,
         })
       : upsertReviewSummaryComment(

--- a/src/review/publish/submitReviewTool.ts
+++ b/src/review/publish/submitReviewTool.ts
@@ -70,7 +70,7 @@ export function buildSubmitReviewTool(params: {
   cachedDiffIndex?: CachedPrDiffIndex;
   canEnforceDiffCacheBeforeSubmit?: () => boolean;
   shouldLinkToSummary?: boolean;
-  summaryCommentIdHint?: number | null;
+  progressCommentIdHint?: number | null;
   recordPublishStep?: (
     step: "inline_review" | "summary_comment" | "labels",
     detail?: { githubId?: string | number; meta?: Record<string, unknown> },
@@ -258,7 +258,7 @@ export function buildSubmitReviewTool(params: {
         publishState: params.state,
         cachedDiffIndex: params.cachedDiffIndex,
         shouldLinkToSummary: params.shouldLinkToSummary,
-        summaryCommentIdHint: params.summaryCommentIdHint,
+        progressCommentIdHint: params.progressCommentIdHint,
         recordPublishStep: params.recordPublishStep,
         storedInlineFingerprints: params.storedInlineFingerprints,
         workItemId: params.workItemId,

--- a/src/review/run/reviewRunTypes.ts
+++ b/src/review/run/reviewRunTypes.ts
@@ -23,7 +23,7 @@ export type ReviewRunParams = {
   readonly cwd?: string;
   readonly workspace: LocalPrWorkspace;
   readonly shouldLinkToSummary?: boolean;
-  readonly summaryCommentIdHint?: number | null;
+  readonly progressCommentIdHint?: number | null;
   readonly hasDescriptionReviewMap?: boolean;
   readonly initialPublishState?: {
     readonly published?: boolean;

--- a/test/agentWorkRepository.test.ts
+++ b/test/agentWorkRepository.test.ts
@@ -80,7 +80,7 @@ describe("loadReviewExecutorPublishContext", () => {
           },
         },
       ],
-      latest_summary_github_id: "1001",
+      latest_progress_comment_github_id: "1001",
     });
 
     await expect(
@@ -102,7 +102,7 @@ describe("loadReviewExecutorPublishContext", () => {
           reviewId: 42,
         },
       ],
-      summaryCommentGithubId: 1001,
+      progressCommentGithubId: 1001,
     });
 
     expect(queryOne).toHaveBeenCalledTimes(1);
@@ -115,14 +115,14 @@ describe("loadReviewExecutorPublishContext", () => {
       current_publish: [],
       prior_summary_exists: false,
       fingerprint_details: [],
-      latest_summary_github_id: "1001",
+      latest_progress_comment_github_id: "1001",
     });
 
     await expect(
       loadReviewExecutorPublishContext(pool, "wi-2", "o/r#1", "review-security"),
     ).resolves.toMatchObject({
       shouldLinkToSummary: false,
-      summaryCommentGithubId: 1001,
+      progressCommentGithubId: 1001,
     });
   });
 });

--- a/test/helpers/publishReviewTestSetup.ts
+++ b/test/helpers/publishReviewTestSetup.ts
@@ -26,7 +26,7 @@ export const publishReviewTestBaseParams = {
   prNumber: 1,
   headSha: "sha",
   hasDescriptionReviewMap: false,
-  summaryCommentIdHint: 99,
+  progressCommentIdHint: 99,
   cfg: {
     piModel: "gpt-4o-mini",
     features: { ...makeTestConfig().features, reviewLabels: "off" as const },

--- a/test/orchestratorRun.test.ts
+++ b/test/orchestratorRun.test.ts
@@ -64,7 +64,14 @@ const testState = vi.hoisted(() => ({
   restrictionFailureTool: null as string | null,
   publishedBatchCount: 0,
   synthesisPublishesSummary: true,
+  progressUrlResolvers: [] as Array<() => Promise<string | undefined>>,
 }));
+
+const publishRecordMocks = vi.hoisted(() => ({
+  getSummaryCommentGithubId: vi.fn<() => Promise<number | null>>(async () => 99),
+}));
+
+vi.mock("../src/agentWork/publishRecordRepository.js", () => publishRecordMocks);
 
 vi.mock("../src/review/run/reviewRunSetup.js", () => ({
   buildReviewRunSetup: vi.fn(() => ({
@@ -113,49 +120,52 @@ vi.mock("../src/review/orchestrator/specialistRun.js", () => ({
 }));
 
 vi.mock("../src/review/orchestrator/publishThreadTool.js", () => ({
-  buildPublishThreadTool: vi.fn(() => {
-    testState.ledger = createFindingLedger();
-    return {
-      piTool: { name: "publish_thread", description: "publish", parameters: {} },
-      executor: vi.fn(async (args: { findings?: readonly ReviewFinding[] }) => {
-        if (!testState.activeSource) throw new Error("missing active source");
-        testState.publishOrder.push(testState.activeSource);
-        testState.publishedBatchCount += 1;
-        const ledger = testState.ledger ?? createFindingLedger();
-        const accepted = (args.findings ?? []).map((item, index) => ({
-          kind: "posted" as const,
-          source: testState.activeSource ?? "correctness",
-          placement: { finding: item, inlineLine: item.startLine, inlinePosted: true },
-          canonicalFingerprint: `${testState.activeSource}-${index}-${item.file}`,
-          reviewId: testState.publishOrder.length,
-        }));
-        testState.ledger = {
-          ...ledger,
-          accepted: [...ledger.accepted, ...accepted],
-          postedInlineCount: ledger.postedInlineCount + accepted.length,
-          threadCallCount: ledger.threadCallCount + 1,
-        };
-        return {
-          kind: "empty",
-          delta: {
-            accepted: [],
-            suppressionFingerprints: [],
-            inlineReviewIds: [],
-            postedInlineCount: 0,
-            threadCallCount: 1,
-            threadBudgetExhausted: false,
-          },
-          publishedThreadOverlapHints: [],
-        };
-      }),
-      setSource: (source: SpecialistId) => {
-        testState.activeSource = source;
-      },
-      getLedger: () => testState.ledger ?? createFindingLedger(),
-      getPublishedBatchCount: () => testState.publishedBatchCount,
-      getStopReason: () => null,
-    };
-  }),
+  buildPublishThreadTool: vi.fn(
+    (params: { resolveProgressCommentUrl: () => Promise<string | undefined> }) => {
+      testState.progressUrlResolvers.push(params.resolveProgressCommentUrl);
+      testState.ledger = createFindingLedger();
+      return {
+        piTool: { name: "publish_thread", description: "publish", parameters: {} },
+        executor: vi.fn(async (args: { findings?: readonly ReviewFinding[] }) => {
+          if (!testState.activeSource) throw new Error("missing active source");
+          testState.publishOrder.push(testState.activeSource);
+          testState.publishedBatchCount += 1;
+          const ledger = testState.ledger ?? createFindingLedger();
+          const accepted = (args.findings ?? []).map((item, index) => ({
+            kind: "posted" as const,
+            source: testState.activeSource ?? "correctness",
+            placement: { finding: item, inlineLine: item.startLine, inlinePosted: true },
+            canonicalFingerprint: `${testState.activeSource}-${index}-${item.file}`,
+            reviewId: testState.publishOrder.length,
+          }));
+          testState.ledger = {
+            ...ledger,
+            accepted: [...ledger.accepted, ...accepted],
+            postedInlineCount: ledger.postedInlineCount + accepted.length,
+            threadCallCount: ledger.threadCallCount + 1,
+          };
+          return {
+            kind: "empty",
+            delta: {
+              accepted: [],
+              suppressionFingerprints: [],
+              inlineReviewIds: [],
+              postedInlineCount: 0,
+              threadCallCount: 1,
+              threadBudgetExhausted: false,
+            },
+            publishedThreadOverlapHints: [],
+          };
+        }),
+        setSource: (source: SpecialistId) => {
+          testState.activeSource = source;
+        },
+        getLedger: () => testState.ledger ?? createFindingLedger(),
+        getPublishedBatchCount: () => testState.publishedBatchCount,
+        getStopReason: () => null,
+      };
+    },
+  ),
 }));
 
 vi.mock("../src/review/orchestrator/publishSummaryTool.js", () => ({
@@ -381,6 +391,9 @@ describe("runOrchestratedPrReview", () => {
     testState.sendDelay = null;
     testState.restrictionFailureTool = null;
     testState.publishedBatchCount = 0;
+    testState.progressUrlResolvers.length = 0;
+    publishRecordMocks.getSummaryCommentGithubId.mockReset();
+    publishRecordMocks.getSummaryCommentGithubId.mockResolvedValue(99);
     testState.synthesisPublishesSummary = true;
     for (const specialist of ["correctness", "security", "quality", "tests"] as const) {
       testState.outcomes.set(specialist, deferred());
@@ -861,5 +874,25 @@ describe("runOrchestratedPrReview", () => {
 
     // +1 refresh for the worker-start progress tick before recon.
     expect(testState.refreshes).toBe(11);
+  });
+
+  it("resolves the current progress comment after orchestration starts", async () => {
+    publishRecordMocks.getSummaryCommentGithubId.mockResolvedValue(123);
+    const recordPublishStep = coordinatedRecordPublishStep();
+    const run = runOrchestratedPrReview({
+      ...params(),
+      progressCommentIdHint: null,
+      recordPublishStep,
+    });
+
+    await vi.waitFor(() => expect(testState.progressUrlResolvers).toHaveLength(1));
+    const resolveUrl = testState.progressUrlResolvers[0];
+    expect(resolveUrl).toBeDefined();
+    await expect(resolveUrl?.()).resolves.toBe("https://github.com/o/r/pull/1#issuecomment-123");
+
+    for (const specialist of ["correctness", "security", "quality", "tests"] as const) {
+      testState.outcomes.get(specialist)?.resolve(empty(specialist));
+    }
+    await run;
   });
 });

--- a/test/orchestratorRun.test.ts
+++ b/test/orchestratorRun.test.ts
@@ -895,4 +895,101 @@ describe("runOrchestratedPrReview", () => {
     }
     await run;
   });
+
+  it("re-reads the progress comment on every batch instead of memoizing the first", async () => {
+    publishRecordMocks.getSummaryCommentGithubId
+      .mockResolvedValueOnce(99)
+      .mockResolvedValueOnce(123);
+    const recordPublishStep = coordinatedRecordPublishStep();
+    const run = runOrchestratedPrReview({
+      ...params(),
+      progressCommentIdHint: null,
+      recordPublishStep,
+    });
+
+    await vi.waitFor(() => expect(testState.progressUrlResolvers).toHaveLength(1));
+    const resolveUrl = testState.progressUrlResolvers[0];
+    await expect(resolveUrl?.()).resolves.toBe("https://github.com/o/r/pull/1#issuecomment-99");
+    await expect(resolveUrl?.()).resolves.toBe("https://github.com/o/r/pull/1#issuecomment-123");
+    expect(publishRecordMocks.getSummaryCommentGithubId).toHaveBeenCalledTimes(2);
+
+    for (const specialist of ["correctness", "security", "quality", "tests"] as const) {
+      testState.outcomes.get(specialist)?.resolve(empty(specialist));
+    }
+    await run;
+  });
+
+  it("falls back to the progress comment hint when the live read fails", async () => {
+    publishRecordMocks.getSummaryCommentGithubId.mockRejectedValueOnce(new Error("db down"));
+    const recordPublishStep = coordinatedRecordPublishStep();
+    const run = runOrchestratedPrReview({
+      ...params(),
+      progressCommentIdHint: 77,
+      recordPublishStep,
+    });
+
+    await vi.waitFor(() => expect(testState.progressUrlResolvers).toHaveLength(1));
+    const resolveUrl = testState.progressUrlResolvers[0];
+    await expect(resolveUrl?.()).resolves.toBe("https://github.com/o/r/pull/1#issuecomment-77");
+
+    for (const specialist of ["correctness", "security", "quality", "tests"] as const) {
+      testState.outcomes.get(specialist)?.resolve(empty(specialist));
+    }
+    await run;
+  });
+
+  it("falls back to the progress comment hint when the live read finds no record", async () => {
+    publishRecordMocks.getSummaryCommentGithubId.mockResolvedValue(null);
+    const recordPublishStep = coordinatedRecordPublishStep();
+    const run = runOrchestratedPrReview({
+      ...params(),
+      progressCommentIdHint: 77,
+      recordPublishStep,
+    });
+
+    await vi.waitFor(() => expect(testState.progressUrlResolvers).toHaveLength(1));
+    const resolveUrl = testState.progressUrlResolvers[0];
+    await expect(resolveUrl?.()).resolves.toBe("https://github.com/o/r/pull/1#issuecomment-77");
+
+    for (const specialist of ["correctness", "security", "quality", "tests"] as const) {
+      testState.outcomes.get(specialist)?.resolve(empty(specialist));
+    }
+    await run;
+  });
+
+  it("resolves no progress comment url when neither the live read nor the hint has one", async () => {
+    publishRecordMocks.getSummaryCommentGithubId.mockResolvedValue(null);
+    const recordPublishStep = coordinatedRecordPublishStep();
+    const run = runOrchestratedPrReview({
+      ...params(),
+      progressCommentIdHint: null,
+      recordPublishStep,
+    });
+
+    await vi.waitFor(() => expect(testState.progressUrlResolvers).toHaveLength(1));
+    const resolveUrl = testState.progressUrlResolvers[0];
+    await expect(resolveUrl?.()).resolves.toBeUndefined();
+
+    for (const specialist of ["correctness", "security", "quality", "tests"] as const) {
+      testState.outcomes.get(specialist)?.resolve(empty(specialist));
+    }
+    await run;
+  });
+
+  it("uses the progress comment hint without a database read when coordination is absent", async () => {
+    const run = runOrchestratedPrReview({
+      ...params(),
+      progressCommentIdHint: 99,
+    });
+
+    await vi.waitFor(() => expect(testState.progressUrlResolvers).toHaveLength(1));
+    const resolveUrl = testState.progressUrlResolvers[0];
+    await expect(resolveUrl?.()).resolves.toBe("https://github.com/o/r/pull/1#issuecomment-99");
+    expect(publishRecordMocks.getSummaryCommentGithubId).not.toHaveBeenCalled();
+
+    for (const specialist of ["correctness", "security", "quality", "tests"] as const) {
+      testState.outcomes.get(specialist)?.resolve(empty(specialist));
+    }
+    await run;
+  });
 });

--- a/test/publishFindingBatch.test.ts
+++ b/test/publishFindingBatch.test.ts
@@ -100,7 +100,7 @@ function batchContext(
     },
     source: "correctness",
     workItemId: "wi-1",
-    progressCommentUrl: PROGRESS_COMMENT_URL,
+    resolveProgressCommentUrl: async () => PROGRESS_COMMENT_URL,
     getToken: () => "token",
     cachedDiffIndex: cachedDiffForLines("src/a.ts", [10]),
     recordPublishStep,
@@ -225,10 +225,24 @@ describe("publishFindingBatch", () => {
     await expect(
       publishFindingBatch(
         [finding],
-        batchContext(createFindingLedger(), undefined, { progressCommentUrl: undefined }),
+        batchContext(createFindingLedger(), undefined, {
+          resolveProgressCommentUrl: async () => undefined,
+        }),
       ),
     ).rejects.toThrow(/progress comment/i);
     expect(createPullRequestReviewWithComments).not.toHaveBeenCalled();
+  });
+
+  it("resolves the progress comment URL when the batch is published", async () => {
+    const resolveProgressCommentUrl = vi.fn(async () => PROGRESS_COMMENT_URL);
+
+    const result = await publishFindingBatch(
+      [finding],
+      batchContext(createFindingLedger(), undefined, { resolveProgressCommentUrl }),
+    );
+
+    expect(result.kind).toBe("published");
+    expect(resolveProgressCommentUrl).toHaveBeenCalledOnce();
   });
 
   it("stops before the GitHub write when the run was superseded", async () => {

--- a/test/publishReview.core.test.ts
+++ b/test/publishReview.core.test.ts
@@ -53,7 +53,7 @@ describe("publishReview core", () => {
     const publishState = testPublishState();
     await publishReviewForTest({
       ...baseParams,
-      summaryCommentIdHint: 99,
+      progressCommentIdHint: 99,
       publishState,
       cachedDiffIndex: cachedDiffForLines("src/x.ts", [4]),
     });
@@ -334,7 +334,7 @@ describe("publishReview core", () => {
     await publishReviewForTest({
       ...baseParams,
       mode: "review-security",
-      summaryCommentIdHint: 99,
+      progressCommentIdHint: 99,
       publishState,
       cachedDiffIndex: cachedDiffForLines("src/x.ts", [4]),
     });
@@ -374,7 +374,7 @@ describe("publishReview core", () => {
     await publishReviewForTest({
       ...baseParams,
       shouldLinkToSummary: true,
-      summaryCommentIdHint: 99,
+      progressCommentIdHint: 99,
       publishState: testPublishState(),
       cachedDiffIndex: cachedDiffForLines("src/x.ts", [4]),
     });
@@ -411,7 +411,7 @@ describe("publishReview core", () => {
       publishReviewForTest({
         ...baseParams,
         shouldLinkToSummary: true,
-        summaryCommentIdHint: null,
+        progressCommentIdHint: null,
         publishState: testPublishState(),
         cachedDiffIndex: cachedDiffForLines("src/x.ts", [4]),
       }),
@@ -430,7 +430,7 @@ describe("publishReview core", () => {
     await publishReviewForTest({
       ...baseParams,
       shouldLinkToSummary: true,
-      summaryCommentIdHint: 99,
+      progressCommentIdHint: 99,
       publishState,
       payload: { ...payload, findings: [] },
     });

--- a/test/publishReview.labelsAndTokenExpiry.test.ts
+++ b/test/publishReview.labelsAndTokenExpiry.test.ts
@@ -213,7 +213,7 @@ describe("publishReview labels and token expiry", () => {
       ...baseParams,
       tokenExpiresAtTs,
       shouldLinkToSummary: true,
-      summaryCommentIdHint: 99,
+      progressCommentIdHint: 99,
       publishState: testPublishState(),
       payload: { ...payload, findings: [] },
     });

--- a/test/publishThreadTool.test.ts
+++ b/test/publishThreadTool.test.ts
@@ -54,7 +54,7 @@ function buildTool(getToken: () => string, shouldAbortPublish?: () => Promise<bo
       hasDescriptionReviewMap: false,
     },
     workItemId: "wi-1",
-    progressCommentUrl: "https://github.com/o/r/pull/1#issuecomment-99",
+    resolveProgressCommentUrl: async () => "https://github.com/o/r/pull/1#issuecomment-99",
     getToken,
     cachedDiffIndex: cachedDiffForLines("src/a.ts", [10, 20]),
     recordPublishStep: vi.fn(async () => undefined),

--- a/test/reviewExecutor.test.ts
+++ b/test/reviewExecutor.test.ts
@@ -217,7 +217,7 @@ describe("executeReviewJob", () => {
       shouldLinkToSummary: false,
       storedInlineFingerprints: [],
       resumedPlacements: [],
-      summaryCommentGithubId: null,
+      progressCommentGithubId: null,
     });
     mocks.fetchPrFiles.mockResolvedValue(prFiles);
     mocks.lightweight.mockResolvedValue({ handled: false });
@@ -294,7 +294,7 @@ describe("executeReviewJob", () => {
       shouldLinkToSummary: false,
       storedInlineFingerprints: [],
       resumedPlacements: [],
-      summaryCommentGithubId: null,
+      progressCommentGithubId: null,
     });
 
     await executeReviewJob(cfg, pool, boss, reviewJob());
@@ -307,6 +307,26 @@ describe("executeReviewJob", () => {
           threadCallCount: 8,
         },
       }),
+    );
+  });
+
+  it("passes the persisted progress comment id into the review run as the hint", async () => {
+    mocks.loadPublishContext.mockResolvedValueOnce({
+      publishState: {
+        summaryPublished: false,
+        inlineReviewIds: [],
+        threadCallCount: 0,
+      },
+      shouldLinkToSummary: false,
+      storedInlineFingerprints: [],
+      resumedPlacements: [],
+      progressCommentGithubId: 4321,
+    });
+
+    await executeReviewJob(cfg, pool, boss, reviewJob());
+
+    expect(mocks.runOrchestratedPrReview).toHaveBeenCalledWith(
+      expect.objectContaining({ progressCommentIdHint: 4321 }),
     );
   });
 


### PR DESCRIPTION
## Summary

- Resolve the current durable progress comment before each specialist batch
- Keep first-review findings when acknowledgement and review queues overlap
- Use progress-comment names across review publishing and persistence
- Keep unresolved progress comments as explicit publish errors
- Add regression coverage for null initial comment hints

## Details

- `publishFindingBatch` requests the link at publish time instead of capturing an optional URL
- Durable orchestrated reviews query the latest completed progress or summary record for every batch