### PR TITLE
List conversation comments once during CI refresh

### DIFF
--- a/src/agentWork/executors/ciRefreshExecutor.ts
+++ b/src/agentWork/executors/ciRefreshExecutor.ts
@@ -64,9 +64,11 @@ export async function executeCiRefreshJob(
     return;
   }
 
+  const conversationComments = await prSurface.listConversationComments();
+
   for (const sentinel of SUMMARY_SENTINELS) {
     try {
-      const comment = await prSurface.findProgressComment(sentinel);
+      const comment = conversationComments.findLast((c) => (c.body ?? "").startsWith(sentinel));
       if (comment == null) continue;
 
       const meta = parseReviewMetaFromCommentBody(comment.body ?? "");

--- a/src/agentWork/executors/ciRefreshExecutor.ts
+++ b/src/agentWork/executors/ciRefreshExecutor.ts
@@ -11,7 +11,7 @@ import {
 import { parseReviewMetaFromCommentBody } from "../../review/ci/reviewMetaParse.js";
 import { REVIEW_CI_SUMMARY_MAX_FAILURES, REVIEW_SUMMARY_SENTINEL } from "../../settings/index.js";
 import { LEGACY_REVIEW_SUMMARY_SENTINELS } from "../../settings/legacyReviewLenses.js";
-import { createPrSurface } from "../../github/prSurface.js";
+import { createPrSurface, type PrConversationComment } from "../../github/prSurface.js";
 import { mintInstallationToken } from "../durableJob.js";
 import { hasActiveReviewWorkItem } from "../repository.js";
 import type { CiRefreshJobData } from "../types.js";
@@ -64,18 +64,29 @@ export async function executeCiRefreshJob(
     return;
   }
 
-  const conversationComments = await prSurface.listConversationComments();
+  let conversationComments: readonly PrConversationComment[];
+  try {
+    conversationComments = await prSurface.listConversationComments();
+  } catch (error) {
+    logWarn("ci_refresh_list_comments_failed", {
+      owner: data.owner,
+      repo: data.repo,
+      pr: data.prNumber,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return;
+  }
 
   for (const sentinel of SUMMARY_SENTINELS) {
     try {
-      const comment = conversationComments.findLast((c) => (c.body ?? "").startsWith(sentinel));
+      const comment = conversationComments.findLast((c) => c.body.startsWith(sentinel));
       if (comment == null) continue;
 
-      const meta = parseReviewMetaFromCommentBody(comment.body ?? "");
+      const meta = parseReviewMetaFromCommentBody(comment.body);
       if (meta == null || meta.headSha !== data.headSha) continue;
-      if (!commentBodyHasCiSummaryCell(comment.body ?? "")) continue;
+      if (!commentBodyHasCiSummaryCell(comment.body)) continue;
 
-      const patched = patchCiSummaryCellInCommentBody(comment.body ?? "", ciSummary);
+      const patched = patchCiSummaryCellInCommentBody(comment.body, ciSummary);
       if (patched == null || patched === comment.body) continue;
 
       await prSurface.editComment(comment.id, patched);

--- a/test/ciRefreshExecutor.test.ts
+++ b/test/ciRefreshExecutor.test.ts
@@ -78,7 +78,7 @@ describe("executeCiRefreshJob", () => {
 
     expect(mocks.hasActiveReviewWorkItem).toHaveBeenCalledWith(pool, "o/r#7");
     expect(
-      surfaceBundle.controls.events.some((event) => event.kind === "findProgressComment"),
+      surfaceBundle.controls.events.some((event) => event.kind === "listConversationComments"),
     ).toBe(false);
     expect(surfaceBundle.controls.events.some((event) => event.kind === "editComment")).toBe(false);
   });
@@ -90,7 +90,7 @@ describe("executeCiRefreshJob", () => {
 
     expect(mocks.hasActiveReviewWorkItem).toHaveBeenCalledWith(pool, "o/r#7");
     expect(
-      surfaceBundle.controls.events.some((event) => event.kind === "findProgressComment"),
+      surfaceBundle.controls.events.some((event) => event.kind === "listConversationComments"),
     ).toBe(true);
     expect(surfaceBundle.controls.events.some((event) => event.kind === "editComment")).toBe(true);
   });

--- a/test/ciRefreshExecutor.test.ts
+++ b/test/ciRefreshExecutor.test.ts
@@ -94,4 +94,14 @@ describe("executeCiRefreshJob", () => {
     ).toBe(true);
     expect(surfaceBundle.controls.events.some((event) => event.kind === "editComment")).toBe(true);
   });
+
+  it("logs and returns without edits when listing comments fails", async () => {
+    vi.spyOn(surfaceBundle.surface, "listConversationComments").mockRejectedValueOnce(
+      new Error("rate limited"),
+    );
+
+    await expect(executeCiRefreshJob(cfg, pool, data)).resolves.toBeUndefined();
+
+    expect(surfaceBundle.controls.events.some((event) => event.kind === "editComment")).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

- Fetch conversation comments once before iterating CI refresh sentinels
- Match progress comments in memory with `findLast`
