### PR TITLE
Release database client before remote GitHub summary call

### DIFF
--- a/src/review/publish/publishSummaryOnly.ts
+++ b/src/review/publish/publishSummaryOnly.ts
@@ -22,7 +22,7 @@ import {
   reviewCheckRunOutcome,
 } from "../../agentWork/reviewCheckRun.js";
 import { logDebug, logWarn } from "../../evlog.js";
-import type { PrSurface } from "../../github/prSurface.js";
+import type { IssueCommentRef, PrSurface } from "../../github/prSurface.js";
 import { findCommentIdByMarker } from "../../github/prSurfaceHelpers.js";
 import { isKnownNoAcceptanceMutationError } from "../../github/mutationErrorContract.js";
 import {
@@ -171,21 +171,40 @@ async function upsertSummaryCommentWithoutRevision(
   return prSurface.upsertProgressComment(body, sentinel, scanned);
 }
 
-async function upsertSummaryCommentAtRevision(
+type PreparedRevisionUpsert =
+  | { readonly kind: "skipped"; readonly result: SummaryCommentUpsertResult }
+  | {
+      readonly kind: "write";
+      readonly body: string;
+      readonly hintCommentId?: number | null;
+      readonly stubPostedAtMs: number | null;
+    };
+
+function skippedRevisionResult(
+  currentComment: IssueCommentRef | null,
+  hintCommentId?: number | null,
+): SummaryCommentUpsertResult {
+  if (currentComment) {
+    return { id: currentComment.id, updated: false, skipped: true };
+  }
+  if (hintCommentId != null) {
+    return { id: hintCommentId, updated: false, skipped: true };
+  }
+  return { id: 0, updated: false, skipped: true };
+}
+
+async function prepareSummaryCommentAtRevision(
   params: Omit<SummaryCommentUpsertParams, "pool" | "progressRevision"> & {
     readonly progressRevision: ProgressCommentRevision;
-    readonly preloadedComment?: Awaited<ReturnType<PrSurface["findProgressComment"]>>;
+    readonly currentComment: IssueCommentRef | null;
   },
   client: PoolClient,
-): Promise<SummaryCommentUpsertResult> {
+): Promise<PreparedRevisionUpsert> {
   const [progressOwner, storedRevision] = await Promise.all([
     getProgressCommentOwner(client, params.resourceKey, params.reviewLens),
     getProgressCommentRevision(client, params.resourceKey, params.reviewLens),
   ]);
-  const currentComment =
-    params.preloadedComment !== undefined
-      ? params.preloadedComment
-      : await params.prSurface.findProgressComment(params.sentinel);
+  const currentComment = params.currentComment;
   const bodyRevision = currentComment
     ? parseProgressRevisionState(currentComment.body ?? "")
     : null;
@@ -196,21 +215,19 @@ async function upsertSummaryCommentAtRevision(
     params.workItemId != null &&
     progressOwner.workItemId !== params.workItemId
   ) {
-    if (currentComment) {
-      return { id: currentComment.id, updated: false, skipped: true };
+    if (currentComment == null && params.hintCommentId == null) {
+      logWarn("review_progress_skipped_foreign_owner", {
+        resourceKey: params.resourceKey,
+        reviewLens: params.reviewLens,
+        workItemId: params.workItemId,
+        ownerWorkItemId: progressOwner.workItemId,
+        progressGeneration: progressOwner.generation,
+      });
     }
-    const hintId = params.hintCommentId;
-    if (hintId != null) {
-      return { id: hintId, updated: false, skipped: true };
-    }
-    logWarn("review_progress_skipped_foreign_owner", {
-      resourceKey: params.resourceKey,
-      reviewLens: params.reviewLens,
-      workItemId: params.workItemId,
-      ownerWorkItemId: progressOwner.workItemId,
-      progressGeneration: progressOwner.generation,
-    });
-    return { id: 0, updated: false, skipped: true };
+    return {
+      kind: "skipped",
+      result: skippedRevisionResult(currentComment, params.hintCommentId),
+    };
   }
   const storedRevisionForRun =
     storedRevision != null && storedRevision.workItemId === params.workItemId
@@ -220,9 +237,17 @@ async function upsertSummaryCommentAtRevision(
     bodyRevision != null && bodyRevision.workItemId === params.workItemId
       ? bodyRevision.revision
       : -1;
-  const currentRevision = currentComment ? Math.max(storedRevisionForRun, bodyRevisionForRun) : -1;
-  if (currentComment && currentRevision >= params.progressRevision) {
-    return { id: currentComment.id, updated: false, skipped: true };
+  // Body revision is the published watermark. Stored revision is the lock-time
+  // claim, so a retry after claim-but-before-GitHub can still write when the
+  // comment is behind. A newer claim still wins without holding the lock across HTTP.
+  if (currentComment && bodyRevisionForRun >= params.progressRevision) {
+    return { kind: "skipped", result: { id: currentComment.id, updated: false, skipped: true } };
+  }
+  if (storedRevisionForRun > params.progressRevision) {
+    return {
+      kind: "skipped",
+      result: skippedRevisionResult(currentComment, params.hintCommentId),
+    };
   }
 
   const stubPostedAtMs =
@@ -232,45 +257,32 @@ async function upsertSummaryCommentAtRevision(
         ? await getProgressStubPostedAtMs(client, params.resourceKey, params.reviewLens)
         : null;
 
-  // Persist stubPostedAtMs before the GitHub comment upsert so it survives
-  // even when the subsequent recordAgentWorkPublishStep call fails.
-  if (params.workItemId != null && stubPostedAtMs != null) {
-    await recordAgentWorkPublishStep(client, {
-      workItemId: params.workItemId,
-      resourceKey: params.resourceKey,
-      reviewLens: params.reviewLens,
-      step: "progress_comment",
-      detail: { stubPostedAtMs },
-      leaseEpoch: params.leaseEpoch ?? null,
-    });
-  }
-
-  const result = await upsertSummaryCommentWithoutRevision({
-    ...params,
-    pool: client,
-    body: withProgressRevisionComment(
-      preserveCiSummaryRowInCommentBody(currentComment?.body ?? "", params.body),
-      params.progressRevision,
-      params.workItemId,
-    ),
-    hintCommentId: currentComment?.id ?? params.hintCommentId,
-  });
+  // Claim this revision under the advisory lock before the GitHub write so a
+  // concurrent older tick cannot pass the check after we unlock.
   if (params.workItemId != null) {
     await recordAgentWorkPublishStep(client, {
       workItemId: params.workItemId,
       resourceKey: params.resourceKey,
       reviewLens: params.reviewLens,
       step: "progress_comment",
-      githubId: result.id,
       leaseEpoch: params.leaseEpoch ?? null,
       detail: {
         progressRevision: params.progressRevision,
-        updated: result.updated,
         ...(stubPostedAtMs != null ? { stubPostedAtMs } : {}),
       },
     });
   }
-  return result;
+
+  return {
+    kind: "write",
+    body: withProgressRevisionComment(
+      preserveCiSummaryRowInCommentBody(currentComment?.body ?? "", params.body),
+      params.progressRevision,
+      params.workItemId,
+    ),
+    hintCommentId: currentComment?.id ?? params.hintCommentId,
+    stubPostedAtMs,
+  };
 }
 
 export async function upsertSummaryCommentWithCreationClaim(
@@ -280,21 +292,21 @@ export async function upsertSummaryCommentWithCreationClaim(
     return upsertSummaryCommentWithoutRevision(params);
   }
 
-  const preloadedComment = await params.prSurface.findProgressComment(params.sentinel);
+  const currentComment = await params.prSurface.findProgressComment(params.sentinel);
 
   const client = await params.pool.connect();
   const lockKey = JSON.stringify([params.resourceKey, params.reviewLens]);
   let lockAcquired = false;
   let outcome:
-    | { readonly kind: "success"; readonly value: SummaryCommentUpsertResult }
+    | { readonly kind: "success"; readonly value: PreparedRevisionUpsert }
     | { readonly kind: "error"; readonly error: unknown };
   try {
     await client.query("SELECT pg_advisory_lock(hashtextextended($1, 0))", [lockKey]);
     lockAcquired = true;
     outcome = {
       kind: "success",
-      value: await upsertSummaryCommentAtRevision(
-        { ...params, progressRevision: params.progressRevision, preloadedComment },
+      value: await prepareSummaryCommentAtRevision(
+        { ...params, progressRevision: params.progressRevision, currentComment },
         client,
       ),
     };
@@ -318,7 +330,32 @@ export async function upsertSummaryCommentWithCreationClaim(
   client.release(unlockError === undefined ? undefined : true);
   if (outcome.kind === "error") throw outcome.error;
   if (unlockError !== undefined) throw unlockError;
-  return outcome.value;
+  if (outcome.value.kind === "skipped") return outcome.value.result;
+
+  const result = await upsertSummaryCommentWithoutRevision({
+    ...params,
+    pool: params.pool,
+    body: outcome.value.body,
+    hintCommentId: outcome.value.hintCommentId,
+  });
+  if (params.workItemId != null) {
+    await recordAgentWorkPublishStep(params.pool, {
+      workItemId: params.workItemId,
+      resourceKey: params.resourceKey,
+      reviewLens: params.reviewLens,
+      step: "progress_comment",
+      githubId: result.id,
+      leaseEpoch: params.leaseEpoch ?? null,
+      detail: {
+        progressRevision: params.progressRevision,
+        updated: result.updated,
+        ...(outcome.value.stubPostedAtMs != null
+          ? { stubPostedAtMs: outcome.value.stubPostedAtMs }
+          : {}),
+      },
+    });
+  }
+  return result;
 }
 
 export type PublishSummaryOnlyResult =

--- a/src/review/publish/publishSummaryOnly.ts
+++ b/src/review/publish/publishSummaryOnly.ts
@@ -174,14 +174,18 @@ async function upsertSummaryCommentWithoutRevision(
 async function upsertSummaryCommentAtRevision(
   params: Omit<SummaryCommentUpsertParams, "pool" | "progressRevision"> & {
     readonly progressRevision: ProgressCommentRevision;
+    readonly preloadedComment?: Awaited<ReturnType<PrSurface["findProgressComment"]>>;
   },
   client: PoolClient,
 ): Promise<SummaryCommentUpsertResult> {
-  const [progressOwner, storedRevision, currentComment] = await Promise.all([
+  const [progressOwner, storedRevision] = await Promise.all([
     getProgressCommentOwner(client, params.resourceKey, params.reviewLens),
     getProgressCommentRevision(client, params.resourceKey, params.reviewLens),
-    params.prSurface.findProgressComment(params.sentinel),
   ]);
+  const currentComment =
+    params.preloadedComment !== undefined
+      ? params.preloadedComment
+      : await params.prSurface.findProgressComment(params.sentinel);
   const bodyRevision = currentComment
     ? parseProgressRevisionState(currentComment.body ?? "")
     : null;
@@ -276,6 +280,8 @@ export async function upsertSummaryCommentWithCreationClaim(
     return upsertSummaryCommentWithoutRevision(params);
   }
 
+  const preloadedComment = await params.prSurface.findProgressComment(params.sentinel);
+
   const client = await params.pool.connect();
   const lockKey = JSON.stringify([params.resourceKey, params.reviewLens]);
   let lockAcquired = false;
@@ -288,7 +294,7 @@ export async function upsertSummaryCommentWithCreationClaim(
     outcome = {
       kind: "success",
       value: await upsertSummaryCommentAtRevision(
-        { ...params, progressRevision: params.progressRevision },
+        { ...params, progressRevision: params.progressRevision, preloadedComment },
         client,
       ),
     };

--- a/test/publishReview.summaryCoordination.test.ts
+++ b/test/publishReview.summaryCoordination.test.ts
@@ -359,7 +359,9 @@ describe("upsertSummaryCommentWithCreationClaim", () => {
     const { pool: lockedPool, release } = createLockedPool();
     vi.mocked(getProgressCommentRevision).mockResolvedValue(null);
     harness.findProgressComment.mockResolvedValue(null);
-    vi.mocked(recordPublishStep).mockRejectedValueOnce(new Error("record failed"));
+    vi.mocked(recordPublishStep)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("record failed"));
 
     await expect(
       upsertSummaryCommentWithCreationClaim({
@@ -386,7 +388,7 @@ describe("upsertSummaryCommentWithCreationClaim", () => {
     ).resolves.toEqual({ id: 99, updated: false, skipped: true });
 
     expect(harness.upsertProgressComment).toHaveBeenCalledOnce();
-    expect(recordPublishStep).toHaveBeenCalledOnce();
+    expect(recordPublishStep).toHaveBeenCalledTimes(2);
     expect(release).toHaveBeenCalledTimes(2);
   });
 
@@ -409,9 +411,63 @@ describe("upsertSummaryCommentWithCreationClaim", () => {
     ).rejects.toThrow("write failed");
 
     expect(getProgressCommentRevision).toHaveBeenCalledWith(client, "o/r#1", "review");
-    expect(recordPublishStep).not.toHaveBeenCalled();
+    expect(recordPublishStep).toHaveBeenCalledWith(
+      client,
+      expect.objectContaining({
+        step: "progress_comment",
+        detail: expect.objectContaining({ progressRevision: 2 }),
+      }),
+    );
     expect(query.mock.calls.at(-1)?.[0]).toContain("pg_advisory_unlock");
     expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("does not hold the pooled client across GitHub progress-comment calls", async () => {
+    const { client, query, release } = createLockedPool();
+    const order: string[] = [];
+    const pool = {
+      connect: vi.fn(async () => {
+        order.push("connect");
+        return client;
+      }),
+    } as unknown as Pool;
+    query.mockImplementation(async (sql: string) => {
+      if (sql.includes("pg_advisory_lock")) order.push("lock");
+      if (sql.includes("pg_advisory_unlock")) order.push("unlock");
+      return { rows: [] };
+    });
+    release.mockImplementation(() => {
+      order.push("release");
+    });
+    harness.findProgressComment.mockImplementation(async () => {
+      order.push("find");
+      return {
+        id: 88,
+        url: "https://example.com/88",
+        body: `${REVIEW_SUMMARY_SENTINEL}\n<!-- pr-agent:progress-revision workItemId=wi-1 value=0 -->`,
+      };
+    });
+    harness.resolveProgressComment.mockImplementation(async () => {
+      order.push("resolve");
+      return { id: 88, url: "https://example.com/88" };
+    });
+    harness.upsertProgressComment.mockImplementation(async () => {
+      order.push("upsert");
+      return { id: 88, updated: true };
+    });
+
+    await upsertSummaryCommentWithCreationClaim({
+      ...claimBase(),
+      pool,
+      progressRevision: 2,
+    });
+
+    expect(order.indexOf("find")).toBeGreaterThan(-1);
+    expect(order.indexOf("find")).toBeLessThan(order.indexOf("connect"));
+    expect(order.indexOf("unlock")).toBeLessThan(order.indexOf("resolve"));
+    expect(order.indexOf("release")).toBeLessThan(order.indexOf("resolve"));
+    expect(order.indexOf("unlock")).toBeLessThan(order.indexOf("upsert"));
+    expect(order.indexOf("release")).toBeLessThan(order.indexOf("upsert"));
   });
 
   it("releases the client when advisory lock acquisition fails", async () => {

--- a/test/publishReview.summaryCoordination.test.ts
+++ b/test/publishReview.summaryCoordination.test.ts
@@ -392,6 +392,70 @@ describe("upsertSummaryCommentWithCreationClaim", () => {
     expect(release).toHaveBeenCalledTimes(2);
   });
 
+  it("retries after a claim recorded under the lock but before the GitHub write", async () => {
+    const { pool: lockedPool } = createLockedPool();
+    vi.mocked(getProgressCommentRevision).mockResolvedValue({ workItemId: "wi-1", revision: 2 });
+    harness.findProgressComment.mockResolvedValue({
+      id: 88,
+      url: "https://example.com/88",
+      body: `${REVIEW_SUMMARY_SENTINEL}\nno revision marker yet`,
+    });
+
+    const result = await upsertSummaryCommentWithCreationClaim({
+      ...claimBase(),
+      pool: lockedPool,
+      progressRevision: 2,
+    });
+
+    expect(result).toEqual({ id: 99, updated: false });
+    const writtenBody = harness.upsertProgressComment.mock.calls[0]?.[0] as string;
+    expect(writtenBody).toContain("workItemId=wi-1 value=2");
+  });
+
+  it("logs the foreign-owner warning only without a comment or hint", async () => {
+    const { pool: lockedPool } = createLockedPool();
+    vi.mocked(getProgressCommentOwner).mockResolvedValue({
+      workItemId: "wi-b",
+      generation: 2,
+    });
+    harness.findProgressComment.mockResolvedValue(null);
+
+    await expect(
+      upsertSummaryCommentWithCreationClaim({
+        ...claimBase(),
+        pool: lockedPool,
+        workItemId: "wi-a",
+        progressRevision: 0,
+      }),
+    ).resolves.toEqual({ id: 0, updated: false, skipped: true });
+
+    expect(logWarn).toHaveBeenCalledWith(
+      "review_progress_skipped_foreign_owner",
+      expect.objectContaining({ ownerWorkItemId: "wi-b" }),
+    );
+
+    vi.mocked(logWarn).mockClear();
+    harness.findProgressComment.mockResolvedValue({
+      id: 88,
+      url: "https://example.com/88",
+      body: `${REVIEW_SUMMARY_SENTINEL}\n<!-- pr-agent:progress-revision workItemId=wi-b value=1 -->`,
+    });
+
+    await expect(
+      upsertSummaryCommentWithCreationClaim({
+        ...claimBase(),
+        pool: lockedPool,
+        workItemId: "wi-a",
+        progressRevision: 0,
+      }),
+    ).resolves.toMatchObject({ id: 88, updated: false, skipped: true });
+
+    expect(logWarn).not.toHaveBeenCalledWith(
+      "review_progress_skipped_foreign_owner",
+      expect.anything(),
+    );
+  });
+
   it("records a revision after the GitHub upsert and unlocks on failure", async () => {
     const { client, pool: lockedPool, query, release } = createLockedPool();
     vi.mocked(getProgressCommentRevision).mockResolvedValue({ workItemId: "wi-1", revision: 0 });


### PR DESCRIPTION
## Summary

- Claim the progress revision under the advisory lock, then release
- Run the GitHub progress upsert after the database client is released
- Prefetch the progress comment before taking the lock
- Record the published comment id in a short independent write
- Assert the release precedes GitHub calls in the coordination test
