### PR TITLE
Select pg-boss singleton_key in orphan reaper

### DIFF
--- a/src/agentWork/reviewQueueSlot.ts
+++ b/src/agentWork/reviewQueueSlot.ts
@@ -178,7 +178,7 @@ export async function reapReviewQueueOrphans(
     work_item_id: string | null;
   }>(
     `SELECT j.id::text AS job_id,
-            j.key AS singleton_key,
+            j.singleton_key,
             j.state::text AS state,
             j.data->>'workItemId' AS work_item_id
        FROM pgboss.job j

--- a/test/integration/reviewQueueOrphanReaper.integration.test.ts
+++ b/test/integration/reviewQueueOrphanReaper.integration.test.ts
@@ -49,8 +49,8 @@ async function deleteReviewJobs(boss: PgBoss): Promise<void> {
 }
 
 describe.skipIf(!hasDatabase)("review queue orphan reaper (integration)", () => {
-  let pool: Pool;
-  let boss: PgBoss;
+  let pool: Pool | undefined;
+  let boss: PgBoss | undefined;
 
   beforeAll(async () => {
     pool = integrationPool();
@@ -63,38 +63,49 @@ describe.skipIf(!hasDatabase)("review queue orphan reaper (integration)", () => 
   });
 
   afterAll(async () => {
-    await stopBoss(boss, DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_SECONDS * 1000);
-    await pool.end();
+    if (boss) await stopBoss(boss, DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_SECONDS * 1000);
+    await pool?.end();
   });
 
   afterEach(async () => {
+    if (!pool || !boss) return;
     await pool.query("DELETE FROM agent_work_items WHERE owner = $1", [OWNER]);
     await pool.query("DELETE FROM webhook_events WHERE event_name = $1", [EVENT]);
     await deleteReviewJobs(boss);
   });
 
-  it("deletes a failed review holder whose work item is not active", async () => {
-    const repo = `repo-${randomUUID().slice(0, 8)}`;
-    const resourceKey = prResourceKey(OWNER, repo, 9);
-    const singletonKey = reviewSingletonKey(resourceKey);
+  async function insertReviewWorkItem(
+    repo: string,
+    resourceKey: string,
+    status: "failed" | "completed",
+  ): Promise<string> {
+    if (!pool) throw new Error("pool is required");
     const webhookEventId = randomUUID();
-    const failedWorkItemId = randomUUID();
-
+    const workItemId = randomUUID();
     await pool.query(
       `INSERT INTO webhook_events (id, dedupe_key, event_name, body_sha256, processing_decision)
        VALUES ($1, $2, $3, 'sha', 'accepted')`,
-      [webhookEventId, `failed-${webhookEventId}`, EVENT],
+      [webhookEventId, `${status}-${webhookEventId}`, EVENT],
     );
     await pool.query(
       `INSERT INTO agent_work_items (
          id, webhook_event_id, type, source, status, owner, repo, pr_number, installation_id,
          head_sha, review_lens, resource_key, priority, payload, completed_at
        ) VALUES (
-         $1, $2, 'review', 'auto', 'failed', $3, $4, 9, 4242, 'sha-old', 'review', $5, 0,
+         $1, $2, 'review', 'auto', $3, $4, $5, 9, 4242, 'sha-old', 'review', $6, 0,
          '{}'::jsonb, now()
        )`,
-      [failedWorkItemId, webhookEventId, OWNER, repo, resourceKey],
+      [workItemId, webhookEventId, status, OWNER, repo, resourceKey],
     );
+    return workItemId;
+  }
+
+  it("deletes a failed review holder whose work item is not active", async () => {
+    if (!pool || !boss) throw new Error("setup required");
+    const repo = `repo-${randomUUID().slice(0, 8)}`;
+    const resourceKey = prResourceKey(OWNER, repo, 9);
+    const singletonKey = reviewSingletonKey(resourceKey);
+    const failedWorkItemId = await insertReviewWorkItem(repo, resourceKey, "failed");
 
     const failedJobId = await boss.send(
       REVIEW_QUEUE,
@@ -111,5 +122,41 @@ describe.skipIf(!hasDatabase)("review queue orphan reaper (integration)", () => 
       staleQueuedLogged: 0,
     });
     await expect(boss.findJobs(REVIEW_QUEUE, { key: singletonKey })).resolves.toEqual([]);
+  });
+
+  it("cancels an active holder whose work item is completed", async () => {
+    if (!pool || !boss) throw new Error("setup required");
+    const repo = `repo-${randomUUID().slice(0, 8)}`;
+    const resourceKey = prResourceKey(OWNER, repo, 9);
+    const singletonKey = reviewSingletonKey(resourceKey);
+    const workItemId = await insertReviewWorkItem(repo, resourceKey, "completed");
+
+    const jobId = await boss.send(REVIEW_QUEUE, { kind: "review", workItemId }, { singletonKey });
+    expect(jobId).toBeTruthy();
+    await pool.query(`UPDATE pgboss.job SET state = 'active', started_on = now() WHERE id = $1`, [
+      jobId,
+    ]);
+
+    await expect(reapReviewQueueOrphans(boss, pool)).resolves.toEqual({
+      released: 1,
+      staleQueuedLogged: 0,
+    });
+    await expect(boss.getBlockedKeys(REVIEW_QUEUE)).resolves.not.toContain(singletonKey);
+  });
+
+  it("cancels a created holder with no workItemId", async () => {
+    if (!pool || !boss) throw new Error("setup required");
+    const repo = `repo-${randomUUID().slice(0, 8)}`;
+    const resourceKey = prResourceKey(OWNER, repo, 9);
+    const singletonKey = reviewSingletonKey(resourceKey);
+
+    const jobId = await boss.send(REVIEW_QUEUE, { kind: "review" }, { singletonKey });
+    expect(jobId).toBeTruthy();
+
+    await expect(reapReviewQueueOrphans(boss, pool)).resolves.toEqual({
+      released: 1,
+      staleQueuedLogged: 0,
+    });
+    await expect(boss.getBlockedKeys(REVIEW_QUEUE)).resolves.not.toContain(singletonKey);
   });
 });

--- a/test/integration/reviewQueueOrphanReaper.integration.test.ts
+++ b/test/integration/reviewQueueOrphanReaper.integration.test.ts
@@ -1,0 +1,115 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { Pool } from "pg";
+import type { PgBoss } from "pg-boss";
+import { createStartedBoss, ensureAgentQueues, stopBoss } from "../../src/agentWork/boss.js";
+import { reapReviewQueueOrphans } from "../../src/agentWork/reviewQueueSlot.js";
+import type { QueueConfig } from "../../src/agentWork/types.js";
+import { prResourceKey, reviewSingletonKey } from "../../src/agentWork/types.js";
+import { runMigrations } from "../../src/db/migrations.js";
+import {
+  DEFAULT_INSTALLATION_GROUP_CONCURRENCY,
+  DEFAULT_QUEUE_DELETE_AFTER_SECONDS,
+  DEFAULT_QUEUE_EXPIRE_IN_SECONDS,
+  DEFAULT_QUEUE_HEARTBEAT_SECONDS,
+  DEFAULT_QUEUE_POLLING_INTERVAL_SECONDS,
+  DEFAULT_QUEUE_RETENTION_SECONDS,
+  DEFAULT_QUEUE_RETRY_DELAY_MAX_SECONDS,
+  DEFAULT_QUEUE_RETRY_DELAY_SECONDS,
+  DEFAULT_QUEUE_RETRY_LIMIT,
+  DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_SECONDS,
+  REVIEW_QUEUE,
+} from "../../src/settings/index.js";
+import { hasDatabase, integrationPool } from "./db.js";
+
+const OWNER = "orphan-reaper-it";
+const EVENT = "orphan-reaper-it";
+const DATABASE_URL = process.env.DATABASE_URL!;
+
+const queueConfig: QueueConfig = {
+  queueRetryLimit: DEFAULT_QUEUE_RETRY_LIMIT,
+  queueRetryDelaySeconds: DEFAULT_QUEUE_RETRY_DELAY_SECONDS,
+  queueRetryDelayMaxSeconds: DEFAULT_QUEUE_RETRY_DELAY_MAX_SECONDS,
+  queueExpireInSeconds: DEFAULT_QUEUE_EXPIRE_IN_SECONDS,
+  queueHeartbeatSeconds: DEFAULT_QUEUE_HEARTBEAT_SECONDS,
+  queuePollingIntervalSeconds: DEFAULT_QUEUE_POLLING_INTERVAL_SECONDS,
+  queueRetentionSeconds: DEFAULT_QUEUE_RETENTION_SECONDS,
+  queueDeleteAfterSeconds: DEFAULT_QUEUE_DELETE_AFTER_SECONDS,
+  installationGroupConcurrency: DEFAULT_INSTALLATION_GROUP_CONCURRENCY,
+};
+
+async function deleteReviewJobs(boss: PgBoss): Promise<void> {
+  const jobs = await boss.findJobs(REVIEW_QUEUE, {});
+  if (jobs.length > 0) {
+    await boss.deleteJob(
+      REVIEW_QUEUE,
+      jobs.map((job) => job.id),
+    );
+  }
+}
+
+describe.skipIf(!hasDatabase)("review queue orphan reaper (integration)", () => {
+  let pool: Pool;
+  let boss: PgBoss;
+
+  beforeAll(async () => {
+    pool = integrationPool();
+    await runMigrations(pool);
+    await pool.query("DELETE FROM agent_work_items WHERE owner = $1", [OWNER]);
+    await pool.query("DELETE FROM webhook_events WHERE event_name = $1", [EVENT]);
+    boss = await createStartedBoss({ databaseUrl: DATABASE_URL, role: "web" });
+    await ensureAgentQueues(boss, queueConfig);
+    await deleteReviewJobs(boss);
+  });
+
+  afterAll(async () => {
+    await stopBoss(boss, DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_SECONDS * 1000);
+    await pool.end();
+  });
+
+  afterEach(async () => {
+    await pool.query("DELETE FROM agent_work_items WHERE owner = $1", [OWNER]);
+    await pool.query("DELETE FROM webhook_events WHERE event_name = $1", [EVENT]);
+    await deleteReviewJobs(boss);
+  });
+
+  it("deletes a failed review holder whose work item is not active", async () => {
+    const repo = `repo-${randomUUID().slice(0, 8)}`;
+    const resourceKey = prResourceKey(OWNER, repo, 9);
+    const singletonKey = reviewSingletonKey(resourceKey);
+    const webhookEventId = randomUUID();
+    const failedWorkItemId = randomUUID();
+
+    await pool.query(
+      `INSERT INTO webhook_events (id, dedupe_key, event_name, body_sha256, processing_decision)
+       VALUES ($1, $2, $3, 'sha', 'accepted')`,
+      [webhookEventId, `failed-${webhookEventId}`, EVENT],
+    );
+    await pool.query(
+      `INSERT INTO agent_work_items (
+         id, webhook_event_id, type, source, status, owner, repo, pr_number, installation_id,
+         head_sha, review_lens, resource_key, priority, payload, completed_at
+       ) VALUES (
+         $1, $2, 'review', 'auto', 'failed', $3, $4, 9, 4242, 'sha-old', 'review', $5, 0,
+         '{}'::jsonb, now()
+       )`,
+      [failedWorkItemId, webhookEventId, OWNER, repo, resourceKey],
+    );
+
+    const failedJobId = await boss.send(
+      REVIEW_QUEUE,
+      { kind: "review", workItemId: failedWorkItemId },
+      { singletonKey },
+    );
+    expect(failedJobId).toBeTruthy();
+    await pool.query(`UPDATE pgboss.job SET state = 'failed', completed_on = now() WHERE id = $1`, [
+      failedJobId,
+    ]);
+
+    await expect(reapReviewQueueOrphans(boss, pool)).resolves.toEqual({
+      released: 1,
+      staleQueuedLogged: 0,
+    });
+    await expect(boss.findJobs(REVIEW_QUEUE, { key: singletonKey })).resolves.toEqual([]);
+  });
+});

--- a/test/reviewQueueSlot.test.ts
+++ b/test/reviewQueueSlot.test.ts
@@ -235,8 +235,8 @@ describe("reapReviewQueueOrphans", () => {
       staleQueuedLogged: 1,
     });
 
-    expect(holderSql).toContain("j.singleton_key");
-    expect(holderSql).not.toContain("j.key");
+    expect(holderSql).toMatch(/\bj\.singleton_key\b/);
+    expect(holderSql).not.toMatch(/\bj\.key\b/);
 
     expect(deleteJob).toHaveBeenCalledWith(REVIEW_QUEUE, "j-fail");
     expect(cancel).toHaveBeenCalledWith(REVIEW_QUEUE, "j-orphan");
@@ -255,5 +255,21 @@ describe("reapReviewQueueOrphans", () => {
         resource_key: "acme/app#9",
       }),
     });
+  });
+
+  it("returns zeros when no holders or stale queued rows", async () => {
+    const cancel = vi.fn(async () => ({ rows: [] }));
+    const deleteJob = vi.fn(async () => ({ rows: [] }));
+    const boss = { cancel, deleteJob } as unknown as PgBoss;
+    const pool = {
+      query: vi.fn(async () => ({ rows: [] })),
+    } as unknown as Pool;
+
+    await expect(reapReviewQueueOrphans(boss, pool)).resolves.toEqual({
+      released: 0,
+      staleQueuedLogged: 0,
+    });
+    expect(deleteJob).not.toHaveBeenCalled();
+    expect(cancel).not.toHaveBeenCalled();
   });
 });

--- a/test/reviewQueueSlot.test.ts
+++ b/test/reviewQueueSlot.test.ts
@@ -193,9 +193,11 @@ describe("reapReviewQueueOrphans", () => {
     const cancel = vi.fn(async () => ({ rows: [] }));
     const deleteJob = vi.fn(async () => ({ rows: [] }));
     const boss = { cancel, deleteJob } as unknown as PgBoss;
+    let holderSql = "";
     const pool = {
       query: vi.fn(async (sql: string) => {
         if (sql.includes("FROM pgboss.job")) {
+          holderSql = sql;
           return {
             rows: [
               {
@@ -232,6 +234,9 @@ describe("reapReviewQueueOrphans", () => {
       released: 2,
       staleQueuedLogged: 1,
     });
+
+    expect(holderSql).toContain("j.singleton_key");
+    expect(holderSql).not.toContain("j.key");
 
     expect(deleteJob).toHaveBeenCalledWith(REVIEW_QUEUE, "j-fail");
     expect(cancel).toHaveBeenCalledWith(REVIEW_QUEUE, "j-orphan");


### PR DESCRIPTION
## Summary
- `reapReviewQueueOrphans` reads `j.singleton_key` from `pgboss.job`.
- The unit test requires that holder SQL and rejects `j.key`.
- The integration test deletes a failed review holder on a live `pgboss.job` table.

<!-- PR_AGENT_DESCRIPTION_BEGIN -->
## PR Agent Description

### PR Type

Bug fix, Tests

### Description

- The reaper query now selects `j.singleton_key` instead of non-existent `j.key` and prevents runtime SQL error.
- The unit test captures holder SQL and asserts it uses `singleton_key` and not `j.key`.
- The new integration test creates a failed review job with inactive work item and verifies reaper deletes it.
<!-- PR_AGENT_DESCRIPTION_END -->