### PR TITLE
Reset review executor mocks between cases

### DIFF
--- a/test/reviewExecutor.test.ts
+++ b/test/reviewExecutor.test.ts
@@ -270,6 +270,10 @@ describe("executeReviewJob", () => {
     mocks.buildTrustedContext.mockResolvedValue("trusted");
     mocks.fetchPriorFeedback.mockResolvedValue(undefined);
     mocks.getSummaryCommentGithubId.mockResolvedValue(1);
+    mocks.shouldSkipWork.mockResolvedValue(false);
+    mocks.getWorkItem.mockResolvedValue(null);
+    mocks.hasCompletedPublishStep.mockResolvedValue(false);
+    mocks.buildStaleReschedule.mockReset();
     mockRepositoryView();
     mockDurableExecution("slash");
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Reset `shouldSkipWork` and related mocks in `test/reviewExecutor.test.ts` before each case

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://myworkspace-wqw2896.slack.com/archives/C04LXFXNUDP/p1788276144707479?thread_ts=1788276144.707479&cid=C04LXFXNUDP)

<div><a href="https://cursor.com/agents/bc-8e3d3b37-6a97-5ce6-8434-149bed1c314d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e3d3b37-6a97-5ce6-8434-149bed1c314d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- PR_AGENT_DESCRIPTION_BEGIN -->
## PR Agent Description

### PR Type

Tests

### Description

- The change adds default mock values for shouldSkipWork, getWorkItem and hasCompletedPublishStep in the executeReviewJob beforeEach.
- It resets buildStaleReschedule with mockReset to clear prior call history between tests.
- This keeps the review executor tests isolated and prevents false passes or failures from leftover mock state.
<!-- pr-agent:operation-intent 53a050d9a60bbe095030d10a -->
<!-- PR_AGENT_DESCRIPTION_END -->