### PR TITLE
Configure oxlint allowlist and clear lint warnings

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -6,7 +6,13 @@
     "suspicious": "warn"
   },
   "rules": {
-    "typescript/no-unsafe-type-assertion": "off"
+    "typescript/no-unsafe-type-assertion": "off",
+    "eslint/no-underscore-dangle": [
+      "warn",
+      {
+        "allow": ["_exhaustive", "__mutating", "__result", "_parentReplacement"]
+      }
+    ]
   },
   "env": {
     "node": true

--- a/src/agent/tools/context7Tools.ts
+++ b/src/agent/tools/context7Tools.ts
@@ -84,7 +84,7 @@ function toPiTool(name: string, t: ReviewTool): PiTool {
     description: t.description,
     parameters: toJsonSchema(t.schema, {
       errorMode: "ignore",
-    }) as PiTool["parameters"],
+    }),
   };
 }
 

--- a/src/agent/tools/parseToolInput.ts
+++ b/src/agent/tools/parseToolInput.ts
@@ -51,7 +51,7 @@ function baseNode(node: SchemaNode): SchemaNode {
  * shape we cannot walk — an unresolvable path is simply never repaired.
  */
 function schemaNodeAtPath(schema: v.GenericSchema, dotPath: string): SchemaNode | null {
-  let current: SchemaNode = schema as unknown as SchemaNode;
+  let current: SchemaNode = schema;
   if (dotPath === "") return current;
   for (const segment of dotPath.split(".")) {
     const base = baseNode(current);
@@ -149,7 +149,7 @@ export function parseToolInput<TSchema extends v.GenericSchema>(
 ): ParsedToolInput<v.InferOutput<TSchema>> {
   const first = v.safeParse(schema, raw);
   if (first.success) {
-    return { ok: true, value: first.output as v.InferOutput<TSchema>, repairs: [] };
+    return { ok: true, value: first.output, repairs: [] };
   }
 
   const title = opts.errorTitle ?? "Tool input validation failed:";
@@ -199,5 +199,5 @@ export function parseToolInput<TSchema extends v.GenericSchema>(
       issues: second.issues,
     };
   }
-  return { ok: true, value: second.output as v.InferOutput<TSchema>, repairs };
+  return { ok: true, value: second.output, repairs };
 }

--- a/src/agent/triage/publishTriage.ts
+++ b/src/agent/triage/publishTriage.ts
@@ -562,9 +562,11 @@ export async function publishTriage(params: PublishTriageParams): Promise<Publis
   }
 
   if (params.findingHistoryCfg) {
-    const threadById = new Map(params.inventory.map((thread) => [thread.rootCommentId, thread]));
+    const activeThreadById = new Map(
+      params.inventory.map((thread) => [thread.rootCommentId, thread]),
+    );
     for (const verdict of params.payload.verdicts) {
-      const thread = threadById.get(verdict.threadRootCommentId);
+      const thread = activeThreadById.get(verdict.threadRootCommentId);
       if (!thread) continue;
       safeRecordThreadFindingHistoryOutcome(params.pool, params.findingHistoryCfg, {
         scope: {

--- a/src/agentRun/sessionHelpers.ts
+++ b/src/agentRun/sessionHelpers.ts
@@ -1,4 +1,4 @@
-import type { Api, AssistantMessage, ProviderId } from "@earendil-works/pi-ai";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
 import type { Config } from "../config.js";
 import type { AgentRunnerTurn } from "../agent/providers/interface.js";
 import type { PiSession } from "../agent/runtime/types.js";
@@ -7,8 +7,8 @@ export function assistantFromText(cfg: Config, text: string, provider: string): 
   return {
     role: "assistant",
     content: text ? [{ type: "text", text }] : [],
-    api: cfg.piApi as Api,
-    provider: (provider || cfg.piProvider) as ProviderId,
+    api: cfg.piApi,
+    provider: provider || cfg.piProvider,
     model: cfg.piModel,
     usage: {
       input: 0,

--- a/src/agentWork/findingHistoryRepository.ts
+++ b/src/agentWork/findingHistoryRepository.ts
@@ -304,7 +304,7 @@ export function safeRecordThreadFindingHistoryOutcome(
   })
     .then((fingerprint) => {
       if (fingerprint == null) return;
-      void recordFindingHistoryOutcome(client, params.scope, fingerprint, params.outcome);
+      return recordFindingHistoryOutcome(client, params.scope, fingerprint, params.outcome);
     })
     .catch((error) => {
       logWarn("finding_history_thread_outcome_failed", {

--- a/src/agentWork/findingHistoryRepository.ts
+++ b/src/agentWork/findingHistoryRepository.ts
@@ -304,7 +304,7 @@ export function safeRecordThreadFindingHistoryOutcome(
   })
     .then((fingerprint) => {
       if (fingerprint == null) return;
-      return recordFindingHistoryOutcome(client, params.scope, fingerprint, params.outcome);
+      void recordFindingHistoryOutcome(client, params.scope, fingerprint, params.outcome);
     })
     .catch((error) => {
       logWarn("finding_history_thread_outcome_failed", {

--- a/src/agentWork/intake/slashIntake.ts
+++ b/src/agentWork/intake/slashIntake.ts
@@ -319,24 +319,27 @@ async function handleSlashReview(ctx: SlashIntakeContext): Promise<void> {
     };
     const cancelled = await cancelActiveReviews(ctx.client, resourceKey, attribution);
     if (cancelled.length > 0) {
-      cancelProgress = {
-        workItemId: cancelled[0]!.id,
-        cancelledWorkItemIds: cancelled.map((row) => row.id),
-        attribution,
-      };
-      ctx.events.push({
-        name: "agent_work_cancel_requested",
-        fields: {
-          type: "review",
-          source: "slash",
-          workItemId: cancelled[0]!.id,
-          resourceKey,
-          cancelledCount: cancelled.length,
-          cancelledByLogin: attribution.login,
-          force: true,
-          ...ctx.correlation,
-        },
-      });
+      const primary = cancelled[0];
+      if (primary) {
+        cancelProgress = {
+          workItemId: primary.id,
+          cancelledWorkItemIds: cancelled.map((row) => row.id),
+          attribution,
+        };
+        ctx.events.push({
+          name: "agent_work_cancel_requested",
+          fields: {
+            type: "review",
+            source: "slash",
+            workItemId: primary.id,
+            resourceKey,
+            cancelledCount: cancelled.length,
+            cancelledByLogin: attribution.login,
+            force: true,
+            ...ctx.correlation,
+          },
+        });
+      }
     }
   }
   const insert = await createReviewWorkItem(ctx.client, {
@@ -398,7 +401,8 @@ async function handleSlashCancel(ctx: SlashIntakeContext): Promise<void> {
     });
     return;
   }
-  const primary = cancelled[0]!;
+  const primary = cancelled[0];
+  if (primary == null) return;
   const cancelledWorkItemIds = cancelled.map((row) => row.id);
   await enqueueSlashAck(ctx, {
     cancelProgress: {

--- a/src/agentWork/intake/workItemRepository.ts
+++ b/src/agentWork/intake/workItemRepository.ts
@@ -471,6 +471,52 @@ export type CancelledActiveTriage = {
   readonly replyTarget: ReplyTarget;
 };
 
+function sortWorkItemsByCreatedAtDesc<T extends { id: string; created_at: Date | string }>(
+  rows: readonly T[],
+): T[] {
+  return [...rows].toSorted((a, b) => {
+    const ta = new Date(a.created_at).getTime();
+    const tb = new Date(b.created_at).getTime();
+    if (tb !== ta) return tb - ta;
+    return b.id.localeCompare(a.id);
+  });
+}
+
+function mapCancelledReviewRows(
+  rows: readonly {
+    id: string;
+    source: WorkSource;
+    head_sha: string;
+    created_at: Date | string;
+  }[],
+): CancelledActiveReview[] {
+  return sortWorkItemsByCreatedAtDesc(rows).map((row) => ({
+    id: row.id,
+    source: row.source,
+    headSha: row.head_sha,
+  }));
+}
+
+function mapCancelledTriageRows(
+  rows: readonly {
+    id: string;
+    head_sha: string;
+    created_at: Date | string;
+    payload: unknown;
+  }[],
+  prNumber: number | undefined,
+): CancelledActiveTriage[] {
+  return sortWorkItemsByCreatedAtDesc(rows).map((row) => {
+    const payload = parseWorkItemPayload("triage", row.payload);
+    return {
+      id: row.id,
+      headSha: row.head_sha,
+      ackTargets: triageAckTargets(payload, prNumber),
+      replyTarget: payload.replyTarget,
+    };
+  });
+}
+
 /**
  * Cancel every queued/running review for a PR (auto or slash).
  * Both queued and running become `cancelled` immediately so the slash uniqueness
@@ -486,26 +532,6 @@ export async function cancelActiveReviews(
 ): Promise<readonly CancelledActiveReview[]> {
   const payloadPatch = JSON.stringify({ cancelAttribution: attribution });
   const lastError = reviewCancelLastError(attribution);
-  const mapRows = (
-    rows: readonly {
-      id: string;
-      source: WorkSource;
-      head_sha: string;
-      created_at: Date | string;
-    }[],
-  ): CancelledActiveReview[] =>
-    [...rows]
-      .sort((a, b) => {
-        const ta = new Date(a.created_at).getTime();
-        const tb = new Date(b.created_at).getTime();
-        if (tb !== ta) return tb - ta;
-        return b.id.localeCompare(a.id);
-      })
-      .map((row) => ({
-        id: row.id,
-        source: row.source,
-        headSha: row.head_sha,
-      }));
 
   const queued = await client.query<{
     id: string;
@@ -544,7 +570,7 @@ export async function cancelActiveReviews(
 		  RETURNING id, source, head_sha, created_at`,
     [resourceKey, lastError, payloadPatch],
   );
-  return [...mapRows(running.rows), ...mapRows(queued.rows)];
+  return [...mapCancelledReviewRows(running.rows), ...mapCancelledReviewRows(queued.rows)];
 }
 
 function triageAckTargets(
@@ -574,30 +600,6 @@ export async function cancelActiveTriage(
 ): Promise<readonly CancelledActiveTriage[]> {
   const payloadPatch = JSON.stringify({ cancelAttribution: attribution });
   const lastError = reviewCancelLastError(attribution);
-  const mapRows = (
-    rows: readonly {
-      id: string;
-      head_sha: string;
-      created_at: Date | string;
-      payload: unknown;
-    }[],
-  ): CancelledActiveTriage[] =>
-    [...rows]
-      .sort((a, b) => {
-        const ta = new Date(a.created_at).getTime();
-        const tb = new Date(b.created_at).getTime();
-        if (tb !== ta) return tb - ta;
-        return b.id.localeCompare(a.id);
-      })
-      .map((row) => {
-        const payload = parseWorkItemPayload("triage", row.payload);
-        return {
-          id: row.id,
-          headSha: row.head_sha,
-          ackTargets: triageAckTargets(payload, prNumber),
-          replyTarget: payload.replyTarget,
-        };
-      });
 
   const queued = await client.query<{
     id: string;
@@ -636,7 +638,10 @@ export async function cancelActiveTriage(
 		 RETURNING id, head_sha, created_at, payload`,
     [resourceKey, lastError, payloadPatch],
   );
-  return [...mapRows(running.rows), ...mapRows(queued.rows)];
+  return [
+    ...mapCancelledTriageRows(running.rows, prNumber),
+    ...mapCancelledTriageRows(queued.rows, prNumber),
+  ];
 }
 
 export async function createAskWorkItem(

--- a/src/agentWork/withOperationIntent.ts
+++ b/src/agentWork/withOperationIntent.ts
@@ -161,10 +161,10 @@ function hasStashedResult(detail: Record<string, unknown>): boolean {
   return Object.prototype.hasOwnProperty.call(detail, OPERATION_INTENT_RESULT_KEY);
 }
 
-function stashedResultValue<T>(detail: Record<string, unknown>): T {
+function stashedResultValue(detail: Record<string, unknown>): unknown {
   // null is the durable sentinel for a successful void mutate() return.
   const value = detail[OPERATION_INTENT_RESULT_KEY];
-  return (value === null ? undefined : value) as T;
+  return value === null ? undefined : value;
 }
 
 function leaseEpochDetail<T>(
@@ -191,7 +191,7 @@ async function finishWithStashedResult<T>(
       },
     });
   }
-  return stashedResultValue<T>(intent.detail);
+  return stashedResultValue(intent.detail) as T;
 }
 
 type RecoveryAttempt<T> = { readonly found: true; readonly value: T } | { readonly found: false };

--- a/src/codeIndex/repository.ts
+++ b/src/codeIndex/repository.ts
@@ -93,7 +93,7 @@ export async function ensureBuildingSnapshot(
   const row = rows[0];
   if (!row) {
     throw new AppError({
-      code: "code_index_snapshot_upsert_failed",
+      code: "code_index.snapshot_upsert_failed",
       message: "INSERT did not return a snapshot row",
     });
   }

--- a/src/codeIndex/repository.ts
+++ b/src/codeIndex/repository.ts
@@ -1,4 +1,5 @@
 import type { Pool, PoolClient } from "pg";
+import { AppError } from "../errors/appError.js";
 import { logWarn } from "../evlog.js";
 import { CODE_INDEX_CHUNKER_VERSION } from "../settings/index.js";
 import type { CodeIndexChunk } from "./chunker.js";
@@ -89,7 +90,14 @@ export async function ensureBuildingSnapshot(
      RETURNING id, status, chunker_version`,
     [scope.installationId, scope.owner, scope.repo, scope.headSha, CODE_INDEX_CHUNKER_VERSION],
   );
-  return mapSnapshot(rows[0]!);
+  const row = rows[0];
+  if (!row) {
+    throw new AppError({
+      code: "code_index_snapshot_upsert_failed",
+      message: "INSERT did not return a snapshot row",
+    });
+  }
+  return mapSnapshot(row);
 }
 
 export async function getSnapshotById(

--- a/src/config.ts
+++ b/src/config.ts
@@ -552,7 +552,7 @@ export async function loadConfig() {
     DEFAULT_LOG_LEVEL,
   );
 
-  const logPrettyDefault = process.env.NODE_ENV === "production" ? false : true;
+  const logPrettyDefault = process.env.NODE_ENV !== "production";
   const logPretty = readStrictBoolean(ENV.LOG_PRETTY, logPrettyDefault);
   const logRedact = readStrictBoolean(ENV.LOG_REDACT, DEFAULT_LOG_REDACT);
 

--- a/src/effect/services/webhookHandlers.ts
+++ b/src/effect/services/webhookHandlers.ts
@@ -161,7 +161,7 @@ export const WebhookHandlersCore = Layer.effect(
             intakeLog,
             {
               pushBeforeSha: data.before,
-              merged: data.pull_request.merged === true,
+              merged: data.pull_request.merged,
             },
           );
         }),

--- a/src/evlog.ts
+++ b/src/evlog.ts
@@ -203,7 +203,7 @@ export function initEvlog(
   initLogger({
     env: {
       service: "pr-agent",
-      environment: (process.env.NODE_ENV ?? "development") as "development" | "production" | "test",
+      environment: process.env.NODE_ENV ?? "development",
     },
     minLevel: logLevel,
     pretty: options?.pretty ?? !isProduction,

--- a/src/github/fakePrSurface.ts
+++ b/src/github/fakePrSurface.ts
@@ -384,8 +384,8 @@ export function createFakePrSurface(
     setPriorInlineFeedback(next) {
       priorInlineFeedback = [...next];
     },
-    setBotFindingThreads(threads) {
-      botFindingThreads = [...threads];
+    setBotFindingThreads(nextThreads) {
+      botFindingThreads = [...nextThreads];
     },
     setReviewCommentParentGraph(nodes) {
       reviewCommentParentGraph = [...nodes];

--- a/src/github/githubErrors.ts
+++ b/src/github/githubErrors.ts
@@ -53,7 +53,7 @@ export type GithubErrorKind =
 export function githubErrorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
   if (typeof error === "object" && error != null && "message" in error) {
-    return String((error as { message: unknown }).message);
+    return String(error.message);
   }
   return String(error);
 }

--- a/src/github/prSurfaceImpl.ts
+++ b/src/github/prSurfaceImpl.ts
@@ -273,7 +273,7 @@ async function listLifecycleReactions(
       repo,
       issue_number: target.prNumber,
       per_page: 100,
-    }) as Promise<readonly ListedReaction[]>;
+    });
   }
   if (target.kind === "issueComment") {
     return octokit.paginate(octokit.rest.reactions.listForIssueComment, {
@@ -281,14 +281,14 @@ async function listLifecycleReactions(
       repo,
       comment_id: target.commentId,
       per_page: 100,
-    }) as Promise<readonly ListedReaction[]>;
+    });
   }
   return octokit.paginate(octokit.rest.reactions.listForPullRequestReviewComment, {
     owner,
     repo,
     comment_id: target.commentId,
     per_page: 100,
-  }) as Promise<readonly ListedReaction[]>;
+  });
 }
 
 async function deleteReaction(

--- a/src/review/placement/reviewDiffIndex.ts
+++ b/src/review/placement/reviewDiffIndex.ts
@@ -146,7 +146,7 @@ export function wrapListPullRequestFilesDiffIngestion(
     const out = await original(args);
     cachedDiffIndex.listPullRequestFilesIngested = true;
     if (out && typeof out === "object") {
-      ingestListPullRequestFilesResult(cachedDiffIndex, out as ListPullRequestFilesToolResult);
+      ingestListPullRequestFilesResult(cachedDiffIndex, out);
     }
     return out;
   };

--- a/src/util/uuidv5.ts
+++ b/src/util/uuidv5.ts
@@ -9,8 +9,8 @@ export function uuidv5(namespaceUuid: string, name: string): string {
     throw new Error(`invalid UUID namespace: ${namespaceUuid}`);
   }
   const hash = createHash("sha1").update(ns).update(name, "utf8").digest();
-  hash[6] = (hash[6]! & 0x0f) | 0x50;
-  hash[8] = (hash[8]! & 0x3f) | 0x80;
+  hash[6] = (hash[6] & 0x0f) | 0x50;
+  hash[8] = (hash[8] & 0x3f) | 0x80;
   const hex = hash.subarray(0, 16).toString("hex");
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }

--- a/test/findingHistoryRepository.test.ts
+++ b/test/findingHistoryRepository.test.ts
@@ -6,9 +6,17 @@ import {
   lookupThreadFingerprint,
   recordFindingHistoryOutcome,
   safeLoadCrossPrSuppressionFingerprints,
+  safeRecordThreadFindingHistoryOutcome,
   safeUpsertFindingHistoryOpen,
   upsertFindingHistoryOpen,
 } from "../src/agentWork/findingHistoryRepository.js";
+
+vi.mock("../src/evlog.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/evlog.js")>();
+  return { ...actual, logWarn: vi.fn() };
+});
+
+import { logWarn } from "../src/evlog.js";
 
 const cfg = {
   findingHistoryEnabled: true,
@@ -133,6 +141,65 @@ describe("safeUpsertFindingHistoryOpen", () => {
       safeUpsertFindingHistoryOpen(pool, { findingHistoryEnabled: true }, openScope, ["fp-a"]),
     ).not.toThrow();
     await expect(query.mock.results[0]?.value).rejects.toThrow("db down");
+  });
+});
+
+describe("safeRecordThreadFindingHistoryOutcome", () => {
+  it("routes an inner outcome failure to the warning instead of rejecting", async () => {
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            detail: {
+              batches: [
+                {
+                  workItemId: "wi-1",
+                  reviewId: 1,
+                  fingerprints: ["fp-1"],
+                  placements: [
+                    {
+                      finding: {
+                        severity: "P2",
+                        file: "a.ts",
+                        startLine: 5,
+                        endLine: 5,
+                        title: "t",
+                        detail: "d",
+                        fixPrompt: "f",
+                      },
+                      resolvedLine: 5,
+                      canonicalFingerprint: "fp-1",
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      })
+      .mockRejectedValueOnce(new Error("outcome write failed"));
+    const pool = { query } as unknown as Pool;
+
+    expect(() =>
+      safeRecordThreadFindingHistoryOutcome(
+        pool,
+        { findingHistoryEnabled: true },
+        {
+          scope: { ...openScope, workItemId: "wi-1" },
+          resourceKey: "acme/app#12",
+          thread: { path: "a.ts", line: 5 },
+          outcome: "fixed",
+        },
+      ),
+    ).not.toThrow();
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(logWarn).toHaveBeenCalledWith(
+      "finding_history_thread_outcome_failed",
+      expect.objectContaining({ outcome: "fixed", message: "outcome write failed" }),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- Allow expected dangling underscores in `.oxlintrc.json`
- Simplify the production logging flag ternary in `src/config.ts`
- Mark the finding-history outcome record as fire-and-forget
- Rename shadowed loop variables in triage publish and fake PrSurface
- Replace in-place sorts with `toSorted` in work item repository methods
- Drop redundant type assertions across backend modules

## Details

- Allow `_exhaustive`, `__mutating`, `__result`, and `_parentReplacement`
- Extract named row mappers in `workItemRepository.ts`
- Throw `AppError` when a code-index snapshot insert returns no row
- Guard `cancelled[0]` in slash intake before use
