### PR TITLE
Stop orphaning stale-head review replacements

### DIFF
--- a/src/agentWork/durableJob.ts
+++ b/src/agentWork/durableJob.ts
@@ -461,9 +461,7 @@ export async function runDurableWorkItem<T extends WorkType>(
   }
 
   async function completeDurableExecution(result: DurableExecutionResult): Promise<void> {
-    // Reschedule enqueue must win over parent skip: execute may already have
-    // persisted a replacement + stolen progress ownership. Skipping here orphans
-    // that replacement and leaves the PR stub stuck on superseded.
+    // Replacement enqueue before skip: execute may already have transferred progress ownership.
     if (result.rescheduled) {
       await completeRescheduledResult(result);
       return;

--- a/src/agentWork/durableJob.ts
+++ b/src/agentWork/durableJob.ts
@@ -42,7 +42,10 @@ import {
 } from "./repository.js";
 import { createPrSurface, type PrSurface } from "../github/prSurface.js";
 import { reactionTargetsForWorkItem } from "./reactionTargets.js";
-import { cancelOrphanedStaleHeadReplacementOnTerminalFailure } from "./reviewReschedule.js";
+import {
+  cancelOrphanedStaleHeadReplacementOnTerminalFailure,
+  isStaleHeadReplacementExhausted,
+} from "./reviewReschedule.js";
 import type { AgentWorkItem, AgentWorkItemCore, WorkType } from "./types.js";
 import { isWorkItemType } from "./types.js";
 import { attachWorkItemPayload } from "./workItemPayloadSchema.js";
@@ -76,6 +79,11 @@ function getCachedBotIdentity(cfg: Config): Promise<BotIdentity> {
     throw error;
   });
   return botIdentityCache;
+}
+
+/** Failures that must terminalise on first throw (no pg-boss / durable retry budget). */
+function isNonRetryableDurableFailure(error: unknown): boolean {
+  return isStaleHeadReplacementExhausted(error);
 }
 
 type DurableExecutionResult = {
@@ -524,7 +532,8 @@ export async function runDurableWorkItem<T extends WorkType>(
     }
     if (await recheckSkippableAndCancel("skipped_after_error")) return;
     const message = error instanceof Error ? error.message : String(error);
-    if (!(spec.job.retryCount >= spec.job.retryLimit)) {
+    // Permanent product failures skip the pg-boss retry budget and fail on first throw.
+    if (!isNonRetryableDurableFailure(error) && !(spec.job.retryCount >= spec.job.retryLimit)) {
       await markRetryingOrCancel(error, message);
       return;
     }

--- a/src/agentWork/durableJob.ts
+++ b/src/agentWork/durableJob.ts
@@ -461,11 +461,14 @@ export async function runDurableWorkItem<T extends WorkType>(
   }
 
   async function completeDurableExecution(result: DurableExecutionResult): Promise<void> {
-    if (await recheckSkippableAndCancel("skipped_after_execute", false)) return;
+    // Reschedule enqueue must win over parent skip: execute may already have
+    // persisted a replacement + stolen progress ownership. Skipping here orphans
+    // that replacement and leaves the PR stub stuck on superseded.
     if (result.rescheduled) {
       await completeRescheduledResult(result);
       return;
     }
+    if (await recheckSkippableAndCancel("skipped_after_execute", false)) return;
     if (result.degraded) await markWorkPublishDegraded(spec.pool, item.id);
     if (!(await markWorkCompleted(spec.pool, item.id, executionEpoch))) {
       await recheckSkippableAndCancel("completion_race", false);

--- a/src/agentWork/executors/reviewExecutor.ts
+++ b/src/agentWork/executors/reviewExecutor.ts
@@ -3,6 +3,7 @@ import type { Pool } from "pg";
 import type { JobWithMetadata, PgBoss } from "pg-boss";
 import type { Config } from "../../config.js";
 import { captureEvent } from "../../analytics/index.js";
+import { AppError, isAppError } from "../../errors/appError.js";
 import {
   classifyFailure,
   classifiedFailureLogFields,
@@ -184,18 +185,28 @@ async function handleStaleHeadReschedule(args: {
   ) {
     return undefined;
   }
-  await completeReviewCheckRun(pool, {
-    prSurface,
-    owner: item.owner,
-    repo: item.repo,
-    prNumber: item.prNumber,
-    workItemId: item.id,
-    resourceKey: item.resourceKey,
-    reviewLens,
-    conclusion: "cancelled",
-    summary: "Review was rescheduled for a newer pull request head.",
-  });
-  return buildStaleReviewRescheduleResult(pool, item, prSurface);
+  if (await shouldSkipWork(pool, item)) {
+    return undefined;
+  }
+  try {
+    await completeReviewCheckRun(pool, {
+      prSurface,
+      owner: item.owner,
+      repo: item.repo,
+      prNumber: item.prNumber,
+      workItemId: item.id,
+      resourceKey: item.resourceKey,
+      reviewLens,
+      conclusion: "cancelled",
+      summary: "Review was rescheduled for a newer pull request head.",
+    });
+    return await buildStaleReviewRescheduleResult(pool, item, prSurface);
+  } catch (error) {
+    if (isAppError(error) && error.code === "agent_work.stale_head_parent_not_reschedulable") {
+      return undefined;
+    }
+    throw error;
+  }
 }
 
 async function completeCheckFromStoredSummary(args: {
@@ -651,20 +662,43 @@ async function runFullReviewAgainstRepositoryView(args: {
     },
   });
 
-  if (
-    staleHeadAtPublish.value &&
-    (payload.source === "slash" || payload.source === "auto") &&
-    !payload.staleHeadRescheduled
-  ) {
-    await completeCheckFromStoredSummary({
-      pool,
-      item,
-      reviewLens,
-      prSurface,
-      conclusion: "cancelled",
-      summary: "Review was rescheduled for a newer pull request head.",
-    });
-    return buildStaleReviewRescheduleResult(pool, item, prSurface);
+  if (staleHeadAtPublish.value) {
+    if (
+      (payload.source === "slash" || payload.source === "auto") &&
+      !payload.staleHeadRescheduled
+    ) {
+      // Burst synchronize may have already cancel-requested this parent and
+      // enqueued a newer auto review. Do not create a competing replacement or
+      // steal progress ownership from that successor.
+      if (!(await shouldSkipWork(pool, item))) {
+        try {
+          await completeCheckFromStoredSummary({
+            pool,
+            item,
+            reviewLens,
+            prSurface,
+            conclusion: "cancelled",
+            summary: "Review was rescheduled for a newer pull request head.",
+          });
+          return await buildStaleReviewRescheduleResult(pool, item, prSurface);
+        } catch (error) {
+          if (
+            !(isAppError(error) && error.code === "agent_work.stale_head_parent_not_reschedulable")
+          ) {
+            throw error;
+          }
+          // Parent became skippable between the check and the insert — fall through.
+        }
+      }
+    } else if (payload.staleHeadRescheduled) {
+      // One-shot replacement also went stale: fail with retry guidance (no loop).
+      throw new AppError({
+        code: "review.stale_head_replacement_exhausted",
+        message:
+          "Stale-head replacement went stale again. Run /review to retry on the latest head.",
+        context: { workItemId: item.id, resourceKey: item.resourceKey },
+      });
+    }
   }
 
   return handleReviewPublishResult({

--- a/src/agentWork/executors/reviewExecutor.ts
+++ b/src/agentWork/executors/reviewExecutor.ts
@@ -3,7 +3,6 @@ import type { Pool } from "pg";
 import type { JobWithMetadata, PgBoss } from "pg-boss";
 import type { Config } from "../../config.js";
 import { captureEvent } from "../../analytics/index.js";
-import { AppError, isAppError } from "../../errors/appError.js";
 import {
   classifyFailure,
   classifiedFailureLogFields,
@@ -86,7 +85,8 @@ import {
   type ReviewExecutorPublishContext,
 } from "../repository.js";
 import {
-  buildStaleReviewRescheduleResult,
+  staleHeadReplacementExhaustedError,
+  tryBuildStaleReviewRescheduleResult,
   type StaleReviewRescheduleResult,
 } from "../reviewReschedule.js";
 import { renderReviewFailureNotice } from "../../review/run/progressComment.js";
@@ -170,6 +170,23 @@ function reviewRunGate(args: {
   };
 }
 
+/**
+ * Build a deferred-head replacement when the parent can still own reschedule.
+ * Runs optional pre-work (check-run cancel) only after the skip guard passes.
+ */
+async function scheduleStaleHeadReplacement(args: {
+  readonly pool: Pool;
+  readonly item: ReviewWorkItem;
+  readonly beforeBuild?: () => Promise<void>;
+}): Promise<StaleReviewRescheduleResult | undefined> {
+  if (await shouldSkipWork(args.pool, args.item)) {
+    return undefined;
+  }
+  await args.beforeBuild?.();
+  return (await tryBuildStaleReviewRescheduleResult(args.pool, args.item)) ?? undefined;
+}
+
+/** Resume a parent that already persisted a replacement marker but has not finished enqueue. */
 async function handleStaleHeadReschedule(args: {
   readonly pool: Pool;
   readonly item: ReviewWorkItem;
@@ -185,28 +202,23 @@ async function handleStaleHeadReschedule(args: {
   ) {
     return undefined;
   }
-  if (await shouldSkipWork(pool, item)) {
-    return undefined;
-  }
-  try {
-    await completeReviewCheckRun(pool, {
-      prSurface,
-      owner: item.owner,
-      repo: item.repo,
-      prNumber: item.prNumber,
-      workItemId: item.id,
-      resourceKey: item.resourceKey,
-      reviewLens,
-      conclusion: "cancelled",
-      summary: "Review was rescheduled for a newer pull request head.",
-    });
-    return await buildStaleReviewRescheduleResult(pool, item, prSurface);
-  } catch (error) {
-    if (isAppError(error) && error.code === "agent_work.stale_head_parent_not_reschedulable") {
-      return undefined;
-    }
-    throw error;
-  }
+  return scheduleStaleHeadReplacement({
+    pool,
+    item,
+    beforeBuild: async () => {
+      await completeReviewCheckRun(pool, {
+        prSurface,
+        owner: item.owner,
+        repo: item.repo,
+        prNumber: item.prNumber,
+        workItemId: item.id,
+        resourceKey: item.resourceKey,
+        reviewLens,
+        conclusion: "cancelled",
+        summary: "Review was rescheduled for a newer pull request head.",
+      });
+    },
+  });
 }
 
 async function completeCheckFromStoredSummary(args: {
@@ -663,15 +675,14 @@ async function runFullReviewAgainstRepositoryView(args: {
   });
 
   if (staleHeadAtPublish.value) {
-    if (
-      (payload.source === "slash" || payload.source === "auto") &&
-      !payload.staleHeadRescheduled
-    ) {
-      // Burst synchronize may have already cancel-requested this parent and
-      // enqueued a newer auto review. Do not create a competing replacement or
-      // steal progress ownership from that successor.
-      if (!(await shouldSkipWork(pool, item))) {
-        try {
+    if (payload.staleHeadRescheduled) {
+      throw staleHeadReplacementExhaustedError(item);
+    }
+    if (payload.source === "slash" || payload.source === "auto") {
+      const reschedule = await scheduleStaleHeadReplacement({
+        pool,
+        item,
+        beforeBuild: async () => {
           await completeCheckFromStoredSummary({
             pool,
             item,
@@ -680,24 +691,9 @@ async function runFullReviewAgainstRepositoryView(args: {
             conclusion: "cancelled",
             summary: "Review was rescheduled for a newer pull request head.",
           });
-          return await buildStaleReviewRescheduleResult(pool, item, prSurface);
-        } catch (error) {
-          if (
-            !(isAppError(error) && error.code === "agent_work.stale_head_parent_not_reschedulable")
-          ) {
-            throw error;
-          }
-          // Parent became skippable between the check and the insert — fall through.
-        }
-      }
-    } else if (payload.staleHeadRescheduled) {
-      // One-shot replacement also went stale: fail with retry guidance (no loop).
-      throw new AppError({
-        code: "review.stale_head_replacement_exhausted",
-        message:
-          "Stale-head replacement went stale again. Run /review to retry on the latest head.",
-        context: { workItemId: item.id, resourceKey: item.resourceKey },
+        },
       });
+      if (reschedule) return reschedule;
     }
   }
 

--- a/src/agentWork/reviewReschedule.ts
+++ b/src/agentWork/reviewReschedule.ts
@@ -38,6 +38,10 @@ export function isStaleHeadParentNotReschedulable(error: unknown): boolean {
   return isAppError(error) && error.code === STALE_HEAD_PARENT_NOT_RESCHEDULABLE;
 }
 
+export function isStaleHeadReplacementExhausted(error: unknown): boolean {
+  return isAppError(error) && error.code === STALE_HEAD_REPLACEMENT_EXHAUSTED;
+}
+
 /** One-shot replacement already consumed; caller should fail with `/review` retry guidance. */
 export function staleHeadReplacementExhaustedError(item: ReviewWorkItem): AppError {
   return new AppError({

--- a/src/agentWork/reviewReschedule.ts
+++ b/src/agentWork/reviewReschedule.ts
@@ -2,11 +2,10 @@ import crypto from "node:crypto";
 import type { Pool, PoolClient } from "pg";
 import type { PgBoss } from "pg-boss";
 import { inTransaction, pgBossDb } from "../db/postgres.js";
-import { AppError } from "../errors/appError.js";
+import { AppError, isAppError } from "../errors/appError.js";
 import { logInfo, logWarn } from "../evlog.js";
 import { sanitizeLogMessage } from "../security/sanitizeLogMessage.js";
 import { ACK_QUEUE, DEFERRED_HEAD_SHA, REVIEW_QUEUE } from "../settings/index.js";
-import type { PrSurface } from "../github/prSurface.js";
 import { transferProgressCommentOwnership } from "./intake/workItemRepository.js";
 import { getWorkItem, markQueuedWorkCancelled } from "./repository.js";
 import { releaseReviewSingletonSlot } from "./singletonQueue.js";
@@ -18,6 +17,9 @@ import {
   type ReviewJobData,
   type ReviewWorkPayload,
 } from "./types.js";
+
+export const STALE_HEAD_PARENT_NOT_RESCHEDULABLE = "agent_work.stale_head_parent_not_reschedulable";
+export const STALE_HEAD_REPLACEMENT_EXHAUSTED = "review.stale_head_replacement_exhausted";
 
 export type StaleReviewRescheduleResult = {
   readonly rescheduled: true;
@@ -31,6 +33,19 @@ type ReviewRescheduleWorkItem = {
   readonly replacementWorkItemId: string;
   readonly headSha: string;
 };
+
+export function isStaleHeadParentNotReschedulable(error: unknown): boolean {
+  return isAppError(error) && error.code === STALE_HEAD_PARENT_NOT_RESCHEDULABLE;
+}
+
+/** One-shot replacement already consumed; caller should fail with `/review` retry guidance. */
+export function staleHeadReplacementExhaustedError(item: ReviewWorkItem): AppError {
+  return new AppError({
+    code: STALE_HEAD_REPLACEMENT_EXHAUSTED,
+    message: "Stale-head replacement went stale again. Run /review to retry on the latest head.",
+    context: { workItemId: item.id, resourceKey: item.resourceKey },
+  });
+}
 
 /**
  * Cancel a queued stale-head replacement that was persisted but never enqueued.
@@ -95,11 +110,8 @@ export async function cancelOrphanedStaleHeadReplacementOnTerminalFailure(
 export async function buildStaleReviewRescheduleResult(
   pool: Pool,
   item: ReviewWorkItem,
-  prSurface: PrSurface,
 ): Promise<StaleReviewRescheduleResult> {
-  const latestHeadSha = await prSurface.getHeadSha();
-  const replacement = await createReviewRescheduleWorkItem(pool, item, latestHeadSha);
-  // Closed over by afterComplete / onRescheduleAbort so terminal abort does not re-read payload.
+  const replacement = await createReviewRescheduleWorkItem(pool, item);
   let replacementEnqueued = false;
   return {
     rescheduled: true,
@@ -128,19 +140,24 @@ export async function buildStaleReviewRescheduleResult(
   };
 }
 
+/** Like buildStaleReviewRescheduleResult, but null when the parent can no longer own a replacement. */
+export async function tryBuildStaleReviewRescheduleResult(
+  pool: Pool,
+  item: ReviewWorkItem,
+): Promise<StaleReviewRescheduleResult | null> {
+  try {
+    return await buildStaleReviewRescheduleResult(pool, item);
+  } catch (error) {
+    if (isStaleHeadParentNotReschedulable(error)) return null;
+    throw error;
+  }
+}
+
 export async function createReviewRescheduleWorkItem(
   pool: Pool,
   item: ReviewWorkItem,
-  /**
-   * Ignored for new inserts — replacements use DEFERRED_HEAD_SHA so the worker
-   * resolves the latest head at claim time (burst synchronize collapse).
-   * Retained for call-site compatibility and conflict-path tests.
-   */
-  _latestHeadSha: string,
 ): Promise<ReviewRescheduleWorkItem> {
   return inTransaction(pool, async (client) => {
-    // Do not steal progress ownership after a newer auto intake (or /cancel)
-    // already cancelled this parent — that orphans the PR on a superseded stub.
     const parentLive = await client.query<{ id: string }>(
       `SELECT id FROM agent_work_items
         WHERE id = $1
@@ -151,7 +168,7 @@ export async function createReviewRescheduleWorkItem(
     );
     if ((parentLive.rowCount ?? 0) === 0) {
       throw new AppError({
-        code: "agent_work.stale_head_parent_not_reschedulable",
+        code: STALE_HEAD_PARENT_NOT_RESCHEDULABLE,
         message: `Parent review ${item.id} is no longer running for stale-head reschedule`,
         context: { workItemId: item.id },
       });
@@ -197,8 +214,6 @@ export async function createReviewRescheduleWorkItem(
       staleHeadReplacementWorkItemId: replacementWorkItemId,
     };
 
-    // Deferred head: worker resolves the newest SHA at claim so rapid pushes
-    // collapse into this one-shot replacement instead of pinning an intermediate head.
     const insertResult = await client.query<{ head_sha: string }>(
       `INSERT INTO agent_work_items (
        id, webhook_event_id, type, source, status, owner, repo, pr_number, installation_id,
@@ -362,6 +377,6 @@ export async function enqueueReviewReschedule(
     previousWorkItemId: item.id,
     replacementWorkItemId: workItemId,
     previousHeadSha: item.headSha,
-    latestHeadSha: replacementHeadSha,
+    replacementHeadSha,
   });
 }

--- a/src/agentWork/reviewReschedule.ts
+++ b/src/agentWork/reviewReschedule.ts
@@ -5,7 +5,7 @@ import { inTransaction, pgBossDb } from "../db/postgres.js";
 import { AppError } from "../errors/appError.js";
 import { logInfo, logWarn } from "../evlog.js";
 import { sanitizeLogMessage } from "../security/sanitizeLogMessage.js";
-import { ACK_QUEUE, REVIEW_QUEUE } from "../settings/index.js";
+import { ACK_QUEUE, DEFERRED_HEAD_SHA, REVIEW_QUEUE } from "../settings/index.js";
 import type { PrSurface } from "../github/prSurface.js";
 import { transferProgressCommentOwnership } from "./intake/workItemRepository.js";
 import { getWorkItem, markQueuedWorkCancelled } from "./repository.js";
@@ -131,9 +131,32 @@ export async function buildStaleReviewRescheduleResult(
 export async function createReviewRescheduleWorkItem(
   pool: Pool,
   item: ReviewWorkItem,
-  latestHeadSha: string,
+  /**
+   * Ignored for new inserts — replacements use DEFERRED_HEAD_SHA so the worker
+   * resolves the latest head at claim time (burst synchronize collapse).
+   * Retained for call-site compatibility and conflict-path tests.
+   */
+  _latestHeadSha: string,
 ): Promise<ReviewRescheduleWorkItem> {
   return inTransaction(pool, async (client) => {
+    // Do not steal progress ownership after a newer auto intake (or /cancel)
+    // already cancelled this parent — that orphans the PR on a superseded stub.
+    const parentLive = await client.query<{ id: string }>(
+      `SELECT id FROM agent_work_items
+        WHERE id = $1
+          AND status = 'running'
+          AND cancel_requested_at IS NULL
+        FOR UPDATE`,
+      [item.id],
+    );
+    if ((parentLive.rowCount ?? 0) === 0) {
+      throw new AppError({
+        code: "agent_work.stale_head_parent_not_reschedulable",
+        message: `Parent review ${item.id} is no longer running for stale-head reschedule`,
+        context: { workItemId: item.id },
+      });
+    }
+
     const payload = item.payload;
     const reviewLens = item.reviewLens;
     let replacementWorkItemId = payload.staleHeadReplacementWorkItemId;
@@ -174,6 +197,8 @@ export async function createReviewRescheduleWorkItem(
       staleHeadReplacementWorkItemId: replacementWorkItemId,
     };
 
+    // Deferred head: worker resolves the newest SHA at claim so rapid pushes
+    // collapse into this one-shot replacement instead of pinning an intermediate head.
     const insertResult = await client.query<{ head_sha: string }>(
       `INSERT INTO agent_work_items (
        id, webhook_event_id, type, source, status, owner, repo, pr_number, installation_id,
@@ -192,7 +217,7 @@ export async function createReviewRescheduleWorkItem(
         item.repo,
         item.prNumber,
         item.installationId,
-        latestHeadSha,
+        DEFERRED_HEAD_SHA,
         reviewLens,
         item.resourceKey,
         JSON.stringify(nextPayload),

--- a/test/durableJob.test.ts
+++ b/test/durableJob.test.ts
@@ -601,6 +601,34 @@ describe("runDurableWorkItem", () => {
     expect(repo.markWorkFailed).not.toHaveBeenCalled();
   });
 
+  it("still enqueues a stale-head replacement when parent becomes skippable after execute", async () => {
+    mockFetchedItem(
+      makeItem({
+        status: "running",
+        payload: {
+          mode: "review",
+          source: "auto",
+          staleHeadReplacementWorkItemId: "replacement-wi",
+        },
+      }),
+    );
+    // cancelBeforeClaim is false; finishRescheduledParentWorkItem then sees cancel_requested.
+    vi.mocked(repo.shouldSkipWork).mockResolvedValueOnce(false).mockResolvedValue(true);
+    vi.mocked(repo.markWorkCompleted).mockResolvedValue(false);
+    vi.mocked(repo.forceMarkRescheduledParentCompleted).mockResolvedValue(false);
+    const afterComplete = vi.fn().mockResolvedValue(undefined);
+    const execute = vi.fn().mockResolvedValue({
+      rescheduled: true,
+      replacementWorkItemId: "replacement-wi",
+      afterComplete,
+    });
+
+    await runReviewWorkItem({ execute });
+
+    expect(afterComplete).toHaveBeenCalledWith(boss, "job-1");
+    expect(repo.markWorkCancelled).toHaveBeenCalledWith(pool, "wi-1", 1);
+  });
+
   it("throws when rescheduled parent cannot be completed and replacement marker exists", async () => {
     mockFetchedItem(
       makeItem({

--- a/test/durableJob.test.ts
+++ b/test/durableJob.test.ts
@@ -30,9 +30,13 @@ vi.mock("../src/agentWork/repository.js", () => ({
   updateRunningWorkHeadSha: vi.fn(),
 }));
 
-vi.mock("../src/agentWork/reviewReschedule.js", () => ({
-  cancelOrphanedStaleHeadReplacementOnTerminalFailure: vi.fn(),
-}));
+vi.mock("../src/agentWork/reviewReschedule.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/agentWork/reviewReschedule.js")>();
+  return {
+    ...actual,
+    cancelOrphanedStaleHeadReplacementOnTerminalFailure: vi.fn(),
+  };
+});
 
 vi.mock("../src/github/appAuth.js", () => ({
   mintInstallationAuth: vi.fn(),
@@ -535,6 +539,28 @@ describe("runDurableWorkItem", () => {
 
     expect(repo.markWorkRetrying).toHaveBeenCalledWith(pool, "wi-1", boom, 1);
     expect(repo.markWorkFailed).not.toHaveBeenCalled();
+  });
+
+  it("terminal-fails stale-head replacement exhaustion without durable retry", async () => {
+    mockFetchedItem(makeItem());
+    const { AppError } = await import("../src/errors/appError.js");
+    const boom = new AppError({
+      code: reviewReschedule.STALE_HEAD_REPLACEMENT_EXHAUSTED,
+      message: "Stale-head replacement went stale again. Run /review to retry on the latest head.",
+    });
+    const onTerminalFailure = vi.fn().mockResolvedValue(undefined);
+    const execute = vi.fn().mockRejectedValue(boom);
+
+    await runReviewWorkItem({ job: makeJob(0, 3), execute, onTerminalFailure });
+
+    expect(repo.markWorkRetrying).not.toHaveBeenCalled();
+    expect(repo.markWorkFailed).toHaveBeenCalledWith(pool, "wi-1", boom, 1);
+    expect(onTerminalFailure).toHaveBeenCalledTimes(1);
+    expect(onTerminalFailure).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "wi-1" }),
+      expect.anything(),
+      boom,
+    );
   });
 
   it("on terminal pg-boss attempt: marks failed and invokes onTerminalFailure", async () => {

--- a/test/durableJobAnalytics.test.ts
+++ b/test/durableJobAnalytics.test.ts
@@ -56,9 +56,13 @@ vi.mock("../src/agentWork/repository.js", () => ({
   updateRunningWorkHeadSha: vi.fn(),
 }));
 
-vi.mock("../src/agentWork/reviewReschedule.js", () => ({
-  cancelOrphanedStaleHeadReplacementOnTerminalFailure: vi.fn(),
-}));
+vi.mock("../src/agentWork/reviewReschedule.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/agentWork/reviewReschedule.js")>();
+  return {
+    ...actual,
+    cancelOrphanedStaleHeadReplacementOnTerminalFailure: vi.fn(),
+  };
+});
 
 vi.mock("../src/github/appAuth.js", () => ({
   mintInstallationAuth: vi.fn(),

--- a/test/integration/workItemRepository.integration.test.ts
+++ b/test/integration/workItemRepository.integration.test.ts
@@ -356,7 +356,7 @@ describe.skipIf(!hasDatabase)("work item repository inserts (integration)", () =
     expect(parent?.type).toBe("review");
     if (parent?.type !== "review") throw new Error("expected review parent");
 
-    const replacement = await createReviewRescheduleWorkItem(pool, parent, "sha-new");
+    const replacement = await createReviewRescheduleWorkItem(pool, parent);
     const owner = await getProgressCommentOwner(pool, resourceKey, "review");
 
     expect(owner).toEqual({ workItemId: replacement.replacementWorkItemId, generation: 5 });

--- a/test/reviewExecutor.test.ts
+++ b/test/reviewExecutor.test.ts
@@ -204,7 +204,7 @@ describe("executeReviewJob", () => {
       mocks.lightweight,
     );
     vi.spyOn(prWorkspace, "withPrRepositoryView").mockImplementation(mocks.withPrRepositoryView);
-    vi.spyOn(reviewReschedule, "buildStaleReviewRescheduleResult").mockImplementation(
+    vi.spyOn(reviewReschedule, "tryBuildStaleReviewRescheduleResult").mockImplementation(
       mocks.buildStaleReschedule,
     );
     vi.spyOn(reviewTrustedContext, "buildTrustedReviewContextForReview").mockImplementation(
@@ -406,7 +406,6 @@ describe("executeReviewJob", () => {
     expect(mocks.buildStaleReschedule).toHaveBeenCalledWith(
       pool,
       expect.objectContaining({ id: "wi-1" }),
-      durableSurfaceBundle.surface,
     );
   });
 
@@ -425,7 +424,6 @@ describe("executeReviewJob", () => {
     expect(mocks.buildStaleReschedule).toHaveBeenCalledWith(
       pool,
       expect.objectContaining({ id: "wi-1", source: "auto" }),
-      durableSurfaceBundle.surface,
     );
   });
 
@@ -481,7 +479,7 @@ describe("executeReviewJob", () => {
           executionEpoch: 1,
           signal: new AbortController().signal,
         }),
-      ).rejects.toMatchObject({ code: "review.stale_head_replacement_exhausted" });
+      ).rejects.toMatchObject({ code: reviewReschedule.STALE_HEAD_REPLACEMENT_EXHAUSTED });
     });
     mocks.runOrchestratedPrReview.mockImplementationOnce(async (params) => {
       const gate = await params.gate.check();

--- a/test/reviewExecutor.test.ts
+++ b/test/reviewExecutor.test.ts
@@ -429,6 +429,71 @@ describe("executeReviewJob", () => {
     );
   });
 
+  it("does not create a stale-head replacement when a newer auto review already cancelled the parent", async () => {
+    mockDurableExecution("auto");
+    vi.spyOn(durableSurfaceBundle.surface, "getHeadSha").mockResolvedValue("new-head");
+    // Gate check (false) then post-orchestrator reschedule guard (true).
+    mocks.shouldSkipWork.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    mocks.runOrchestratedPrReview.mockImplementationOnce(async (params) => {
+      const gate = await params.gate.check();
+      expect(gate).toEqual({ kind: "stop", reason: "stale_head" });
+      return { published: false, publishAttempts: 0, publishSuperseded: true };
+    });
+
+    await executeReviewJob(cfg, pool, boss, reviewJob());
+
+    expect(mocks.buildStaleReschedule).not.toHaveBeenCalled();
+    expect(reviewCheckRun.completeReviewCheckRun).toHaveBeenCalledWith(
+      pool,
+      expect.objectContaining({
+        conclusion: "cancelled",
+        summary: "Review publish was skipped because the work was superseded or cancelled.",
+      }),
+    );
+  });
+
+  it("fails a one-shot stale-head replacement with retry guidance instead of quiet supersede", async () => {
+    mockDurableExecution("auto");
+    mocks.lightweight.mockResolvedValue({ handled: false });
+    vi.spyOn(durableSurfaceBundle.surface, "getHeadSha").mockResolvedValue("newer-head");
+    vi.spyOn(durableSurfaceBundle.surface, "listChangedFiles").mockResolvedValue({
+      ...prFiles,
+      headSha: "old-replacement-head",
+    });
+    vi.spyOn(durableJob, "runDurableWorkItem").mockImplementation(async (spec) => {
+      const item = makeReviewWorkItem({
+        id: "wi-replacement",
+        source: "auto",
+        status: "running",
+        headSha: "old-replacement-head",
+        payload: {
+          mode: "review",
+          source: "auto",
+          staleHeadRescheduled: true,
+          staleHeadReplacementWorkItemId: "wi-replacement",
+        },
+      });
+      await expect(
+        spec.execute(item, {
+          prSurface: durableSurfaceBundle.surface,
+          headSha: "old-replacement-head",
+          pullRequest: { ...pullRequest, head: { sha: "old-replacement-head" } },
+          executionEpoch: 1,
+          signal: new AbortController().signal,
+        }),
+      ).rejects.toMatchObject({ code: "review.stale_head_replacement_exhausted" });
+    });
+    mocks.runOrchestratedPrReview.mockImplementationOnce(async (params) => {
+      const gate = await params.gate.check();
+      expect(gate).toEqual({ kind: "stop", reason: "stale_head" });
+      return { published: false, publishAttempts: 0, publishSuperseded: true };
+    });
+
+    await executeReviewJob(cfg, pool, boss, reviewJob());
+
+    expect(mocks.buildStaleReschedule).not.toHaveBeenCalled();
+  });
+
   it("preserves superseded gate stops without checking the pull request head", async () => {
     mocks.shouldSkipWork.mockResolvedValue(true);
     mocks.getWorkItem.mockResolvedValueOnce(

--- a/test/reviewReschedule.test.ts
+++ b/test/reviewReschedule.test.ts
@@ -8,14 +8,13 @@ import {
   cancelUnenqueuedStaleHeadReplacement,
   createReviewRescheduleWorkItem,
   enqueueReviewReschedule,
+  STALE_HEAD_PARENT_NOT_RESCHEDULABLE,
+  STALE_HEAD_REPLACEMENT_EXHAUSTED,
+  staleHeadReplacementExhaustedError,
+  tryBuildStaleReviewRescheduleResult,
 } from "../src/agentWork/reviewReschedule.js";
 import type { ReviewWorkItem } from "../src/agentWork/types.js";
 import { makeReviewWorkItem } from "./helpers/agentWorkItems.js";
-import { createFakePrSurface } from "../src/github/prSurface.js";
-
-function prSurfaceWithHead(headSha: string) {
-  return createFakePrSurface({ owner: "o", repo: "r", prNumber: 1 }, { headSha }).surface;
-}
 
 vi.mock("../src/agentWork/repository.js", () => ({
   getWorkItem: vi.fn(),
@@ -77,7 +76,6 @@ describe("createReviewRescheduleWorkItem", () => {
           staleHeadReplacementWorkItemId: "existing-replacement",
         },
       }),
-      "newhead",
     );
 
     expect(replacement).toEqual({
@@ -106,7 +104,6 @@ describe("createReviewRescheduleWorkItem", () => {
           staleHeadReplacementWorkItemId: "existing-replacement",
         },
       }),
-      "newhead",
     );
 
     expect(replacement.replacementWorkItemId).toBe("existing-replacement");
@@ -125,7 +122,7 @@ describe("createReviewRescheduleWorkItem", () => {
       .mockResolvedValue({ rowCount: 1, rows: [] });
     const pool = { query } as unknown as Pool;
 
-    const replacement = await createReviewRescheduleWorkItem(pool, makeItem(), "newhead");
+    const replacement = await createReviewRescheduleWorkItem(pool, makeItem());
 
     expect(replacement).toEqual({
       replacementWorkItemId: "generated-replacement",
@@ -141,9 +138,9 @@ describe("createReviewRescheduleWorkItem", () => {
     const query = vi.fn().mockResolvedValue({ rowCount: 0, rows: [] });
     const pool = { query } as unknown as Pool;
 
-    await expect(createReviewRescheduleWorkItem(pool, makeItem(), "newhead")).rejects.toMatchObject(
-      { code: "agent_work.stale_head_parent_not_reschedulable" },
-    );
+    await expect(createReviewRescheduleWorkItem(pool, makeItem())).rejects.toMatchObject({
+      code: STALE_HEAD_PARENT_NOT_RESCHEDULABLE,
+    });
     expect(query).toHaveBeenCalledTimes(1);
   });
 
@@ -167,11 +164,7 @@ describe("createReviewRescheduleWorkItem", () => {
       },
     });
 
-    const result = await buildStaleReviewRescheduleResult(
-      pool,
-      parent,
-      prSurfaceWithHead("newhead"),
-    );
+    const result = await buildStaleReviewRescheduleResult(pool, parent);
     const insertParams = query.mock.calls.find((call) =>
       String(call[0]).includes("INSERT INTO agent_work_items"),
     )?.[1] as unknown[] | undefined;
@@ -202,7 +195,7 @@ describe("createReviewRescheduleWorkItem", () => {
       .mockResolvedValue({ rowCount: 1, rows: [] });
     const pool = { query } as unknown as Pool;
 
-    const replacement = await createReviewRescheduleWorkItem(pool, makeItem(), "newhead");
+    const replacement = await createReviewRescheduleWorkItem(pool, makeItem());
 
     expect(replacement.replacementWorkItemId).toBe("winner-replacement");
     expect(getWorkItem).toHaveBeenCalledWith(pool, "parent-wi");
@@ -229,7 +222,6 @@ describe("createReviewRescheduleWorkItem", () => {
           staleHeadReplacementWorkItemId: "existing-replacement",
         },
       }),
-      prSurfaceWithHead("latest-head"),
     );
     await result.afterComplete(boss, "active-job");
 
@@ -237,6 +229,40 @@ describe("createReviewRescheduleWorkItem", () => {
     expect(ackCall?.[1]).toMatchObject({
       progress: { headSha: "persisted-head" },
     });
+  });
+});
+
+describe("stale-head shared helpers", () => {
+  it("tryBuild returns null when the parent is not reschedulable", async () => {
+    const query = vi.fn().mockResolvedValue({ rowCount: 0, rows: [] });
+    const pool = { query } as unknown as Pool;
+
+    await expect(tryBuildStaleReviewRescheduleResult(pool, makeItem())).resolves.toBeNull();
+  });
+
+  it("tryBuild returns a reschedule result for a live parent", async () => {
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: "parent-wi" }] })
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [{ replacement_id: "generated-replacement" }],
+      })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ head_sha: DEFERRED_HEAD_SHA }] })
+      .mockResolvedValue({ rowCount: 1, rows: [] });
+    const pool = { query } as unknown as Pool;
+
+    const result = await tryBuildStaleReviewRescheduleResult(pool, makeItem());
+    expect(result).toMatchObject({
+      rescheduled: true,
+      replacementWorkItemId: "generated-replacement",
+    });
+  });
+
+  it("staleHeadReplacementExhaustedError uses the shared exhausted code", () => {
+    const error = staleHeadReplacementExhaustedError(makeItem());
+    expect(error.code).toBe(STALE_HEAD_REPLACEMENT_EXHAUSTED);
+    expect(error.message).toMatch(/\/review/);
   });
 });
 
@@ -557,7 +583,6 @@ describe("buildStaleReviewRescheduleResult onRescheduleAbort", () => {
           staleHeadReplacementWorkItemId: "existing-replacement",
         },
       }),
-      prSurfaceWithHead("latest-head"),
     );
     await result.onRescheduleAbort(boss, boom);
 
@@ -585,7 +610,6 @@ describe("buildStaleReviewRescheduleResult onRescheduleAbort", () => {
           staleHeadReplacementWorkItemId: "existing-replacement",
         },
       }),
-      prSurfaceWithHead("latest-head"),
     );
     await result.afterComplete(boss, "active-job");
     await result.onRescheduleAbort(boss, new Error("should not cancel"));
@@ -611,7 +635,6 @@ describe("buildStaleReviewRescheduleResult onRescheduleAbort", () => {
           staleHeadReplacementEnqueued: true,
         },
       }),
-      prSurfaceWithHead("latest-head"),
     );
     const error = new Error("parent failed");
     await result.onRescheduleAbort(boss, error);

--- a/test/reviewReschedule.test.ts
+++ b/test/reviewReschedule.test.ts
@@ -10,6 +10,7 @@ import {
   enqueueReviewReschedule,
   STALE_HEAD_PARENT_NOT_RESCHEDULABLE,
   STALE_HEAD_REPLACEMENT_EXHAUSTED,
+  isStaleHeadReplacementExhausted,
   staleHeadReplacementExhaustedError,
   tryBuildStaleReviewRescheduleResult,
 } from "../src/agentWork/reviewReschedule.js";
@@ -263,6 +264,8 @@ describe("stale-head shared helpers", () => {
     const error = staleHeadReplacementExhaustedError(makeItem());
     expect(error.code).toBe(STALE_HEAD_REPLACEMENT_EXHAUSTED);
     expect(error.message).toMatch(/\/review/);
+    expect(isStaleHeadReplacementExhausted(error)).toBe(true);
+    expect(isStaleHeadReplacementExhausted(new Error("other"))).toBe(false);
   });
 });
 

--- a/test/reviewReschedule.test.ts
+++ b/test/reviewReschedule.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Pool, PoolClient } from "pg";
 import type { PgBoss } from "pg-boss";
-import { ACK_QUEUE, REVIEW_QUEUE } from "../src/settings/index.js";
+import { ACK_QUEUE, DEFERRED_HEAD_SHA, REVIEW_QUEUE } from "../src/settings/index.js";
 import {
   buildStaleReviewRescheduleResult,
   cancelOrphanedStaleHeadReplacementOnTerminalFailure,
@@ -61,10 +61,11 @@ beforeEach(() => {
 
 describe("createReviewRescheduleWorkItem", () => {
   it("keeps the first persisted head_sha when replacement row already exists", async () => {
-    const query = vi.fn().mockResolvedValue({
-      rowCount: 1,
-      rows: [{ head_sha: "persisted-head" }],
-    });
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: "parent-wi" }] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ head_sha: "persisted-head" }] })
+      .mockResolvedValue({ rowCount: 1, rows: [] });
     const pool = { query } as unknown as Pool;
 
     const replacement = await createReviewRescheduleWorkItem(
@@ -83,16 +84,17 @@ describe("createReviewRescheduleWorkItem", () => {
       replacementWorkItemId: "existing-replacement",
       headSha: "persisted-head",
     });
-    const sql = String(query.mock.calls[0]?.[0]);
-    expect(sql).toContain("RETURNING head_sha");
-    expect(sql).not.toContain("head_sha = EXCLUDED.head_sha");
+    const insertSql = String(query.mock.calls[1]?.[0]);
+    expect(insertSql).toContain("RETURNING head_sha");
+    expect(insertSql).not.toContain("head_sha = EXCLUDED.head_sha");
   });
 
   it("reuses persisted replacement id without creating a new marker", async () => {
-    const query = vi.fn().mockResolvedValue({
-      rowCount: 1,
-      rows: [{ head_sha: "newhead" }],
-    });
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: "parent-wi" }] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ head_sha: DEFERRED_HEAD_SHA }] })
+      .mockResolvedValue({ rowCount: 1, rows: [] });
     const pool = { query } as unknown as Pool;
 
     const replacement = await createReviewRescheduleWorkItem(
@@ -108,32 +110,48 @@ describe("createReviewRescheduleWorkItem", () => {
     );
 
     expect(replacement.replacementWorkItemId).toBe("existing-replacement");
-    expect(query).toHaveBeenCalledTimes(2);
+    expect(query.mock.calls.some((call) => String(call[0]).includes("FOR UPDATE"))).toBe(true);
   });
 
-  it("persists marker then inserts replacement on first attempt", async () => {
+  it("persists marker then inserts a deferred-head replacement on first attempt", async () => {
     const query = vi
       .fn()
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: "parent-wi" }] })
       .mockResolvedValueOnce({
         rowCount: 1,
         rows: [{ replacement_id: "generated-replacement" }],
       })
-      .mockResolvedValueOnce({ rowCount: 1, rows: [{ head_sha: "newhead" }] });
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ head_sha: DEFERRED_HEAD_SHA }] })
+      .mockResolvedValue({ rowCount: 1, rows: [] });
     const pool = { query } as unknown as Pool;
 
     const replacement = await createReviewRescheduleWorkItem(pool, makeItem(), "newhead");
 
-    expect(replacement.replacementWorkItemId).toBe("generated-replacement");
-    expect(query).toHaveBeenCalledTimes(3);
-    expect(String(query.mock.calls[0]?.[0])).toContain(
+    expect(replacement).toEqual({
+      replacementWorkItemId: "generated-replacement",
+      headSha: DEFERRED_HEAD_SHA,
+    });
+    expect(String(query.mock.calls[1]?.[0])).toContain(
       "payload->>'staleHeadReplacementWorkItemId') IS NULL",
     );
+    expect(query.mock.calls[2]?.[1]?.[7]).toBe(DEFERRED_HEAD_SHA);
+  });
+
+  it("refuses to create a replacement when the parent is already cancel-requested", async () => {
+    const query = vi.fn().mockResolvedValue({ rowCount: 0, rows: [] });
+    const pool = { query } as unknown as Pool;
+
+    await expect(createReviewRescheduleWorkItem(pool, makeItem(), "newhead")).rejects.toMatchObject(
+      { code: "agent_work.stale_head_parent_not_reschedulable" },
+    );
+    expect(query).toHaveBeenCalledTimes(1);
   });
 
   it("preserves auto source on the replacement work item and ack", async () => {
     const query = vi
       .fn()
-      .mockResolvedValueOnce({ rowCount: 1, rows: [{ head_sha: "newhead" }] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: "parent-wi" }] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ head_sha: DEFERRED_HEAD_SHA }] })
       .mockResolvedValue({ rowCount: 1, rows: [] });
     const pool = { query } as unknown as Pool;
     const send = vi.fn().mockResolvedValue("job-id");
@@ -154,12 +172,15 @@ describe("createReviewRescheduleWorkItem", () => {
       parent,
       prSurfaceWithHead("newhead"),
     );
-    expect(query.mock.calls[0]?.[1]?.[2]).toBe("auto");
+    const insertParams = query.mock.calls.find((call) =>
+      String(call[0]).includes("INSERT INTO agent_work_items"),
+    )?.[1] as unknown[] | undefined;
+    expect(insertParams?.[2]).toBe("auto");
     await result.afterComplete(boss, "active-job");
 
     const ackCall = send.mock.calls.find(([queue]) => queue === ACK_QUEUE);
     expect(ackCall?.[1]).toMatchObject({
-      progress: { source: "auto", headSha: "newhead" },
+      progress: { source: "auto", headSha: DEFERRED_HEAD_SHA },
     });
   });
 
@@ -175,8 +196,10 @@ describe("createReviewRescheduleWorkItem", () => {
     );
     const query = vi
       .fn()
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: "parent-wi" }] })
       .mockResolvedValueOnce({ rowCount: 0, rows: [] })
-      .mockResolvedValueOnce({ rowCount: 1, rows: [{ head_sha: "newhead" }] });
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ head_sha: DEFERRED_HEAD_SHA }] })
+      .mockResolvedValue({ rowCount: 1, rows: [] });
     const pool = { query } as unknown as Pool;
 
     const replacement = await createReviewRescheduleWorkItem(pool, makeItem(), "newhead");
@@ -188,8 +211,9 @@ describe("createReviewRescheduleWorkItem", () => {
   it("uses the persisted replacement head for the ack after an insert conflict", async () => {
     const query = vi
       .fn()
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: "parent-wi" }] })
       .mockResolvedValueOnce({ rowCount: 1, rows: [{ head_sha: "persisted-head" }] })
-      .mockResolvedValueOnce({ rowCount: 1, rows: [] });
+      .mockResolvedValue({ rowCount: 1, rows: [] });
     const pool = { query } as unknown as Pool;
     const send = vi.fn().mockResolvedValue("job-id");
     const findJobs = vi.fn().mockResolvedValue([]);
@@ -543,8 +567,9 @@ describe("buildStaleReviewRescheduleResult onRescheduleAbort", () => {
   it("does not cancel after afterComplete marks the replacement enqueued", async () => {
     const query = vi
       .fn()
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: "parent-wi" }] })
       .mockResolvedValueOnce({ rowCount: 1, rows: [{ head_sha: "persisted-head" }] })
-      .mockResolvedValueOnce({ rowCount: 1, rows: [] });
+      .mockResolvedValue({ rowCount: 1, rows: [] });
     const pool = { query } as unknown as Pool;
     const send = vi.fn().mockResolvedValue("job-id");
     const findJobs = vi.fn().mockResolvedValue([]);


### PR DESCRIPTION
## Summary
- Unify stale-head reschedule into one flow with shared parent and exhaust helpers
- Refuse replacement creation when the parent is no longer live
- Insert replacements with deferred head SHA resolved at worker claim
- Prefer reschedule enqueue over parent skip after execute
- Fail a second stale replacement with `/review` retry guidance

## Details
- `scheduleStaleHeadReplacement` owns skip check, optional check cancel, and `tryBuildStaleReviewRescheduleResult`
- `createReviewRescheduleWorkItem` locks the live parent and inserts `DEFERRED_HEAD_SHA`
- `completeDurableExecution` runs `completeRescheduledResult` before skip checks
- Second-stale one-shots throw `review.stale_head_replacement_exhausted`
