### PR TITLE
Treat replacement string literally in modifyWorkspaceFile

### DIFF
--- a/src/agent/triage/triageWorkspaceTools.ts
+++ b/src/agent/triage/triageWorkspaceTools.ts
@@ -264,7 +264,10 @@ export function buildTriageWorkspaceTools(params: {
       const content = await readFile(fullPath, "utf8");
       const matches = countOccurrences(content, oldText);
       if (matches === 1) {
-        await writeFile(fullPath, content.replace(oldText, newText));
+        await writeFile(
+          fullPath,
+          content.replace(oldText, () => newText),
+        );
         return { ok: true, path: rel };
       }
       if (matches > 1) {

--- a/test/triageWorkspaceTools.test.ts
+++ b/test/triageWorkspaceTools.test.ts
@@ -396,6 +396,20 @@ describe("buildTriageWorkspaceTools", () => {
     expect(await readFile(join(root, "src/app.ts"), "utf8")).toBe("const value = 2;\n");
   });
 
+  it("inserts replacement strings with dollar sequences literally", async () => {
+    const { root, executors } = await setup({
+      files: { "src/app.ts": 'const msg = "OLD";\n' },
+    });
+    const newText = 'const msg = "$1 $$ $&";';
+    const out = await executors.editWorkspaceFile({
+      path: "src/app.ts",
+      oldText: 'const msg = "OLD";',
+      newText,
+    });
+    expect(out).toEqual({ ok: true, path: "src/app.ts" });
+    expect(await readFile(join(root, "src/app.ts"), "utf8")).toBe(`${newText}\n`);
+  });
+
   it("edits a CRLF file with the normalized text the model saw, preserving CRLF", async () => {
     const { root, executors } = await setup({
       files: { "src/app.ts": "const value = 1;\r\nconst other = 3;\r\n" },

--- a/test/triageWorkspaceTools.test.ts
+++ b/test/triageWorkspaceTools.test.ts
@@ -400,7 +400,7 @@ describe("buildTriageWorkspaceTools", () => {
     const { root, executors } = await setup({
       files: { "src/app.ts": 'const msg = "OLD";\n' },
     });
-    const newText = 'const msg = "$1 $$ $&";';
+    const newText = 'const msg = "$1 $$ $& $` $\'";';
     const out = await executors.editWorkspaceFile({
       path: "src/app.ts",
       oldText: 'const msg = "OLD";',


### PR DESCRIPTION
## Summary

- Replace via a callback so dollar sequences stay literal in triage edits
