### PR TITLE
Recover typed result in operation intent reconciliation

### DIFF
--- a/src/agentWork/withOperationIntent.ts
+++ b/src/agentWork/withOperationIntent.ts
@@ -356,10 +356,8 @@ async function withOperationIntentBody<T>(params: WithOperationIntentParams<T>):
   // publish_records). Side effect is done — never remutate. If recover can
   // rebuild a typed result, stash it so later retries do not return undefined.
   if (intent.status === "reconciled") {
-    if (params.recover != null) {
-      const recovered = await recoverByExactEvidence(params, intent, null);
-      if (recovered.found) return recovered.value;
-    }
+    const recovered = await recoverByExactEvidence(params, intent, null);
+    if (recovered.found) return recovered.value;
     return undefined as T;
   }
 

--- a/src/agentWork/withOperationIntent.ts
+++ b/src/agentWork/withOperationIntent.ts
@@ -230,6 +230,7 @@ async function recoverByExactEvidence<T>(
     operationKey: params.operationKey,
     status: "reconciled",
     publishRecordId: recovery.publishRecordId,
+    ...leaseEpochDetail(params),
     detail: resultDetail,
   });
   return { found: true, value: recovery.value };
@@ -351,9 +352,14 @@ async function withOperationIntentBody<T>(params: WithOperationIntentParams<T>):
     return finishWithStashedResult(params, intent);
   }
 
-  // Reconciled without a return value (void mutate, or recovered publish_records):
-  // side effect is done — idempotent completion, never remutate.
+  // Reconciled without a stashed return value (void mutate, or recovered
+  // publish_records). Side effect is done — never remutate. If recover can
+  // rebuild a typed result, stash it so later retries do not return undefined.
   if (intent.status === "reconciled") {
+    if (params.recover != null) {
+      const recovered = await recoverByExactEvidence(params, intent, null);
+      if (recovered.found) return recovered.value;
+    }
     return undefined as T;
   }
 

--- a/test/withOperationIntent.test.ts
+++ b/test/withOperationIntent.test.ts
@@ -556,6 +556,81 @@ describe("withOperationIntent", () => {
     );
   });
 
+  it("returns undefined when recover finds no evidence on a reconciled intent without __result", async () => {
+    const mutate = vi.fn(async () => ({ id: 99 }));
+    const recover = vi.fn(async () => ({ kind: "absent" as const }));
+    vi.mocked(persistOperationIntent).mockResolvedValue({
+      id: "intent-1",
+      workItemId: "wi-1",
+      operationKey: "ask:reply:o/r#1",
+      mutationKind: "github.ask_reply",
+      status: "reconciled",
+      publishRecordId: null,
+      detail: { recoveredAfterMutating: true },
+    });
+
+    await expect(withOperationIntent({ ...baseParams, recover, mutate })).resolves.toBeUndefined();
+    expect(recover).toHaveBeenCalledOnce();
+    expect(mutate).not.toHaveBeenCalled();
+    expect(reconcileOperationIntent).not.toHaveBeenCalled();
+  });
+
+  it("wraps a recover-hook failure on a reconciled intent without __result", async () => {
+    const mutate = vi.fn(async () => ({ id: 99 }));
+    const recover = vi.fn(async () => {
+      throw new Error("evidence lookup failed");
+    });
+    vi.mocked(persistOperationIntent).mockResolvedValue({
+      id: "intent-1",
+      workItemId: "wi-1",
+      operationKey: "ask:reply:o/r#1",
+      mutationKind: "github.ask_reply",
+      status: "reconciled",
+      publishRecordId: null,
+      detail: { recoveredAfterMutating: true },
+    });
+
+    await expect(withOperationIntent({ ...baseParams, recover, mutate })).rejects.toMatchObject({
+      code: "operation_intent.recovery_failed",
+    });
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  it("propagates leaseEpoch when reconciling exact-evidence recovery", async () => {
+    const mutate = vi.fn(async () => ({ id: 99 }));
+    const recoveredValue = { id: 7, updated: false };
+    const recover = vi.fn(async () => ({
+      kind: "reconciled" as const,
+      value: recoveredValue,
+    }));
+    vi.mocked(persistOperationIntent).mockResolvedValue({
+      id: "intent-1",
+      workItemId: "wi-1",
+      operationKey: "ask:reply:o/r#1",
+      mutationKind: "github.ask_reply",
+      status: "reconciled",
+      publishRecordId: null,
+      detail: { recoveredAfterMutating: true },
+    });
+
+    const result = await withOperationIntent({
+      ...baseParams,
+      leaseEpoch: 7,
+      recover,
+      mutate,
+    });
+
+    expect(result).toEqual(recoveredValue);
+    expect(mutate).not.toHaveBeenCalled();
+    expect(reconcileOperationIntent).toHaveBeenCalledWith(
+      pool,
+      expect.objectContaining({
+        status: "reconciled",
+        leaseEpoch: 7,
+      }),
+    );
+  });
+
   it("remutates after status failed even if __mutating residue remains", async () => {
     const mutate = vi.fn(async () => ({ commentId: 3 }));
     vi.mocked(persistOperationIntent).mockResolvedValue({

--- a/test/withOperationIntent.test.ts
+++ b/test/withOperationIntent.test.ts
@@ -465,6 +465,97 @@ describe("withOperationIntent", () => {
     expect(mutate).not.toHaveBeenCalled();
   });
 
+  it("stashes exact-evidence recovery so a later retry returns the recovered value", async () => {
+    const mutate = vi.fn(async () => ({ id: 99, updated: true }));
+    const recoveredValue = { id: 42, updated: false };
+    const recover = vi.fn(async () => ({
+      kind: "reconciled" as const,
+      value: recoveredValue,
+    }));
+    vi.mocked(persistOperationIntent).mockResolvedValue({
+      id: "intent-1",
+      workItemId: "wi-1",
+      operationKey: "ask:reply:o/r#1",
+      mutationKind: "github.ask_reply",
+      status: "outcome_unknown",
+      publishRecordId: null,
+      detail: { __mutating: false },
+    });
+    vi.mocked(findCompletedPublishRecordId).mockResolvedValue(null);
+
+    const first = await withOperationIntent({
+      ...baseParams,
+      recover,
+      mutate,
+    });
+
+    expect(first).toEqual(recoveredValue);
+    expect(mutate).not.toHaveBeenCalled();
+    expect(reconcileOperationIntent).toHaveBeenCalledWith(
+      pool,
+      expect.objectContaining({
+        status: "reconciled",
+        detail: { __result: recoveredValue },
+      }),
+    );
+
+    vi.mocked(persistOperationIntent).mockResolvedValue({
+      id: "intent-1",
+      workItemId: "wi-1",
+      operationKey: "ask:reply:o/r#1",
+      mutationKind: "github.ask_reply",
+      status: "reconciled",
+      publishRecordId: null,
+      detail: { __result: recoveredValue },
+    });
+    recover.mockClear();
+
+    const second = await withOperationIntent({
+      ...baseParams,
+      recover,
+      mutate,
+    });
+
+    expect(second).toEqual(recoveredValue);
+    expect(recover).not.toHaveBeenCalled();
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  it("returns recovered value when retrying an intent reconciled without stashed result but with recover hook", async () => {
+    const mutate = vi.fn(async () => ({ id: 99, updated: true }));
+    const recoveredValue = { id: 7, updated: false };
+    const recover = vi.fn(async () => ({
+      kind: "reconciled" as const,
+      value: recoveredValue,
+    }));
+    vi.mocked(persistOperationIntent).mockResolvedValue({
+      id: "intent-1",
+      workItemId: "wi-1",
+      operationKey: "ask:reply:o/r#1",
+      mutationKind: "github.ask_reply",
+      status: "reconciled",
+      publishRecordId: "pub-1",
+      detail: { recoveredAfterMutating: true },
+    });
+
+    const result = await withOperationIntent({
+      ...baseParams,
+      recover,
+      mutate,
+    });
+
+    expect(result).toEqual(recoveredValue);
+    expect(mutate).not.toHaveBeenCalled();
+    expect(recover).toHaveBeenCalledOnce();
+    expect(reconcileOperationIntent).toHaveBeenCalledWith(
+      pool,
+      expect.objectContaining({
+        status: "reconciled",
+        detail: { __result: recoveredValue },
+      }),
+    );
+  });
+
   it("remutates after status failed even if __mutating residue remains", async () => {
     const mutate = vi.fn(async () => ({ commentId: 3 }));
     vi.mocked(persistOperationIntent).mockResolvedValue({


### PR DESCRIPTION
## Summary

- Call `recover` when a reconciled intent has no stashed result
- Stash the recovered value so later retries return it
- Spread `leaseEpochDetail` during exact evidence recovery
