### PR TITLE
Block non-Node manifests in triage write policy

### DIFF
--- a/src/agent/triage/triageWritePolicy.ts
+++ b/src/agent/triage/triageWritePolicy.ts
@@ -53,6 +53,17 @@ export const TRIAGE_CONTROL_PATH_PATTERNS: readonly RegExp[] = [
   /(^|\/)pnpm-workspace\.ya?ml$/i,
   /(^|\/)\.pubignore$/i,
   /(^|\/)pubspec\.ya?ml$/i,
+  /(^|\/)\.gitmodules$/i,
+  /(^|\/)pyproject\.toml$/i,
+  /(^|\/)setup\.(?:py|cfg)$/i,
+  /(^|\/)Cargo\.toml$/i,
+  /(^|\/)go\.(?:mod|work)$/i,
+  /(^|\/)Gemfile$/i,
+  /(^|\/)build\.gradle(?:\.kts)?$/i,
+  /(^|\/)pom\.xml$/i,
+  /(^|\/)CMakeLists\.txt$/i,
+  /(^|\/)bunfig\.toml$/i,
+  /(^|\/)deno\.jsonc?$/i,
 ];
 
 /** New files may only be created under these explicitly safe path classes. */

--- a/src/agent/triage/triageWritePolicy.ts
+++ b/src/agent/triage/triageWritePolicy.ts
@@ -56,14 +56,20 @@ export const TRIAGE_CONTROL_PATH_PATTERNS: readonly RegExp[] = [
   /(^|\/)\.gitmodules$/i,
   /(^|\/)pyproject\.toml$/i,
   /(^|\/)setup\.(?:py|cfg)$/i,
+  /(^|\/)poetry\.lock$/i,
+  /(^|\/)uv\.lock$/i,
   /(^|\/)Cargo\.toml$/i,
+  /(^|\/)Cargo\.lock$/i,
   /(^|\/)go\.(?:mod|work)$/i,
+  /(^|\/)go\.sum$/i,
   /(^|\/)Gemfile$/i,
+  /(^|\/)Gemfile\.lock$/i,
   /(^|\/)build\.gradle(?:\.kts)?$/i,
   /(^|\/)pom\.xml$/i,
   /(^|\/)CMakeLists\.txt$/i,
   /(^|\/)bunfig\.toml$/i,
   /(^|\/)deno\.jsonc?$/i,
+  /(^|\/)deno\.lock$/i,
 ];
 
 /** New files may only be created under these explicitly safe path classes. */

--- a/test/triageWritePolicy.test.ts
+++ b/test/triageWritePolicy.test.ts
@@ -41,14 +41,29 @@ describe("triageWritePolicy", () => {
     ".gitmodules",
     "pyproject.toml",
     "setup.py",
+    "setup.cfg",
+    "poetry.lock",
+    "uv.lock",
     "Cargo.toml",
+    "Cargo.lock",
     "go.mod",
+    "go.work",
+    "go.sum",
     "Gemfile",
+    "Gemfile.lock",
     "build.gradle",
+    "build.gradle.kts",
     "pom.xml",
     "CMakeLists.txt",
     "bunfig.toml",
     "deno.json",
+    "deno.jsonc",
+    "deno.lock",
+    "src/go.mod",
+    "subproject/build.gradle",
+    "lib/pyproject.toml",
+    "vendor/Cargo.toml",
+    "sub/Cargo.lock",
   ] as const)("denies control-plane path %s", (path) => {
     expect(isTriageControlPath(path)).toBe(true);
   });
@@ -68,6 +83,10 @@ describe("triageWritePolicy", () => {
     "src/lib.rs",
     "docs/guide.md",
     "test/foo.test.ts",
+    "pom.xml.template",
+    "CMakeLists.txt.bak",
+    "bunfig.toml.bak",
+    "deno.json.lock",
   ] as const)("allows non-control path %s", (path) => {
     expect(isTriageControlPath(path)).toBe(false);
   });

--- a/test/triageWritePolicy.test.ts
+++ b/test/triageWritePolicy.test.ts
@@ -38,6 +38,17 @@ describe("triageWritePolicy", () => {
     "Makefile",
     "package.json",
     "nub.jsonc",
+    ".gitmodules",
+    "pyproject.toml",
+    "setup.py",
+    "Cargo.toml",
+    "go.mod",
+    "Gemfile",
+    "build.gradle",
+    "pom.xml",
+    "CMakeLists.txt",
+    "bunfig.toml",
+    "deno.json",
   ] as const)("denies control-plane path %s", (path) => {
     expect(isTriageControlPath(path)).toBe(true);
   });
@@ -51,12 +62,15 @@ describe("triageWritePolicy", () => {
     expect(isTriageControlPath(path)).toBe(true);
   });
 
-  it.each(["src/app.ts", "docs/guide.md", "test/foo.test.ts"] as const)(
-    "allows non-control path %s",
-    (path) => {
-      expect(isTriageControlPath(path)).toBe(false);
-    },
-  );
+  it.each([
+    "src/app.ts",
+    "src/main.py",
+    "src/lib.rs",
+    "docs/guide.md",
+    "test/foo.test.ts",
+  ] as const)("allows non-control path %s", (path) => {
+    expect(isTriageControlPath(path)).toBe(false);
+  });
 
   it("requires safe path classes for new files", () => {
     expect(isTriageSafeNewFilePath("docs/note.md")).toBe(true);


### PR DESCRIPTION
## Summary

- Deny `.gitmodules` and non-Node manifests in triage write policy
- Cover the new denied paths in write policy tests
