### PR TITLE
Destroy connection on unlock or rollback failure

### DIFF
--- a/src/codeIndex/buildJob.ts
+++ b/src/codeIndex/buildJob.ts
@@ -78,9 +78,10 @@ export async function buildCodeIndexFromWorkspace(
   if (snapshot.status === "ready") return;
 
   const client = await pool.connect();
+  let unlockError: unknown;
   try {
     // Serialize inline + worker builders for the same snapshot.
-    await client.query("SELECT pg_advisory_lock(hashtext($1::text))", [snapshot.id]);
+    await client.query("SELECT pg_advisory_lock(hashtextextended($1::text, 0))", [snapshot.id]);
     try {
       const current = await getSnapshotById(client, snapshot.id);
       if (!current || current.status === "ready") return;
@@ -101,12 +102,20 @@ export async function buildCodeIndexFromWorkspace(
         throw error;
       }
     } finally {
-      await client
-        .query("SELECT pg_advisory_unlock(hashtext($1::text))", [snapshot.id])
-        .catch(() => undefined);
+      try {
+        await client.query("SELECT pg_advisory_unlock(hashtextextended($1::text, 0))", [
+          snapshot.id,
+        ]);
+      } catch (error) {
+        unlockError = error;
+        logWarn("code_index_unlock_failed", {
+          snapshotId: snapshot.id,
+          message: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
   } finally {
-    client.release();
+    client.release(unlockError !== undefined ? true : undefined);
   }
 }
 

--- a/src/db/postgres.ts
+++ b/src/db/postgres.ts
@@ -37,16 +37,21 @@ export async function inTransaction<T>(
   fn: (client: PoolClient) => Promise<T>,
 ): Promise<T> {
   const client = await pool.connect();
+  let rollbackError: unknown;
   try {
     await client.query("BEGIN");
     const result = await fn(client);
     await client.query("COMMIT");
     return result;
   } catch (e) {
-    await client.query("ROLLBACK");
+    try {
+      await client.query("ROLLBACK");
+    } catch (error) {
+      rollbackError = error;
+    }
     throw e;
   } finally {
-    client.release();
+    client.release(rollbackError !== undefined ? true : undefined);
   }
 }
 

--- a/src/db/postgres.ts
+++ b/src/db/postgres.ts
@@ -1,6 +1,7 @@
 import { Pool, type PoolClient, type QueryResult, type QueryResultRow } from "pg";
 import type { Db } from "pg-boss";
 import type { Config } from "../config.js";
+import { logWarn } from "../evlog.js";
 import {
   POSTGRES_CONNECTION_TIMEOUT_MS,
   POSTGRES_IDLE_IN_TRANSACTION_TIMEOUT_MS,
@@ -48,6 +49,9 @@ export async function inTransaction<T>(
       await client.query("ROLLBACK");
     } catch (error) {
       rollbackError = error;
+      logWarn("postgres_rollback_failed", {
+        message: error instanceof Error ? error.message : String(error),
+      });
     }
     throw e;
   } finally {


### PR DESCRIPTION
## Summary

- Upgrade code index advisory locks to 64-bit `hashtextextended`
- Destroy the Postgres client on unlock or rollback failure
