### PR TITLE
Collapse the reschedule abort expect call

### DIFF
--- a/test/reviewReschedule.test.ts
+++ b/test/reviewReschedule.test.ts
@@ -719,11 +719,7 @@ describe("buildStaleReviewRescheduleResult onRescheduleAbort", () => {
     await expect(result.afterComplete(boss)).rejects.toBe(leaseLost);
     await result.onRescheduleAbort(boss, leaseLost);
 
-    expect(markQueuedWorkCancelled).toHaveBeenCalledWith(
-      pool,
-      "existing-replacement",
-      leaseLost,
-    );
+    expect(markQueuedWorkCancelled).toHaveBeenCalledWith(pool, "existing-replacement", leaseLost);
   });
 
   it("does not cancel after afterComplete marks the replacement enqueued", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Collapse the `markQueuedWorkCancelled` expect in `test/reviewReschedule.test.ts` onto one line

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://myworkspace-wqw2896.slack.com/archives/C04LXFXNUDP/p1788276144707479?thread_ts=1788276144.707479&cid=C04LXFXNUDP)

<div><a href="https://cursor.com/agents/bc-8e3d3b37-6a97-5ce6-8434-149bed1c314d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e3d3b37-6a97-5ce6-8434-149bed1c314d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- PR_AGENT_DESCRIPTION_BEGIN -->
## PR Agent Description

### PR Type

Tests

### Description

- The change collapses a multiline `markQueuedWorkCancelled` expectation to a single line in `test/reviewReschedule.test.ts`.
- It keeps the `onRescheduleAbort` lease-lost test behavior unchanged for reviewers.
- It improves readability with no functional or contract change.
<!-- pr-agent:operation-intent 83f3ea33f3b7a9dd33b168f2 -->
<!-- PR_AGENT_DESCRIPTION_END -->