### PR TITLE
Strip line breaks from git person names

### DIFF
--- a/src/prWorkspace/writablePrCheckout.ts
+++ b/src/prWorkspace/writablePrCheckout.ts
@@ -137,7 +137,13 @@ export function gitPersonFromGithubUser(user: {
   const login = user.login?.trim();
   if (!login) return null;
   if (user.type === "Bot" || login.endsWith("[bot]")) return null;
-  const name = (user.name?.trim() || login).trim();
+  const rawName = user.name?.trim() || login;
+  const name =
+    rawName
+      .replace(/[\r\n]+/g, " ")
+      .split("\0")
+      .join(" ")
+      .trim() || login;
   if (!name) return null;
   const email = (user.email?.trim() || githubNoreplyEmail(user.id, login)).trim();
   if (!email.includes("@")) return null;
@@ -148,17 +154,26 @@ export function formatCoAuthoredByTrailer(person: GitPerson): string {
   return `Co-authored-by: ${person.name} <${person.email}>`;
 }
 
+function gitPersonHasForbiddenChars(value: string): boolean {
+  return value.includes("\r") || value.includes("\n") || value.includes("\0");
+}
+
 function validateGitPerson(person: GitPerson, field: string): void {
   const name = person.name.trim();
   const email = person.email.trim();
-  if (!name || name.includes("<") || name.includes(">")) {
+  if (!name || name.includes("<") || name.includes(">") || gitPersonHasForbiddenChars(name)) {
     throw new AppError({
       code: "pr_workspace.commit_identity_invalid",
       message: `${field} name is invalid`,
       context: { field },
     });
   }
-  if (!email.includes("@") || email.includes("<") || email.includes(">")) {
+  if (
+    !email.includes("@") ||
+    email.includes("<") ||
+    email.includes(">") ||
+    gitPersonHasForbiddenChars(email)
+  ) {
     throw new AppError({
       code: "pr_workspace.commit_identity_invalid",
       message: `${field} email is invalid`,

--- a/test/writablePrCheckout.test.ts
+++ b/test/writablePrCheckout.test.ts
@@ -282,7 +282,7 @@ describe("writable PR checkout", () => {
     });
   });
 
-  it("sanitizes line breaks in GitHub profile names", () => {
+  it("sanitizes line breaks and null bytes in GitHub profile names", () => {
     expect(
       gitPersonFromGithubUser({
         id: 42,
@@ -299,16 +299,44 @@ describe("writable PR checkout", () => {
         type: "User",
       }),
     ).toEqual({ name: "alice", email: githubNoreplyEmail(42, "alice") });
+    expect(
+      gitPersonFromGithubUser({
+        id: 42,
+        login: "alice",
+        name: "Alice\0Evil",
+        type: "User",
+      }),
+    ).toEqual({ name: "Alice Evil", email: githubNoreplyEmail(42, "alice") });
+    expect(
+      gitPersonFromGithubUser({
+        id: 42,
+        login: "alice",
+        name: "\0\0",
+        type: "User",
+      }),
+    ).toEqual({ name: "alice", email: githubNoreplyEmail(42, "alice") });
   });
 
-  it("rejects commit identities with line breaks in name or email", () => {
+  it("rejects commit identities with forbidden characters in name or email", () => {
     const subject = "fix: guard null user";
     const validCoAuthor = { name: "Bot", email: "bot@example.com" };
 
-    expect(() => gitIdentityEnv({ name: "Alice\nInject", email: "alice@example.com" })).toThrow(
-      AppError,
-    );
-    expect(() => gitIdentityEnv({ name: "Alice", email: "alice\n@example.com" })).toThrow(AppError);
+    for (const name of ["Alice\nInject", "Alice\0Inject"]) {
+      try {
+        gitIdentityEnv({ name, email: "alice@example.com" });
+      } catch (error) {
+        expect(error).toBeInstanceOf(AppError);
+        expect((error as AppError).code).toBe("pr_workspace.commit_identity_invalid");
+        continue;
+      }
+      expect.unreachable(`gitIdentityEnv accepted forbidden name ${JSON.stringify(name)}`);
+    }
+    try {
+      gitIdentityEnv({ name: "Alice", email: "alice\n@example.com" });
+    } catch (error) {
+      expect(error).toBeInstanceOf(AppError);
+      expect((error as AppError).code).toBe("pr_workspace.commit_identity_invalid");
+    }
     try {
       gitIdentityEnv({ name: "Alice\r", email: "alice@example.com" });
     } catch (error) {
@@ -316,13 +344,25 @@ describe("writable PR checkout", () => {
       expect((error as AppError).code).toBe("pr_workspace.commit_identity_invalid");
     }
 
-    expect(() =>
-      buildCommitCommandArgs({
-        files: ["x"],
-        subject,
-        coAuthoredBy: [{ name: "Co\nAuthor", email: "co@example.com" }],
-      }),
-    ).toThrow(AppError);
+    for (const coAuthor of [
+      { name: "Co\nAuthor", email: "co@example.com" },
+      { name: "Co\0Author", email: "co@example.com" },
+    ]) {
+      try {
+        buildCommitCommandArgs({
+          files: ["x"],
+          subject,
+          coAuthoredBy: [coAuthor],
+        });
+      } catch (error) {
+        expect(error).toBeInstanceOf(AppError);
+        expect((error as AppError).code).toBe("pr_workspace.commit_identity_invalid");
+        continue;
+      }
+      expect.unreachable(
+        `buildCommitCommandArgs accepted forbidden co-author ${JSON.stringify(coAuthor)}`,
+      );
+    }
     expect(() =>
       buildCommitCommandArgs({
         files: ["x"],
@@ -336,6 +376,21 @@ describe("writable PR checkout", () => {
         subject,
         coAuthoredBy: [{ name: "Co", email: "co@example.com\0" }],
       });
+    } catch (error) {
+      expect(error).toBeInstanceOf(AppError);
+      expect((error as AppError).code).toBe("pr_workspace.commit_identity_invalid");
+    }
+
+    const personFromUntrustedProfile = gitPersonFromGithubUser({
+      id: 42,
+      login: "alice",
+      name: "Alice",
+      email: "alice\n@example.com",
+      type: "User",
+    });
+    expect(personFromUntrustedProfile).not.toBeNull();
+    try {
+      gitIdentityEnv(personFromUntrustedProfile!);
     } catch (error) {
       expect(error).toBeInstanceOf(AppError);
       expect((error as AppError).code).toBe("pr_workspace.commit_identity_invalid");

--- a/test/writablePrCheckout.test.ts
+++ b/test/writablePrCheckout.test.ts
@@ -39,6 +39,7 @@ import {
   buildCommitCommandArgs,
   buildTriageCommitAttribution,
   formatCoAuthoredByTrailer,
+  gitIdentityEnv,
   gitPersonFromGithubUser,
   githubNoreplyEmail,
   StaleHeadPushError,
@@ -279,6 +280,66 @@ describe("writable PR checkout", () => {
       coAuthoredBy: [],
       source: "app",
     });
+  });
+
+  it("sanitizes line breaks in GitHub profile names", () => {
+    expect(
+      gitPersonFromGithubUser({
+        id: 42,
+        login: "alice",
+        name: "Alice\nEvil\rTrailer",
+        type: "User",
+      }),
+    ).toEqual({ name: "Alice Evil Trailer", email: githubNoreplyEmail(42, "alice") });
+    expect(
+      gitPersonFromGithubUser({
+        id: 42,
+        login: "alice",
+        name: "\n\r\n",
+        type: "User",
+      }),
+    ).toEqual({ name: "alice", email: githubNoreplyEmail(42, "alice") });
+  });
+
+  it("rejects commit identities with line breaks in name or email", () => {
+    const subject = "fix: guard null user";
+    const validCoAuthor = { name: "Bot", email: "bot@example.com" };
+
+    expect(() => gitIdentityEnv({ name: "Alice\nInject", email: "alice@example.com" })).toThrow(
+      AppError,
+    );
+    expect(() => gitIdentityEnv({ name: "Alice", email: "alice\n@example.com" })).toThrow(AppError);
+    try {
+      gitIdentityEnv({ name: "Alice\r", email: "alice@example.com" });
+    } catch (error) {
+      expect(error).toBeInstanceOf(AppError);
+      expect((error as AppError).code).toBe("pr_workspace.commit_identity_invalid");
+    }
+
+    expect(() =>
+      buildCommitCommandArgs({
+        files: ["x"],
+        subject,
+        coAuthoredBy: [{ name: "Co\nAuthor", email: "co@example.com" }],
+      }),
+    ).toThrow(AppError);
+    expect(() =>
+      buildCommitCommandArgs({
+        files: ["x"],
+        subject,
+        coAuthoredBy: [validCoAuthor, { name: "Other", email: "other\r@example.com" }],
+      }),
+    ).toThrow(AppError);
+    try {
+      buildCommitCommandArgs({
+        files: ["x"],
+        subject,
+        coAuthoredBy: [{ name: "Co", email: "co@example.com\0" }],
+      });
+    } catch (error) {
+      expect(error).toBeInstanceOf(AppError);
+      expect((error as AppError).code).toBe("pr_workspace.commit_identity_invalid");
+    }
   });
 
   it("maps GitHub users to git people with noreply and bot rejection", () => {


### PR DESCRIPTION
## Summary

- Strip CR, LF, and null bytes from GitHub profile names before git identity
- Reject control characters in `validateGitPerson`
- Throw `AppError` when a name or email contains a forbidden character
