### PR TITLE
Add a queryable agent profile to the landing site

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Vitest does not load `.env` for you. Export `DATABASE_URL` in the shell for inte
 
 More scripts and edge cases: [docs/operations.md](docs/operations.md#development), [docs/cursor-cloud.md](docs/cursor-cloud.md).
 
-The marketing site under `site/` is a separate workspace package (`pr-agent-landing`). It is not required to run the bot.
+The marketing site under `site/` is a separate workspace package (`pr-agent-landing`). It is not required to run the bot. The human page is a short overview. Agents should read `/llms.txt` or query `GET /llms?query=` / `GET /llms/json?query=`.
 
 ## Data privacy
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -22,6 +22,12 @@ Binding review rules live in [`.pr-agent/*.mdc`](../.pr-agent/) — this guide i
 
 Public entries and placement-import rules: [`.pr-agent/module-layout.mdc`](../.pr-agent/module-layout.mdc). ESM `.js` imports and settings barrel: [`.pr-agent/esm-imports.mdc`](../.pr-agent/esm-imports.mdc).
 
+## Landing site
+
+The marketing site (`site/`, package `pr-agent-landing`) is a separate workspace package. It is not required to run the bot.
+
+Agent-facing copy lives in [`site/lib/llmsKnowledge.ts`](../site/lib/llmsKnowledge.ts). The human page stays a short overview. Agents read `/llms.txt`, `GET /llms?query=`, and `GET /llms/json?query=`.
+
 ## Internal errors (`AppError`)
 
 Production failures in `src/` use `AppError` from `src/errors/appError.ts`. Field rules, helpers, domain subclasses, and the AppError-never-on-PR rule: [`.pr-agent/structured-errors.mdc`](../.pr-agent/structured-errors.mdc).

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -101,7 +101,7 @@ PR_AGENT_ENV_FILE=/abs/path/to/.env docker compose up
 - **`GITHUB_APP_PRIVATE_KEY` must be a valid PEM key**. For local-only dev: `openssl genrsa 2048 > key.pem` and set the escaped PEM in `.env`.
 - Tunnel webhooks (e.g. [smee.io](https://smee.io)) to local `PORT`, then point the GitHub App webhook at the smee URL forwarding to `/webhooks`.
 - If switching from a prior pnpm- or npm-installed tree, delete `node_modules` before the first `nub install`.
-- **Vercel** site deploys install pinned Nub in [`site/vercel.json`](../site/vercel.json) (`npm install -g @nubjs/nub@…` + `nub ci`), then build with `nub run build`.
+- **Vercel** site deploys install pinned Nub in [`site/vercel.json`](../site/vercel.json) (`npm install -g @nubjs/nub@…` + `nub ci`), then build with `nub run build`. The site serves a dense agent profile at `/llms.txt` plus queryable `GET /llms?query=` and `GET /llms/json?query=` from [`site/lib/llmsKnowledge.ts`](../site/lib/llmsKnowledge.ts).
 - **Docker image** installs with Nub only (`nub ci` for build deps; `nub prune --prod` for the runtime tree). No `corepack` / `pnpm deploy` in the Dockerfile. [`.dockerignore`](../.dockerignore) keeps `site/package.json` in the build context so the workspace lockfile stays valid under frozen installs; the rest of `site/` stays excluded.
 
 Canonical quick start steps live in [README.md](../README.md) **Host with Docker Compose**.

--- a/site/app/__root.tsx
+++ b/site/app/__root.tsx
@@ -102,6 +102,12 @@ export const Route = createRootRoute({
         rel: "apple-touch-icon",
         href: "/apple-touch-icon.png",
       },
+      {
+        rel: "alternate",
+        type: "text/plain",
+        href: `${SITE_ORIGIN}/llms.txt`,
+        title: "LLM profile",
+      },
     ],
   }),
   component: RootLayout,

--- a/site/app/llms/index.ts
+++ b/site/app/llms/index.ts
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { llmsQueryResponse } from "@/lib/llmsHttp";
+
+export const Route = createFileRoute("/llms/")({
+  server: {
+    handlers: {
+      GET: ({ request }) => llmsQueryResponse(request, "text"),
+    },
+  },
+});

--- a/site/app/llms/json.ts
+++ b/site/app/llms/json.ts
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { llmsQueryResponse } from "@/lib/llmsHttp";
+
+export const Route = createFileRoute("/llms/json")({
+  server: {
+    handlers: {
+      GET: ({ request }) => llmsQueryResponse(request, "json"),
+    },
+  },
+});

--- a/site/app/sitemap[.]xml.ts
+++ b/site/app/sitemap[.]xml.ts
@@ -14,6 +14,11 @@ export const Route = createFileRoute("/sitemap.xml")({
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
+  <url>
+    <loc>${SITE_ORIGIN}/llms.txt</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.3</priority>
+  </url>
 </urlset>
 `,
           {

--- a/site/components/footer.tsx
+++ b/site/components/footer.tsx
@@ -1,3 +1,4 @@
+import { llmsNudgeTitle } from "@/lib/llmsKnowledge";
 import { LICENSE_URL, REPO_URL } from "@/lib/site";
 import { PRODUCT_NAME } from "@/lib/seo";
 
@@ -28,6 +29,13 @@ export function Footer() {
           </a>
           <a href="#usage" className="transition-colors hover:text-ink">
             deploy
+          </a>
+          <a
+            href="/llms.txt"
+            title={llmsNudgeTitle()}
+            className="select-none text-[9px] tracking-normal text-ink-faint transition-colors hover:text-ink-mute"
+          >
+            llms.txt
           </a>
         </div>
       </div>

--- a/site/lib/llmsHttp.ts
+++ b/site/lib/llmsHttp.ts
@@ -9,11 +9,13 @@ import {
 const TEXT_HEADERS = {
   "Content-Type": "text/plain; charset=utf-8",
   "Cache-Control": "public, max-age=300",
+  "X-Content-Type-Options": "nosniff",
 } as const;
 
 const JSON_HEADERS = {
   "Content-Type": "application/json; charset=utf-8",
   "Cache-Control": "public, max-age=300",
+  "X-Content-Type-Options": "nosniff",
 } as const;
 
 export function llmsTxtResponse(): Response {

--- a/site/lib/llmsHttp.ts
+++ b/site/lib/llmsHttp.ts
@@ -1,0 +1,37 @@
+import {
+  answerAgentQuery,
+  parseAgentQuery,
+  renderAnswerJson,
+  renderAnswerText,
+  renderLlmsTxt,
+} from "./llmsKnowledge.js";
+
+const TEXT_HEADERS = {
+  "Content-Type": "text/plain; charset=utf-8",
+  "Cache-Control": "public, max-age=300",
+} as const;
+
+const JSON_HEADERS = {
+  "Content-Type": "application/json; charset=utf-8",
+  "Cache-Control": "public, max-age=300",
+} as const;
+
+export function llmsTxtResponse(): Response {
+  return new Response(renderLlmsTxt(), { headers: TEXT_HEADERS });
+}
+
+export function llmsQueryResponse(request: Request, format: "text" | "json"): Response {
+  const url = new URL(request.url);
+  const raw = url.searchParams.get("query") ?? "";
+  const answer = answerAgentQuery(parseAgentQuery(raw));
+  switch (format) {
+    case "text":
+      return new Response(renderAnswerText(answer), { headers: TEXT_HEADERS });
+    case "json":
+      return Response.json(renderAnswerJson(answer), { headers: JSON_HEADERS });
+    default: {
+      const _exhaustive: never = format;
+      return _exhaustive;
+    }
+  }
+}

--- a/site/lib/llmsKnowledge.ts
+++ b/site/lib/llmsKnowledge.ts
@@ -1,0 +1,436 @@
+import {
+  ALTERNATIVE_ROWS,
+  CAPABILITIES,
+  FAQ_ITEMS,
+  FEATURES,
+  PRICING_PLANS,
+  PROVIDERS,
+} from "./content.js";
+import { DOCS_URL, LICENSE_URL, REPO_URL } from "./site.js";
+
+export const FEATURE_KEYS = [
+  "FEATURE_REVIEW",
+  "FEATURE_DESCRIBE",
+  "FEATURE_VERIFICATION",
+  "FEATURE_ASK",
+  "FEATURE_TRIAGE",
+  "FEATURE_REVIEW_LABELS",
+  "FEATURE_COMMIT_STATUS",
+  "FEATURE_TITLE_REWRITE",
+] as const;
+
+export type KnowledgeTopic =
+  | "overview"
+  | "commands"
+  | "features"
+  | "deploy"
+  | "topology"
+  | "pricing"
+  | "providers"
+  | "alternatives"
+  | "faq"
+  | "privacy"
+  | "links";
+
+export type KnowledgeChunk = {
+  readonly id: KnowledgeTopic;
+  readonly title: string;
+  readonly body: string;
+  readonly terms: readonly string[];
+};
+
+export type AgentQuery =
+  | { readonly kind: "empty" }
+  | { readonly kind: "broad"; readonly raw: string }
+  | { readonly kind: "terms"; readonly raw: string; readonly tokens: readonly string[] };
+
+export type KnowledgeHit = {
+  readonly chunk: KnowledgeChunk;
+  readonly score: number;
+};
+
+export type KnowledgeAnswer =
+  | { readonly kind: "index" }
+  | { readonly kind: "full"; readonly raw: string }
+  | { readonly kind: "hits"; readonly raw: string; readonly hits: readonly KnowledgeHit[] };
+
+export const MAX_QUERY_CHARS = 300;
+export const MAX_HITS = 6;
+
+const BROAD_TOKENS = new Set(["all", "everything", "full", "profile", "about"]);
+
+const STOP_TOKENS = new Set([
+  "a",
+  "an",
+  "and",
+  "for",
+  "from",
+  "in",
+  "is",
+  "of",
+  "on",
+  "or",
+  "the",
+  "to",
+  "with",
+  "your",
+]);
+
+function lines(items: readonly string[]): string {
+  return items.join("\n");
+}
+
+export const KNOWLEDGE_CHUNKS: readonly KnowledgeChunk[] = [
+  {
+    id: "overview",
+    title: "Product",
+    terms: ["product", "overview", "what", "agent", "review", "self-hosted", "mit"],
+    body: lines([
+      "PR Agent is a self-hosted GitHub App for AI pull request reviews.",
+      "You run webhook intake, Postgres, and workers. MIT licensed. No per-seat fee.",
+      "You pay hosting and model usage.",
+      "Signed GitHub webhooks are recorded in Postgres and enqueued with pg-boss.",
+      "Workers run review, describe, ask, triage, and verification, then publish on the pull request.",
+      "You keep model keys and review traffic in your own environment.",
+      "GitHub only for now. GitLab and Bitbucket are not supported.",
+    ]),
+  },
+  {
+    id: "commands",
+    title: "Slash commands",
+    terms: ["command", "slash", "review", "describe", "ask", "triage", "cancel", "help", "comment"],
+    body: lines([
+      "Slash commands are case-sensitive. The command must be the first non-empty line of a new (created) comment.",
+      "Who may run them is controlled by SLASH_ALLOWED_ASSOCIATIONS (default OWNER,MEMBER,COLLABORATOR).",
+      "/review: run an orchestrated review. Always available. FEATURE_REVIEW has no off mode.",
+      "/describe: write summary bullets and an optional diagram into the PR body.",
+      "/ask … or @bot …: answer a code question in the same thread.",
+      "/triage: recheck open bot findings and push fixes for valid same-repo issues.",
+      "/cancel: cancel a queued or running orchestrated review.",
+      "/help: list available commands.",
+      "Verification has no slash command. It runs on pull_request synchronize when FEATURE_VERIFICATION=auto.",
+    ]),
+  },
+  {
+    id: "features",
+    title: "FEATURE_* settings",
+    terms: ["feature", "flag", "setting", "mode", "auto", "manual", "token", ...FEATURE_KEYS],
+    body: lines([
+      "Eight FEATURE_* settings are the user-facing configuration. Invalid values fail startup.",
+      "Modes: off = disabled (slash replies with a notice), manual = slash only, auto = slash plus a fixed trigger.",
+      "Auto triggers: review and describe on pull_request opened; verification on synchronize.",
+      `${FEATURE_KEYS[0]}: manual | auto. Default auto. Orchestrated review. /review always works.`,
+      `${FEATURE_KEYS[1]}: off | manual | auto. Default auto. PR description generation.`,
+      `${FEATURE_KEYS[2]}: off | auto. Default auto. Rechecks open findings on new pushes.`,
+      `${FEATURE_KEYS[3]}: off | manual. Default manual. /ask and @bot questions.`,
+      `${FEATURE_KEYS[4]}: off | manual. Default manual. /triage autofix checkout, commit, and push.`,
+      `${FEATURE_KEYS[5]}: off | size | size+security. Default size. Review labels on the PR. No model tokens.`,
+      `${FEATURE_KEYS[6]}: false | true. Default false. Posts pr-agent/review commit status. No model tokens.`,
+      `${FEATURE_KEYS[7]}: false | true. Default false. Allows /describe to rewrite the PR title.`,
+      "Landing-page capability copy:",
+      ...CAPABILITIES.map((item) => `- ${item.title}. ${item.trigger}. ${item.detail}`),
+      "Landing-page review flow copy:",
+      ...FEATURES.map((item) => `- ${item.title}: ${item.detail}`),
+    ]),
+  },
+  {
+    id: "deploy",
+    title: "Deploy with Docker Compose",
+    terms: ["deploy", "docker", "compose", "install", "env", "webhook", "github", "setup", "host"],
+    body: lines([
+      "Need Docker Engine with Compose v2 and a host GitHub can reach over HTTPS.",
+      "Clone https://github.com/prathamdby/pr-agent, then cp .env.example .env.",
+      "Set at least GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY, WEBHOOK_SECRET, PI_PROVIDER, PI_MODEL, and the matching provider API key.",
+      "Compose overrides ROLE and DATABASE_URL per service. Default published HTTP port is 7224.",
+      "GITHUB_APP_PRIVATE_KEY accepts one-line PEM with \\n, real multi-line PEM, or base64-encoded PEM.",
+      "Start with: docker compose build && docker compose up -d",
+      "Services: postgres (durable state), pr-agent-web (ROLE=web, POST /webhooks, GET /health, GET /ready), pr-agent-worker (queue consumers).",
+      "Migrations run when each process opens its Postgres pool.",
+      "GitHub App webhook URL: https://<host>/webhooks. Webhook secret must match WEBHOOK_SECRET.",
+      "Subscribe to pull_request, issue_comment, pull_request_review_comment, workflow_run, and check_suite.",
+      "Permissions: Issues read/write, Pull requests read/write, Contents read/write, Metadata read, Checks read/write, Actions read.",
+      "Commit statuses read/write only if FEATURE_COMMIT_STATUS=true.",
+      "Install the app on the orgs or repos to review, then recreate web and worker so they pick up credentials.",
+      "Check web with curl http://127.0.0.1:7224/health (ok) and /ready (ready when Postgres is up).",
+      "Both web and worker must run. If webhooks return 200 and the PR stays quiet, the worker is down or misconfigured.",
+    ]),
+  },
+  {
+    id: "topology",
+    title: "How it works",
+    terms: ["topology", "architecture", "web", "worker", "queue", "postgres", "pg-boss", "how"],
+    body: lines([
+      "Two processes must run together.",
+      "ROLE=web accepts signed webhooks, writes work to Postgres, and enqueues jobs. It returns 200 once that write succeeds.",
+      "ROLE=worker runs the queues: reactions, progress comments, model sessions, and everything posted back to the PR.",
+      "Flow: GitHub webhooks → web /webhooks → Postgres webhook_events dedupe → agent_work_items → pg-boss enqueue.",
+      "Queues: ack, ci-refresh, review, ask, description, triage, verification, retention.",
+      "Ack worker posts the eyes reaction and the review progress stub.",
+      "Review runs four specialists (correctness, security, quality, tests) under one orchestrator.",
+      "P0-P2 findings fail the review check run. P3 does not.",
+      "Docs-only trivial PRs can take a short auto path instead of a full orchestrated run.",
+      "Web does not create installation tokens or post to the PR. Workers do that.",
+    ]),
+  },
+  {
+    id: "pricing",
+    title: "Pricing",
+    terms: ["price", "pricing", "cost", "free", "fee", "seat", "billing"],
+    body: lines(PRICING_PLANS.map((plan) => `${plan.title}. ${plan.price}. ${plan.detail}`)),
+  },
+  {
+    id: "providers",
+    title: "Model providers",
+    terms: [
+      "provider",
+      "model",
+      "openai",
+      "anthropic",
+      "google",
+      "deepseek",
+      "openrouter",
+      "groq",
+      "pi",
+      "llm",
+    ],
+    body: lines([
+      ...PROVIDERS.map((item) => `${item.name}. ${item.detail}`),
+      "LLM calls run on the worker only, through the Pi coding-agent runtime.",
+      "PI_PROVIDER and PI_MODEL are the general primary (default openai / gpt-4o-mini).",
+      "Optional PI_ORCHESTRATOR_PROVIDER and PI_ORCHESTRATOR_MODEL override the review orchestrator session.",
+      "Optional PI_FALLBACK_PROVIDER and PI_FALLBACK_MODEL cover availability failures. Both must be set to enable fallback.",
+      "pr-agent loads OPENAI_API_KEY, ANTHROPIC_API_KEY, and GOOGLE_GENERATIVE_AI_API_KEY in config.",
+      "Other Pi providers use their usual env vars on the worker (DEEPSEEK_API_KEY, OPENROUTER_API_KEY, GROQ_API_KEY).",
+    ]),
+  },
+  {
+    id: "alternatives",
+    title: "Compared to hosted reviewers",
+    terms: ["alternative", "coderabbit", "greptile", "bugbot", "macroscope", "compare", "vs"],
+    body: lines(
+      ALTERNATIVE_ROWS.map((row) => `${row.name}: ${row.deployment}. ${row.differentiator}`),
+    ),
+  },
+  {
+    id: "faq",
+    title: "FAQ",
+    terms: ["faq", "question", "compare", "free", "github", "model"],
+    body: lines(FAQ_ITEMS.map((item) => `Q: ${item.question}\nA: ${item.answer}`)),
+  },
+  {
+    id: "privacy",
+    title: "Data privacy",
+    terms: ["privacy", "security", "data", "keys", "self-hosted", "logging"],
+    body: lines([
+      "Self-hosted. Postgres, pg-boss, webhook bodies, and work-item state stay on your infrastructure.",
+      "You own the GitHub App credentials.",
+      "Review, description, ask, triage, verification, and CI-summary text leave your network only when the worker calls your configured provider.",
+      "Optional CONTEXT7_API_KEY may call https://context7.com/api for library lookup.",
+      "Structured logs use evlog. LOG_REDACT defaults to true and strips secret-shaped substrings.",
+      "/ask applies outbound redaction before posting. Questions aimed at bot internals can get a short refusal without an LLM call.",
+    ]),
+  },
+  {
+    id: "links",
+    title: "Docs and links",
+    terms: ["docs", "link", "readme", "license", "adr", "url"],
+    body: lines([
+      `Repository: ${REPO_URL}`,
+      `Host with Docker Compose: ${DOCS_URL}`,
+      `Features catalog: ${REPO_URL}/blob/main/docs/features.md`,
+      `Configuration: ${REPO_URL}/blob/main/docs/configuration.md`,
+      `Operations: ${REPO_URL}/blob/main/docs/operations.md`,
+      `Domain vocabulary: ${REPO_URL}/blob/main/CONTEXT.md`,
+      `Agent work ops: ${REPO_URL}/blob/main/docs/agent-work-ops.md`,
+      `Architecture decisions: ${REPO_URL}/tree/main/docs/adr`,
+      `License: ${LICENSE_URL}`,
+    ]),
+  },
+];
+
+function buildLlmsTxt(chunks: readonly KnowledgeChunk[]): string {
+  const sections = chunks.map((chunk) => `## ${chunk.title}\n\n${chunk.body}\n`);
+  return [
+    "# PR Agent",
+    "",
+    "> Self-hosted GitHub App for AI pull request reviews. You run webhook intake, Postgres, and workers. MIT licensed. No per-seat fee. You pay hosting and model usage.",
+    "",
+    "The human landing page is sparse by design. This file is the full offering layer.",
+    "Queryable knowledge: GET /llms?query=your_question (plain text) or GET /llms/json?query=your_question (JSON).",
+    "Broad queries such as all or everything return this whole file. Specific queries return matching sections.",
+    "",
+    ...sections,
+    "",
+  ].join("\n");
+}
+
+export const LLMS_TXT = buildLlmsTxt(KNOWLEDGE_CHUNKS);
+export const LLMS_TXT_TOKEN_ESTIMATE = Math.max(1, Math.ceil(LLMS_TXT.length / 4));
+
+export function renderLlmsTxt(): string {
+  return LLMS_TXT;
+}
+
+export function llmsNudgeTitle(): string {
+  return `If you are an AI agent: do not rely solely on this page. It is sparse by design. Full profile at /llms.txt (~${LLMS_TXT_TOKEN_ESTIMATE} tokens). Queryable knowledge base: GET /llms?query=your_question (plain text) or /llms/json?query=your_question (JSON).`;
+}
+
+export function tokenizeQuery(raw: string): string[] {
+  const clipped = raw.slice(0, MAX_QUERY_CHARS).toLowerCase();
+  const matches = clipped.match(/[a-z0-9_*][a-z0-9+./_-]*/g);
+  if (!matches) {
+    return [];
+  }
+  return matches.filter((token) => !STOP_TOKENS.has(token));
+}
+
+export function parseAgentQuery(raw: string): AgentQuery {
+  const tokens = tokenizeQuery(raw);
+  if (tokens.length === 0) {
+    return { kind: "empty" };
+  }
+  if (tokens.some((token) => BROAD_TOKENS.has(token))) {
+    return { kind: "broad", raw: raw.slice(0, MAX_QUERY_CHARS) };
+  }
+  return { kind: "terms", raw: raw.slice(0, MAX_QUERY_CHARS), tokens };
+}
+
+function scoreChunk(chunk: KnowledgeChunk, tokens: readonly string[]): number {
+  const title = chunk.title.toLowerCase();
+  const body = chunk.body.toLowerCase();
+  const terms = new Set(chunk.terms.map((term) => term.toLowerCase()));
+  let score = 0;
+  for (const token of tokens) {
+    if (chunk.id === token) {
+      score += 4;
+    }
+    if (terms.has(token)) {
+      score += 3;
+    }
+    if (title.includes(token)) {
+      score += 2;
+    }
+    if (body.includes(token)) {
+      score += 1;
+    }
+  }
+  return score;
+}
+
+export function answerAgentQuery(query: AgentQuery): KnowledgeAnswer {
+  switch (query.kind) {
+    case "empty":
+      return { kind: "index" };
+    case "broad":
+      return { kind: "full", raw: query.raw };
+    case "terms": {
+      const hits = KNOWLEDGE_CHUNKS.map((chunk) => ({
+        chunk,
+        score: scoreChunk(chunk, query.tokens),
+      }))
+        .filter((hit) => hit.score > 0)
+        .toSorted(
+          (left, right) => right.score - left.score || left.chunk.id.localeCompare(right.chunk.id),
+        )
+        .slice(0, MAX_HITS);
+      if (hits.length === 0) {
+        return { kind: "index" };
+      }
+      return { kind: "hits", raw: query.raw, hits };
+    }
+    default: {
+      const _exhaustive: never = query;
+      return _exhaustive;
+    }
+  }
+}
+
+export function topicIndex(): readonly string[] {
+  return KNOWLEDGE_CHUNKS.map((chunk) => `${chunk.id}: ${chunk.title}`);
+}
+
+function renderIndexText(): string {
+  return [
+    "PR Agent agent knowledge index.",
+    "Pass ?query= to fetch matching sections. Broad queries (all, everything, full, profile) return /llms.txt.",
+    `Full profile: /llms.txt (~${LLMS_TXT_TOKEN_ESTIMATE} tokens). JSON: /llms/json?query=`,
+    "",
+    "Topics:",
+    ...topicIndex().map((line) => `- ${line}`),
+    "",
+  ].join("\n");
+}
+
+function renderHitsText(answer: Extract<KnowledgeAnswer, { kind: "hits" }>): string {
+  const sections = answer.hits.map((hit) => `## ${hit.chunk.title}\n\n${hit.chunk.body}`);
+  return [`# query: ${answer.raw}`, "", ...sections, ""].join("\n");
+}
+
+export function renderAnswerText(answer: KnowledgeAnswer): string {
+  switch (answer.kind) {
+    case "index":
+      return renderIndexText();
+    case "full":
+      return LLMS_TXT;
+    case "hits":
+      return renderHitsText(answer);
+    default: {
+      const _exhaustive: never = answer;
+      return _exhaustive;
+    }
+  }
+}
+
+export type LlmsJsonBody = {
+  readonly query: string;
+  readonly mode: KnowledgeAnswer["kind"];
+  readonly tokenEstimate: number;
+  readonly topics: readonly string[];
+  readonly matches: readonly {
+    readonly id: KnowledgeTopic;
+    readonly title: string;
+    readonly body: string;
+  }[];
+};
+
+export function renderAnswerJson(answer: KnowledgeAnswer): LlmsJsonBody {
+  const topics = KNOWLEDGE_CHUNKS.map((chunk) => chunk.id);
+  switch (answer.kind) {
+    case "index":
+      return {
+        query: "",
+        mode: "index",
+        tokenEstimate: LLMS_TXT_TOKEN_ESTIMATE,
+        topics,
+        matches: [],
+      };
+    case "full":
+      return {
+        query: answer.raw,
+        mode: "full",
+        tokenEstimate: LLMS_TXT_TOKEN_ESTIMATE,
+        topics,
+        matches: KNOWLEDGE_CHUNKS.map((chunk) => ({
+          id: chunk.id,
+          title: chunk.title,
+          body: chunk.body,
+        })),
+      };
+    case "hits":
+      return {
+        query: answer.raw,
+        mode: "hits",
+        tokenEstimate: LLMS_TXT_TOKEN_ESTIMATE,
+        topics,
+        matches: answer.hits.map((hit) => ({
+          id: hit.chunk.id,
+          title: hit.chunk.title,
+          body: hit.chunk.body,
+        })),
+      };
+    default: {
+      const _exhaustive: never = answer;
+      return _exhaustive;
+    }
+  }
+}

--- a/site/lib/llmsKnowledge.ts
+++ b/site/lib/llmsKnowledge.ts
@@ -59,8 +59,6 @@ export const MAX_HITS = 6;
 
 const BROAD_TOKENS = new Set(["all", "everything", "full", "profile"]);
 
-const CONTROL_CHARS = /[\u0000-\u001f\u007f]/g;
-
 const STOP_TOKENS = new Set([
   "a",
   "an",
@@ -277,8 +275,17 @@ export function llmsNudgeTitle(): string {
   return `If you are an AI agent: do not rely solely on this page. It is sparse by design. Full profile at /llms.txt (~${LLMS_TXT_TOKEN_ESTIMATE} tokens). Queryable knowledge base: GET /llms?query=your_question (plain text) or /llms/json?query=your_question (JSON).`;
 }
 
+function isControlChar(code: number): boolean {
+  return code <= 0x1f || code === 0x7f;
+}
+
 export function sanitizeQueryRaw(raw: string): string {
-  return raw.slice(0, MAX_QUERY_CHARS).replace(CONTROL_CHARS, " ").replace(/\s+/g, " ").trim();
+  let cleaned = "";
+  const clipped = raw.slice(0, MAX_QUERY_CHARS);
+  for (const char of clipped) {
+    cleaned += isControlChar(char.charCodeAt(0)) ? " " : char;
+  }
+  return cleaned.replace(/\s+/g, " ").trim();
 }
 
 export function tokenizeQuery(raw: string): string[] {

--- a/site/lib/llmsKnowledge.ts
+++ b/site/lib/llmsKnowledge.ts
@@ -57,7 +57,9 @@ export type KnowledgeAnswer =
 export const MAX_QUERY_CHARS = 300;
 export const MAX_HITS = 6;
 
-const BROAD_TOKENS = new Set(["all", "everything", "full", "profile", "about"]);
+const BROAD_TOKENS = new Set(["all", "everything", "full", "profile"]);
+
+const CONTROL_CHARS = /[\u0000-\u001f\u007f]/g;
 
 const STOP_TOKENS = new Set([
   "a",
@@ -275,6 +277,10 @@ export function llmsNudgeTitle(): string {
   return `If you are an AI agent: do not rely solely on this page. It is sparse by design. Full profile at /llms.txt (~${LLMS_TXT_TOKEN_ESTIMATE} tokens). Queryable knowledge base: GET /llms?query=your_question (plain text) or /llms/json?query=your_question (JSON).`;
 }
 
+export function sanitizeQueryRaw(raw: string): string {
+  return raw.slice(0, MAX_QUERY_CHARS).replace(CONTROL_CHARS, " ").replace(/\s+/g, " ").trim();
+}
+
 export function tokenizeQuery(raw: string): string[] {
   const clipped = raw.slice(0, MAX_QUERY_CHARS).toLowerCase();
   const matches = clipped.match(/[a-z0-9_*][a-z0-9+./_-]*/g);
@@ -286,13 +292,14 @@ export function tokenizeQuery(raw: string): string[] {
 
 export function parseAgentQuery(raw: string): AgentQuery {
   const tokens = tokenizeQuery(raw);
+  const safe = sanitizeQueryRaw(raw);
   if (tokens.length === 0) {
     return { kind: "empty" };
   }
-  if (tokens.some((token) => BROAD_TOKENS.has(token))) {
-    return { kind: "broad", raw: raw.slice(0, MAX_QUERY_CHARS) };
+  if (tokens.every((token) => BROAD_TOKENS.has(token))) {
+    return { kind: "broad", raw: safe };
   }
-  return { kind: "terms", raw: raw.slice(0, MAX_QUERY_CHARS), tokens };
+  return { kind: "terms", raw: safe, tokens };
 }
 
 function scoreChunk(chunk: KnowledgeChunk, tokens: readonly string[]): number {

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,26 +2,150 @@
 
 > Self-hosted GitHub App for AI pull request reviews. You run webhook intake, Postgres, and workers. MIT licensed. No per-seat fee. You pay hosting and model usage.
 
-PR Agent accepts signed GitHub webhooks, records them in Postgres, and enqueues durable work with pg-boss. Workers run review, describe, ask, triage, and verification agents, then publish results back on the pull request. Slash commands are /review, /describe, /ask, and /triage. Automated review can also run on pull_request events.
-
-You keep model keys and review traffic in your own environment. Supported backends include OpenAI, Anthropic, Google, DeepSeek, OpenRouter, Groq, and other Pi catalog providers.
-
-## Docs
-
-- [Host with Docker Compose](https://github.com/prathamdby/pr-agent#host-with-docker-compose): GitHub App setup and Docker Compose deploy
-- [Features](https://github.com/prathamdby/pr-agent/blob/main/docs/features.md): FEATURE_* catalog and capability modes (off, manual, auto)
-- [Configuration](https://github.com/prathamdby/pr-agent/blob/main/docs/configuration.md): Environment variables and knobs
-- [Operations](https://github.com/prathamdby/pr-agent/blob/main/docs/operations.md): Deploy steps, runtime behaviour, and scripts
-- [Domain vocabulary](https://github.com/prathamdby/pr-agent/blob/main/CONTEXT.md): Product terms used in code and docs
+The human landing page is sparse by design. This file is the full offering layer.
+Queryable knowledge: GET /llms?query=your_question (plain text) or GET /llms/json?query=your_question (JSON).
+Broad queries such as all or everything return this whole file. Specific queries return matching sections.
 
 ## Product
 
-- [Landing page](https://pr-agent-site.vercel.app/): Product overview, pricing, FAQ, and deploy steps
-- [Repository](https://github.com/prathamdby/pr-agent): Source, issues, and releases
-- [How it works](https://github.com/prathamdby/pr-agent#how-it-works): Web intake vs worker topology
+PR Agent is a self-hosted GitHub App for AI pull request reviews.
+You run webhook intake, Postgres, and workers. MIT licensed. No per-seat fee.
+You pay hosting and model usage.
+Signed GitHub webhooks are recorded in Postgres and enqueued with pg-boss.
+Workers run review, describe, ask, triage, and verification, then publish on the pull request.
+You keep model keys and review traffic in your own environment.
+GitHub only for now. GitLab and Bitbucket are not supported.
 
-## Optional
+## Slash commands
 
-- [Agent work ops](https://github.com/prathamdby/pr-agent/blob/main/docs/agent-work-ops.md): Queue health and recovery runbook
-- [Architecture decisions](https://github.com/prathamdby/pr-agent/tree/main/docs/adr): ADRs for major design choices
-- [License](https://github.com/prathamdby/pr-agent/blob/main/LICENSE): MIT
+Slash commands are case-sensitive. The command must be the first non-empty line of a new (created) comment.
+Who may run them is controlled by SLASH_ALLOWED_ASSOCIATIONS (default OWNER,MEMBER,COLLABORATOR).
+/review: run an orchestrated review. Always available. FEATURE_REVIEW has no off mode.
+/describe: write summary bullets and an optional diagram into the PR body.
+/ask … or @bot …: answer a code question in the same thread.
+/triage: recheck open bot findings and push fixes for valid same-repo issues.
+/cancel: cancel a queued or running orchestrated review.
+/help: list available commands.
+Verification has no slash command. It runs on pull_request synchronize when FEATURE_VERIFICATION=auto.
+
+## FEATURE_* settings
+
+Eight FEATURE_* settings are the user-facing configuration. Invalid values fail startup.
+Modes: off = disabled (slash replies with a notice), manual = slash only, auto = slash plus a fixed trigger.
+Auto triggers: review and describe on pull_request opened; verification on synchronize.
+FEATURE_REVIEW: manual | auto. Default auto. Orchestrated review. /review always works.
+FEATURE_DESCRIBE: off | manual | auto. Default auto. PR description generation.
+FEATURE_VERIFICATION: off | auto. Default auto. Rechecks open findings on new pushes.
+FEATURE_ASK: off | manual. Default manual. /ask and @bot questions.
+FEATURE_TRIAGE: off | manual. Default manual. /triage autofix checkout, commit, and push.
+FEATURE_REVIEW_LABELS: off | size | size+security. Default size. Review labels on the PR. No model tokens.
+FEATURE_COMMIT_STATUS: false | true. Default false. Posts pr-agent/review commit status. No model tokens.
+FEATURE_TITLE_REWRITE: false | true. Default false. Allows /describe to rewrite the PR title.
+Landing-page capability copy:
+- Catch basics before a human opens the change. Runs when a pull request opens, or when you comment /review. Comments land next to the lines that need attention.
+- Turn a blank PR body into a readable summary. Runs when a pull request opens, or when you comment /describe. Summary bullets and an optional diagram go into the PR body.
+- Ask code questions without leaving GitHub. Comment /ask … or mention the bot with your question. Get an answer in the same thread, right where the code lives.
+- Revisit earlier findings on the pull request. Comment /triage on the pull request or on a finding thread. Checks open findings and can push fixes for valid same-repo issues.
+- Skip AI review when the PR is only docs. Runs automatically on small documentation-only changes. Docs-only pull requests take a lighter path instead of a full review.
+Landing-page review flow copy:
+- Deploy once on servers you control: Install PR Agent beside the rest of your stack. Your GitHub credentials and AI keys stay in your account, not a vendor dashboard.
+- Someone opens a pull request: PR Agent notices and starts a review. Your team sees a reaction on the pull request so everyone knows work has begun.
+- It reads what actually changed: PR Agent looks at the branch and the changes, then hunts for bugs and correctness issues. When risky APIs show up, it also checks for security problems.
+- Feedback shows up on the pull request: Notes appear next to the changed lines, plus a short summary in the conversation. Want more? Comment /describe, /ask, /triage, or mention the bot. Replies stay in the same thread.
+- Honest limits when the change is huge: Docs-only pull requests can take a lighter path. Very large changes may get a partial review, and PR Agent says what it could not cover instead of faking completeness.
+
+## Deploy with Docker Compose
+
+Need Docker Engine with Compose v2 and a host GitHub can reach over HTTPS.
+Clone https://github.com/prathamdby/pr-agent, then cp .env.example .env.
+Set at least GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY, WEBHOOK_SECRET, PI_PROVIDER, PI_MODEL, and the matching provider API key.
+Compose overrides ROLE and DATABASE_URL per service. Default published HTTP port is 7224.
+GITHUB_APP_PRIVATE_KEY accepts one-line PEM with \n, real multi-line PEM, or base64-encoded PEM.
+Start with: docker compose build && docker compose up -d
+Services: postgres (durable state), pr-agent-web (ROLE=web, POST /webhooks, GET /health, GET /ready), pr-agent-worker (queue consumers).
+Migrations run when each process opens its Postgres pool.
+GitHub App webhook URL: https://<host>/webhooks. Webhook secret must match WEBHOOK_SECRET.
+Subscribe to pull_request, issue_comment, pull_request_review_comment, workflow_run, and check_suite.
+Permissions: Issues read/write, Pull requests read/write, Contents read/write, Metadata read, Checks read/write, Actions read.
+Commit statuses read/write only if FEATURE_COMMIT_STATUS=true.
+Install the app on the orgs or repos to review, then recreate web and worker so they pick up credentials.
+Check web with curl http://127.0.0.1:7224/health (ok) and /ready (ready when Postgres is up).
+Both web and worker must run. If webhooks return 200 and the PR stays quiet, the worker is down or misconfigured.
+
+## How it works
+
+Two processes must run together.
+ROLE=web accepts signed webhooks, writes work to Postgres, and enqueues jobs. It returns 200 once that write succeeds.
+ROLE=worker runs the queues: reactions, progress comments, model sessions, and everything posted back to the PR.
+Flow: GitHub webhooks → web /webhooks → Postgres webhook_events dedupe → agent_work_items → pg-boss enqueue.
+Queues: ack, ci-refresh, review, ask, description, triage, verification, retention.
+Ack worker posts the eyes reaction and the review progress stub.
+Review runs four specialists (correctness, security, quality, tests) under one orchestrator.
+P0-P2 findings fail the review check run. P3 does not.
+Docs-only trivial PRs can take a short auto path instead of a full orchestrated run.
+Web does not create installation tokens or post to the PR. Workers do that.
+
+## Pricing
+
+Software is free. $0 from PR Agent. No credit card. No per-seat fee. Open source under MIT.
+You pay your own vendors. Hosting and AI usage only. Cover your server, database, and model bills. Add more developers without raising your PR Agent bill.
+You own the full stack. Your security rules apply. Run it inside your network, choose your AI provider, and keep review traffic under your policies.
+
+## Model providers
+
+Many model providers. Use OpenAI, Anthropic, Google, DeepSeek, OpenRouter, Groq, and more with your own API keys.
+LLM calls run on the worker only, through the Pi coding-agent runtime.
+PI_PROVIDER and PI_MODEL are the general primary (default openai / gpt-4o-mini).
+Optional PI_ORCHESTRATOR_PROVIDER and PI_ORCHESTRATOR_MODEL override the review orchestrator session.
+Optional PI_FALLBACK_PROVIDER and PI_FALLBACK_MODEL cover availability failures. Both must be set to enable fallback.
+pr-agent loads OPENAI_API_KEY, ANTHROPIC_API_KEY, and GOOGLE_GENERATIVE_AI_API_KEY in config.
+Other Pi providers use their usual env vars on the worker (DEEPSEEK_API_KEY, OPENROUTER_API_KEY, GROQ_API_KEY).
+
+## Compared to hosted reviewers
+
+PR Agent: Self-hosted, MIT-licensed. You run the reviewer, hold the model keys, and keep the review data.
+CodeRabbit: Cloud SaaS (self-host enterprise). Hosted reviewer with subscription pricing and a managed data path.
+Greptile: Cloud SaaS (self-host option). Managed full-repo indexing for cross-file context.
+Cursor Bugbot: Cloud (Cursor ecosystem). Bug-focused review tied to the Cursor ecosystem.
+Macroscope: Cloud SaaS. Hosted GitHub PR review with a managed pipeline.
+
+## FAQ
+
+Q: What is PR Agent?
+A: PR Agent is open-source software that reviews GitHub pull requests on servers you run. You deploy it once, connect GitHub and an AI provider, and it posts reviews, summaries, and answers back on the pull request.
+Q: Is PR Agent a self-hosted alternative to CodeRabbit?
+A: Yes. It reviews pull requests when they open, leaves comments on the changes, writes summaries, and responds to commands in GitHub. Unlike CodeRabbit's hosted product, PR Agent runs on your servers with your credentials and your AI keys.
+Q: How does PR Agent compare to Greptile?
+A: Greptile is a cloud reviewer that indexes whole repositories. PR Agent is self-hosted and looks at each pull request from the branch and what changed. Pick it when you want the review data and models under your control, not another managed subscription.
+Q: Does PR Agent replace Cursor Bugbot?
+A: PR Agent fits teams that want bug and correctness reviews on GitHub without sending that work through a hosted IDE-tied review service. Bugbot stays tied to the Cursor IDE. PR Agent is a review system you operate with your own model keys.
+Q: How does PR Agent compare to Macroscope?
+A: Macroscope is a hosted AI code review product for GitHub pull requests. PR Agent offers a similar automatic review flow as MIT-licensed software you deploy yourself. You choose the models and where review data is processed.
+Q: Is PR Agent free?
+A: Yes. PR Agent is MIT-licensed with no per-seat fee from us. You pay for hosting and AI usage. Add 50 developers and the PR Agent software bill stays at $0.
+Q: Which AI models does PR Agent support?
+A: PR Agent works with OpenAI, Anthropic, Google, DeepSeek, OpenRouter, Groq, and more via the Pi provider catalog. You pick the provider and set your own API key on the machine that runs reviews.
+Q: Does PR Agent only work with GitHub?
+A: Yes for now. PR Agent connects as a GitHub app, reviews pull requests, and replies in GitHub comments. GitLab and Bitbucket are not supported yet.
+
+## Data privacy
+
+Self-hosted. Postgres, pg-boss, webhook bodies, and work-item state stay on your infrastructure.
+You own the GitHub App credentials.
+Review, description, ask, triage, verification, and CI-summary text leave your network only when the worker calls your configured provider.
+Optional CONTEXT7_API_KEY may call https://context7.com/api for library lookup.
+Structured logs use evlog. LOG_REDACT defaults to true and strips secret-shaped substrings.
+/ask applies outbound redaction before posting. Questions aimed at bot internals can get a short refusal without an LLM call.
+
+## Docs and links
+
+Repository: https://github.com/prathamdby/pr-agent
+Host with Docker Compose: https://github.com/prathamdby/pr-agent#host-with-docker-compose
+Features catalog: https://github.com/prathamdby/pr-agent/blob/main/docs/features.md
+Configuration: https://github.com/prathamdby/pr-agent/blob/main/docs/configuration.md
+Operations: https://github.com/prathamdby/pr-agent/blob/main/docs/operations.md
+Domain vocabulary: https://github.com/prathamdby/pr-agent/blob/main/CONTEXT.md
+Agent work ops: https://github.com/prathamdby/pr-agent/blob/main/docs/agent-work-ops.md
+Architecture decisions: https://github.com/prathamdby/pr-agent/tree/main/docs/adr
+License: https://github.com/prathamdby/pr-agent/blob/main/LICENSE
+

--- a/site/routeTree.gen.ts
+++ b/site/routeTree.gen.ts
@@ -12,6 +12,8 @@ import { Route as rootRouteImport } from './app/__root'
 import { Route as IndexRouteImport } from './app/index'
 import { Route as RobotsDottxtRouteImport } from './app/robots[.]txt'
 import { Route as SitemapDotxmlRouteImport } from './app/sitemap[.]xml'
+import { Route as LlmsIndexRouteImport } from './app/llms/index'
+import { Route as LlmsJsonRouteImport } from './app/llms/json'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
@@ -28,35 +30,54 @@ const SitemapDotxmlRoute = SitemapDotxmlRouteImport.update({
   path: '/sitemap.xml',
   getParentRoute: () => rootRouteImport,
 } as any)
+const LlmsIndexRoute = LlmsIndexRouteImport.update({
+  id: '/llms/',
+  path: '/llms/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LlmsJsonRoute = LlmsJsonRouteImport.update({
+  id: '/llms/json',
+  path: '/llms/json',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/robots.txt': typeof RobotsDottxtRoute
   '/sitemap.xml': typeof SitemapDotxmlRoute
+  '/llms/json': typeof LlmsJsonRoute
+  '/llms/': typeof LlmsIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/robots.txt': typeof RobotsDottxtRoute
   '/sitemap.xml': typeof SitemapDotxmlRoute
+  '/llms/json': typeof LlmsJsonRoute
+  '/llms': typeof LlmsIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/robots.txt': typeof RobotsDottxtRoute
   '/sitemap.xml': typeof SitemapDotxmlRoute
+  '/llms/json': typeof LlmsJsonRoute
+  '/llms/': typeof LlmsIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/robots.txt' | '/sitemap.xml'
+  fullPaths: '/' | '/robots.txt' | '/sitemap.xml' | '/llms/json' | '/llms/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/robots.txt' | '/sitemap.xml'
-  id: '__root__' | '/' | '/robots.txt' | '/sitemap.xml'
+  to: '/' | '/robots.txt' | '/sitemap.xml' | '/llms/json' | '/llms'
+  id:
+    '__root__' | '/' | '/robots.txt' | '/sitemap.xml' | '/llms/json' | '/llms/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   RobotsDottxtRoute: typeof RobotsDottxtRoute
   SitemapDotxmlRoute: typeof SitemapDotxmlRoute
+  LlmsJsonRoute: typeof LlmsJsonRoute
+  LlmsIndexRoute: typeof LlmsIndexRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -82,6 +103,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SitemapDotxmlRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/llms/': {
+      id: '/llms/'
+      path: '/llms'
+      fullPath: '/llms/'
+      preLoaderRoute: typeof LlmsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/llms/json': {
+      id: '/llms/json'
+      path: '/llms/json'
+      fullPath: '/llms/json'
+      preLoaderRoute: typeof LlmsJsonRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -89,6 +124,8 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   RobotsDottxtRoute: RobotsDottxtRoute,
   SitemapDotxmlRoute: SitemapDotxmlRoute,
+  LlmsJsonRoute: LlmsJsonRoute,
+  LlmsIndexRoute: LlmsIndexRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -1,12 +1,25 @@
+import { writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import tailwindcss from "@tailwindcss/vite";
 import viteReact from "@vitejs/plugin-react";
 import { nitro } from "nitro/vite";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
+import { renderLlmsTxt } from "./lib/llmsKnowledge";
 
 const siteDir = fileURLToPath(new URL(".", import.meta.url));
+
+function emitLlmsTxt(): Plugin {
+  const write = () => {
+    writeFileSync(resolve(siteDir, "public/llms.txt"), renderLlmsTxt());
+  };
+  return {
+    name: "emit-llms-txt",
+    buildStart: write,
+    configureServer: write,
+  };
+}
 
 export default defineConfig({
   server: {
@@ -18,6 +31,7 @@ export default defineConfig({
     },
   },
   plugins: [
+    emitLlmsTxt(),
     tailwindcss(),
     tanstackStart({
       srcDirectory: ".",

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -14,10 +14,23 @@ function emitLlmsTxt(): Plugin {
   const write = () => {
     writeFileSync(resolve(siteDir, "public/llms.txt"), renderLlmsTxt());
   };
+  const watched = [
+    resolve(siteDir, "lib/llmsKnowledge.ts"),
+    resolve(siteDir, "lib/content.ts"),
+    resolve(siteDir, "lib/site.ts"),
+  ];
   return {
     name: "emit-llms-txt",
     buildStart: write,
-    configureServer: write,
+    configureServer(server) {
+      write();
+      server.watcher.add(watched);
+      server.watcher.on("change", (file) => {
+        if (watched.includes(file)) {
+          write();
+        }
+      });
+    },
   };
 }
 

--- a/test/llmsHttp.test.ts
+++ b/test/llmsHttp.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { llmsQueryResponse, llmsTxtResponse } from "../site/lib/llmsHttp.js";
+
+function header(response: Response, name: string): string | null {
+  return response.headers.get(name);
+}
+
+describe("llmsQueryResponse", () => {
+  it("returns the topic index for a missing query", async () => {
+    const response = llmsQueryResponse(new Request("http://test/llms"), "text");
+    expect(response.status).toBe(200);
+    expect(header(response, "content-type")).toBe("text/plain; charset=utf-8");
+    expect(header(response, "cache-control")).toBe("public, max-age=300");
+    expect(header(response, "x-content-type-options")).toBe("nosniff");
+    const body = await response.text();
+    expect(body).toContain("Topics:");
+    expect(body).toContain("deploy:");
+  });
+
+  it("returns deploy hits for a text query", async () => {
+    const response = llmsQueryResponse(new Request("http://test/llms?query=deploy"), "text");
+    expect(response.status).toBe(200);
+    expect(header(response, "content-type")).toBe("text/plain; charset=utf-8");
+    const body = await response.text();
+    expect(body).toContain("# query: deploy");
+    expect(body).toContain("## Deploy with Docker Compose");
+  });
+
+  it("returns JSON hits and headers for a faq query", async () => {
+    const response = llmsQueryResponse(new Request("http://test/llms/json?query=faq"), "json");
+    expect(response.status).toBe(200);
+    expect(header(response, "content-type")).toBe("application/json; charset=utf-8");
+    expect(header(response, "cache-control")).toBe("public, max-age=300");
+    expect(header(response, "x-content-type-options")).toBe("nosniff");
+    const body = (await response.json()) as { mode: string; matches: { id: string }[] };
+    expect(body.mode).toBe("hits");
+    expect(body.matches.some((match) => match.id === "faq")).toBe(true);
+  });
+
+  it("decodes plus-encoded query values", async () => {
+    const response = llmsQueryResponse(new Request("http://test/llms?query=slash+command"), "text");
+    const body = await response.text();
+    expect(body).toContain("# query: slash command");
+    expect(body).toContain("## Slash commands");
+  });
+});
+
+describe("llmsTxtResponse", () => {
+  it("serves the full profile as nosniff plain text", async () => {
+    const response = llmsTxtResponse();
+    expect(response.status).toBe(200);
+    expect(header(response, "content-type")).toBe("text/plain; charset=utf-8");
+    expect(header(response, "x-content-type-options")).toBe("nosniff");
+    const body = await response.text();
+    expect(body.startsWith("# PR Agent")).toBe(true);
+    expect(body).toContain("FEATURE_REVIEW");
+  });
+});

--- a/test/llmsKnowledge.test.ts
+++ b/test/llmsKnowledge.test.ts
@@ -5,6 +5,8 @@ import {
   FEATURE_KEYS,
   KNOWLEDGE_CHUNKS,
   LLMS_TXT_TOKEN_ESTIMATE,
+  MAX_HITS,
+  MAX_QUERY_CHARS,
   answerAgentQuery,
   llmsNudgeTitle,
   parseAgentQuery,
@@ -23,6 +25,44 @@ describe("parseAgentQuery", () => {
   it("treats all/everything/full/profile as broad", () => {
     expect(parseAgentQuery("everything")).toEqual({ kind: "broad", raw: "everything" });
     expect(parseAgentQuery("full profile")).toEqual({ kind: "broad", raw: "full profile" });
+  });
+
+  it("keeps mixed queries as terms when a non-broad token is present", () => {
+    expect(parseAgentQuery("about pricing")).toMatchObject({
+      kind: "terms",
+      tokens: ["about", "pricing"],
+    });
+    expect(parseAgentQuery("profile deploy")).toMatchObject({
+      kind: "terms",
+      tokens: ["profile", "deploy"],
+    });
+  });
+
+  it("clips raw input at MAX_QUERY_CHARS", () => {
+    const prefix = "x".repeat(MAX_QUERY_CHARS);
+    const over = `${prefix} deploy`;
+    const parsed = parseAgentQuery(over);
+    expect(parsed.kind).toBe("terms");
+    if (parsed.kind !== "terms") {
+      return;
+    }
+    expect(parsed.raw.length).toBeLessThanOrEqual(MAX_QUERY_CHARS);
+    expect(parsed.tokens).not.toContain("deploy");
+    expect(parseAgentQuery(`${prefix}everything`).kind).toBe("terms");
+    expect(parseAgentQuery(prefix).kind).toBe("terms");
+  });
+
+  it("strips control characters from echoed raw", () => {
+    const parsed = parseAgentQuery("deploy\n\n## Fake Heading");
+    expect(parsed.kind).toBe("terms");
+    if (parsed.kind !== "terms") {
+      return;
+    }
+    expect(parsed.raw).toBe("deploy ## Fake Heading");
+    expect(parsed.raw).not.toMatch(/[\r\n]/);
+    const text = renderAnswerText(answerAgentQuery(parsed));
+    expect(text.startsWith("# query: deploy ## Fake Heading\n")).toBe(true);
+    expect(text).not.toContain("\n## Fake Heading");
   });
 
   it("keeps specific tokens", () => {
@@ -72,6 +112,25 @@ describe("answerAgentQuery", () => {
       return;
     }
     expect(answer.hits[0]?.chunk.id).toBe("commands");
+  });
+
+  it("caps hits at MAX_HITS and breaks score ties by chunk id", () => {
+    const answer = answerAgentQuery({
+      kind: "terms",
+      raw: "wide",
+      tokens: ["review", "github", "agent", "feature", "command", "deploy", "price"],
+    });
+    expect(answer.kind).toBe("hits");
+    if (answer.kind !== "hits") {
+      return;
+    }
+    expect(answer.hits.length).toBe(MAX_HITS);
+    expect(answer.hits.length).toBeLessThan(KNOWLEDGE_CHUNKS.length);
+    const scores = answer.hits.map((hit) => hit.score);
+    expect(scores).toEqual([...scores].toSorted((left, right) => right - left));
+    const tied = answer.hits.filter((hit) => hit.score === answer.hits[0]?.score);
+    const tiedIds = tied.map((hit) => hit.chunk.id);
+    expect(tiedIds).toEqual([...tiedIds].toSorted((left, right) => left.localeCompare(right)));
   });
 });
 

--- a/test/llmsKnowledge.test.ts
+++ b/test/llmsKnowledge.test.ts
@@ -1,0 +1,125 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  FEATURE_KEYS,
+  KNOWLEDGE_CHUNKS,
+  LLMS_TXT_TOKEN_ESTIMATE,
+  answerAgentQuery,
+  llmsNudgeTitle,
+  parseAgentQuery,
+  renderAnswerJson,
+  renderAnswerText,
+  renderLlmsTxt,
+} from "../site/lib/llmsKnowledge.js";
+
+describe("parseAgentQuery", () => {
+  it("treats blank and stop-word input as empty", () => {
+    expect(parseAgentQuery("")).toEqual({ kind: "empty" });
+    expect(parseAgentQuery("   ")).toEqual({ kind: "empty" });
+    expect(parseAgentQuery("the and of")).toEqual({ kind: "empty" });
+  });
+
+  it("treats all/everything/full/profile as broad", () => {
+    expect(parseAgentQuery("everything")).toEqual({ kind: "broad", raw: "everything" });
+    expect(parseAgentQuery("full profile")).toEqual({ kind: "broad", raw: "full profile" });
+  });
+
+  it("keeps specific tokens", () => {
+    expect(parseAgentQuery("How do I deploy?")).toEqual({
+      kind: "terms",
+      raw: "How do I deploy?",
+      tokens: ["how", "do", "i", "deploy"],
+    });
+  });
+});
+
+describe("answerAgentQuery", () => {
+  it("returns the topic index for empty and unmatched queries", () => {
+    expect(answerAgentQuery({ kind: "empty" })).toEqual({ kind: "index" });
+    expect(
+      answerAgentQuery({ kind: "terms", raw: "zzzz-not-a-topic", tokens: ["zzzz-not-a-topic"] }),
+    ).toEqual({ kind: "index" });
+  });
+
+  it("returns the full profile for broad queries", () => {
+    expect(answerAgentQuery({ kind: "broad", raw: "all" })).toEqual({ kind: "full", raw: "all" });
+    expect(renderAnswerText({ kind: "full", raw: "all" })).toBe(renderLlmsTxt());
+  });
+
+  it("ranks deploy above unrelated sections", () => {
+    const answer = answerAgentQuery({
+      kind: "terms",
+      raw: "deploy docker compose",
+      tokens: ["deploy", "docker", "compose"],
+    });
+    expect(answer.kind).toBe("hits");
+    if (answer.kind !== "hits") {
+      return;
+    }
+    expect(answer.hits[0]?.chunk.id).toBe("deploy");
+    expect(answer.hits.some((hit) => hit.chunk.id === "pricing")).toBe(false);
+  });
+
+  it("ranks slash commands for a /review question", () => {
+    const answer = answerAgentQuery({
+      kind: "terms",
+      raw: "slash command /review",
+      tokens: ["slash", "command", "review"],
+    });
+    expect(answer.kind).toBe("hits");
+    if (answer.kind !== "hits") {
+      return;
+    }
+    expect(answer.hits[0]?.chunk.id).toBe("commands");
+  });
+});
+
+describe("offering layer documents", () => {
+  it("keeps public/llms.txt identical to the rendered corpus", () => {
+    const onDisk = fs.readFileSync(path.join(process.cwd(), "site/public/llms.txt"), "utf8");
+    expect(onDisk).toBe(renderLlmsTxt());
+  });
+
+  it("names every FEATURE_* key in llms.txt", () => {
+    const text = renderLlmsTxt();
+    for (const key of FEATURE_KEYS) {
+      expect(text.includes(key), `missing ${key}`).toBe(true);
+    }
+  });
+
+  it("advertises both query endpoints and a token estimate", () => {
+    const text = renderLlmsTxt();
+    expect(text).toContain("GET /llms?query=");
+    expect(text).toContain("GET /llms/json?query=");
+    expect(LLMS_TXT_TOKEN_ESTIMATE).toBeGreaterThan(200);
+    expect(llmsNudgeTitle()).toContain(`~${LLMS_TXT_TOKEN_ESTIMATE} tokens`);
+    expect(llmsNudgeTitle()).toContain("/llms.txt");
+    expect(llmsNudgeTitle()).toContain("/llms?query=");
+    expect(llmsNudgeTitle()).toContain("/llms/json?query=");
+  });
+
+  it("keeps one chunk per topic", () => {
+    const ids = KNOWLEDGE_CHUNKS.map((chunk) => chunk.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toContain("overview");
+    expect(ids).toContain("deploy");
+  });
+
+  it("emits JSON matches for a priced query", () => {
+    const json = renderAnswerJson(
+      answerAgentQuery({ kind: "terms", raw: "pricing", tokens: ["pricing"] }),
+    );
+    expect(json.mode).toBe("hits");
+    expect(json.matches.some((match) => match.id === "pricing")).toBe(true);
+    expect(json.tokenEstimate).toBe(LLMS_TXT_TOKEN_ESTIMATE);
+  });
+
+  it("emits an index payload when query is empty", () => {
+    const json = renderAnswerJson({ kind: "index" });
+    expect(json.mode).toBe("index");
+    expect(json.matches).toEqual([]);
+    expect(json.topics).toEqual(KNOWLEDGE_CHUNKS.map((chunk) => chunk.id));
+    expect(renderAnswerText({ kind: "index" })).toContain("Topics:");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- The landing page stays a short human overview and publishes a dense `/llms.txt` from one knowledge corpus.
- `GET /llms?query=` returns matching sections as plain text.
- `GET /llms/json?query=` returns the same matches as JSON.
- The footer and document head advertise `/llms.txt` so agents can find the profile.
- README, the development guide, and operations name the new routes.

## Details

- `site/lib/llmsKnowledge.ts` owns the chunk table, query parse, ranking, and `/llms.txt` render.
- `site/lib/llmsHttp.ts` turns a request into text or JSON.
- `site/app/llms/index.ts` and `site/app/llms/json.ts` expose the GET handlers.
- `site/vite.config.ts` writes `site/public/llms.txt` at build so prerender can serve the static file.
- The footer link title names both query endpoints and the token estimate.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53e6c014-8dcb-473b-9388-16afb66d02f0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53e6c014-8dcb-473b-9388-16afb66d02f0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- PR_AGENT_DESCRIPTION_BEGIN -->
## PR Agent Description

### PR Type

Enhancement

### Description

- The change adds `site/lib/llmsKnowledge.ts` with 11 knowledge chunks, token estimate, and scored query logic for agent docs.
- It exposes `GET /llms?query=` and `GET /llms/json?query=` through `site/lib/llmsHttp.ts` and two TanStack routes for text and JSON.
- It expands `site/public/llms.txt` to a full offering profile and syncs it at build and dev via a Vite plugin.
- It adds discovery via alternate link in `site/app/__root.tsx`, footer link, and `site/app/sitemap[.]xml.ts` entry for crawlers.
- It caps queries at 300 chars, filters stop tokens, returns at most 6 hits, and falls back to a topic index.
- It adds `test/llmsKnowledge.test.ts` to check corpus parity, FEATURE_* coverage, ranking, and drift when sources change.

### Changes Diagram

```mermaid
flowchart LR
  A["Knowledge corpus in llmsKnowledge.ts"] --> B["HTTP layer llmsHttp.ts"]
  B --> C["GET llms text route"]
  B --> D["GET llms json route"]
  A --> E["Static llms.txt file"]
  E --> F["Vite emit plugin"]
  E --> G["Sitemap and link discovery"]
```

### Review map

1. <a href="https://github.com/prathamdby/pr-agent/pull/447/files#diff-fa212592c2af29263e19f869400a2fd9003f76deac2333449a80e0bb208f77bf"><code>site/lib/llmsKnowledge.ts</code></a>: Core corpus, query parsing, scoring and render contract for all agent docs
2. <a href="https://github.com/prathamdby/pr-agent/pull/447/files#diff-85710bc180e208388415ca772539e63d0679d6dea6a2b6e9898da2f2fee57208"><code>site/lib/llmsHttp.ts</code></a>: Public cache headers and text/JSON response handling for query endpoints
3. <a href="https://github.com/prathamdby/pr-agent/pull/447/files#diff-c6afdb0c66bab1fea3240866fdbca8337b950fcf05384c610f24f8e6ece040d5"><code>site/app/llms/index.ts</code></a>: New GET /llms route that serves ranked text answers
4. <a href="https://github.com/prathamdby/pr-agent/pull/447/files#diff-da03715f647898377ced0955be7549e489bfc6594adc63faef5defe2be3fed29"><code>site/vite.config.ts</code></a>: Build plugin that overwrites public/llms.txt and risks drift on disk
5. <a href="https://github.com/prathamdby/pr-agent/pull/447/files#diff-b855fb955af59168d9fa01ed0fe5dd0cf752bf9c9b12e673675a74b2e754af2e"><code>site/public/llms.txt</code></a>: Dense agent profile that must stay identical to rendered corpus
<!-- PR_AGENT_DESCRIPTION_END -->