### PR TITLE
Reshape AGENTS.md as a pointer index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,50 +1,20 @@
-# AGENTS.md
+# pr-agent
 
-Indexer for agents working on **pr-agent**. Open the linked source; do not treat this file as the rulebook.
+**Vocabulary** — [CONTEXT.md](CONTEXT.md). Naming a product concept.
+**Topology** — [README.md](README.md) "How It Works". Web, worker, or queue edges.
+**Feature** — [docs/features.md](docs/features.md). A `FEATURE_*` setting.
+**Knob** — [docs/configuration.md](docs/configuration.md). An env, default, or code constant.
+**Module** — [docs/development.md](docs/development.md). Layout, imports, prompts, or the topology-diagram rubric.
+**Behaviour** — [docs/operations.md](docs/operations.md). Deploy, scripts, or runtime behaviour.
+**Queue** — [docs/agent-work-ops.md](docs/agent-work-ops.md). Durable-work health or recovery.
+**ADR** — [docs/adr/](docs/adr/). A significant architecture decision.
+**Cursor Cloud** — [docs/cursor-cloud.md](docs/cursor-cloud.md). Cloud VM services or setup.
 
-## What this is
+Same PR: update every pointer whose branch matched the change.
 
-- **Navigation only** — pointers to product language, design, and deeper docs.
-- **Progressive disclosure** — read the entry you need; leave the rest closed.
-- If a rule already lives elsewhere, **link it; do not restate it**.
+## Check
 
-## Product (always)
-
-**pr-agent** — GitHub PR agent: automated reviews on `pull_request` events plus `/review`, `/describe`, `/ask`, and `/triage`. Roles: **web** (webhook intake) and **worker** (queues). Topology: [README.md](README.md) "How It Works".
-
-**Language / design:** [CONTEXT.md](CONTEXT.md) is the canonical domain vocabulary. Use those terms; do not invent synonyms.
-
-## Open when
-
-| Need                                       | Source                                                                                                                  |
-| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
-| Naming, product concepts                   | [CONTEXT.md](CONTEXT.md)                                                                                                |
-| Runtime topology                           | [README.md](README.md) "How It Works"                                                                                   |
-| Feature catalog (`FEATURE_*`)              | [docs/features.md](docs/features.md)                                                                                    |
-| Env, constants, knob checklist             | [docs/configuration.md](docs/configuration.md) · CI: [`test/settingsInventory.test.ts`](test/settingsInventory.test.ts) |
-| Modules, imports, prompts, topology rubric | [docs/development.md](docs/development.md)                                                                              |
-| Behaviour, deploy, scripts                 | [docs/operations.md](docs/operations.md)                                                                                |
-| Queue health / recovery                    | [docs/agent-work-ops.md](docs/agent-work-ops.md)                                                                        |
-| Architecture decisions                     | [docs/adr/](docs/adr/)                                                                                                  |
-| Cursor Cloud services / gotchas            | [docs/cursor-cloud.md](docs/cursor-cloud.md)                                                                            |
-
-## Same-PR doc updates
-
-| Change                                       | Update                                         |
-| -------------------------------------------- | ---------------------------------------------- |
-| Domain vocabulary or product concept         | [CONTEXT.md](CONTEXT.md)                       |
-| Env, default, or code constant               | [docs/configuration.md](docs/configuration.md) |
-| Module layout, entry points, or import rules | [docs/development.md](docs/development.md)     |
-| Runtime topology                             | [README.md](README.md) "How It Works"          |
-| Behaviour, deploy, or scripts                | [docs/operations.md](docs/operations.md)       |
-| Significant architecture decision            | new ADR under [docs/adr/](docs/adr/)           |
-| Cursor Cloud setup                           | [docs/cursor-cloud.md](docs/cursor-cloud.md)   |
-
-Skip doc updates when none of the above apply.
-
-## Before ship (local CI gate)
-
-Run the backend **check** job from [`.github/workflows/ci.yml`](.github/workflows/ci.yml) locally before every push or PR update. Do not ship a fix that fails these steps.
+Before every push, run the backend check job from [`.github/workflows/ci.yml`](.github/workflows/ci.yml):
 
 ```bash
 nub run check:effect-versions
@@ -54,4 +24,4 @@ nub run test
 nub run build
 ```
 
-`check:code` is typecheck + lint + fmt. Fix format with `nub run fmt` when `fmt:check` fails. Integration and docker jobs need services; run `nub run test:integration` when the change touches durable work, webhooks, or DB paths.
+Done when every command exits 0. Format with `nub run fmt` if `fmt:check` fails. Also run `nub run test:integration` when the change touches durable work, webhooks, or DB paths.

--- a/skills/authoring-pr-agent-rules/SKILL.md
+++ b/skills/authoring-pr-agent-rules/SKILL.md
@@ -114,7 +114,7 @@ For every new `.mdc`:
 | "Duplicating existing rules is safer under time pressure" | Duplicates waste the 20-file cap and dilute attention. Inventory first.                |
 | "Fill all remaining slots so the stakeholder sees volume" | Empty slots beat weak rules. Stop when the quality bar fails.                          |
 | "Bodies over 1000 chars are fine; more detail helps"      | Excess is truncated at load — silent loss. Cut to ≤1000.                               |
-| "Update AGENTS.md instead; it's always applied"           | AGENTS.md is navigation (`AGENTS.md` says so). Binding review prefs are `.mdc`.        |
+| "Update AGENTS.md instead; it's always applied"           | AGENTS.md is the pointer index. Binding review prefs are `.pr-agent/*.mdc`.            |
 
 ## Red flags — STOP
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- AGENTS.md lists one leading-word pointer per doc and one same-PR write rule.
- Check runs the backend job from ci.yml and names the fmt and integration gotchas.
- The authoring skill names `.pr-agent/*.mdc` as the binding preference path.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bacc62e9-83b3-494e-99eb-95650a9d2b17?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bacc62e9-83b3-494e-99eb-95650a9d2b17&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- PR_AGENT_DESCRIPTION_BEGIN -->
## PR Agent Description

### PR Type

Documentation

### Description

- The change rewrites AGENTS.md into a compact pointer index that links Vocabulary, Topology, Feature, Knob and other docs.
- It replaces long tables and descriptions with a short list and a same-PR doc update rule.
- It shortens the Check section but keeps the backend check job, build, test, and integration guidance.
- It fixes SKILL.md to call AGENTS.md the pointer index and to point review prefs to `.pr-agent/*.mdc`.
<!-- PR_AGENT_DESCRIPTION_END -->