### PR TITLE
Trim agent tool CPU and response bytes

### DIFF
--- a/src/agent/tools/codeIndexTools.ts
+++ b/src/agent/tools/codeIndexTools.ts
@@ -22,21 +22,16 @@ export const searchCodeIndexSchema = v.object({
   limit: v.optional(v.pipe(v.number(), v.integer(), v.gtValue(0)), CODE_INDEX_MAX_RESULTS),
 });
 
-async function verifyChunkHash(
+async function linesForChunkVerification(
   workspace: LocalPrWorkspace,
   path: string,
-  startLine: number,
-  endLine: number,
-  contentHash: Buffer,
-): Promise<boolean> {
+): Promise<string[] | null> {
   const normalized = path.replace(/\\/g, "/");
-  if (!workspace.isPathInCheckout(normalized)) return false;
+  if (!workspace.isPathInCheckout(normalized)) return null;
   const safePath = assertWorkspacePath(workspace.agentCwd, normalized);
   const content = await readFile(safePath, "utf8").catch(() => null);
-  if (content == null) return false;
-  const lines = content.split("\n");
-  const slice = lines.slice(startLine - 1, endLine).join("\n");
-  return createHash("sha256").update(slice).digest().equals(contentHash);
+  if (content == null) return null;
+  return content.split("\n");
 }
 
 function toCodeIndexBundle(tool: LocalTool): {
@@ -80,17 +75,24 @@ export function buildCodeIndexTools(params: {
         limit,
         allowedPaths,
       );
+      // One read per path: hints often cluster on the same file, and the
+      // old per-row read re-read and re-split it for every hint.
+      const linesByPath = new Map<string, Promise<string[] | null>>();
+      const linesForPath = (path: string): Promise<string[] | null> => {
+        const cached = linesByPath.get(path);
+        if (cached) return cached;
+        const pending = linesForChunkVerification(params.workspace, path);
+        linesByPath.set(path, pending);
+        return pending;
+      };
       const verifiedRows = await Promise.all(
         rows.map(async (row) => {
           try {
             assertPathAllowedForAsk(row.path, params.pathGate);
-            const hashOk = await verifyChunkHash(
-              params.workspace,
-              row.path,
-              row.start_line,
-              row.end_line,
-              row.content_hash,
-            );
+            const lines = await linesForPath(row.path);
+            if (lines == null) return { row, hashOk: false };
+            const slice = lines.slice(row.start_line - 1, row.end_line).join("\n");
+            const hashOk = createHash("sha256").update(slice).digest().equals(row.content_hash);
             return { row, hashOk };
           } catch {
             return { row, hashOk: false };

--- a/src/agent/tools/context7Tools.ts
+++ b/src/agent/tools/context7Tools.ts
@@ -161,7 +161,9 @@ async function context7Get(
   const contentType = res.headers.get("content-type") ?? "";
   if (contentType.toLowerCase().includes("application/json")) {
     const body: unknown = await res.json();
-    return redactContext7Response(JSON.stringify(body, null, 2), apiKey);
+    // Compact serialization: identical content, ~40% fewer bytes/tokens
+    // than indented output on structured result lists.
+    return redactContext7Response(JSON.stringify(body), apiKey);
   }
   return redactContext7Response(await res.text(), apiKey);
 }

--- a/src/agent/tools/localWorkspaceTools.ts
+++ b/src/agent/tools/localWorkspaceTools.ts
@@ -121,20 +121,18 @@ function segmentsExcluding(
   excluded?: readonly number[],
 ): [number, number][] {
   if (!excluded || excluded.length === 0) return [[startLine, endLine]];
-  const skip = new Set(excluded);
+  // Interval walk over the sorted in-range clamp set: O(k log k) instead of
+  // a per-line scan of the whole [start, end] range.
+  const sorted = [...new Set(excluded)]
+    .filter((line) => line >= startLine && line <= endLine)
+    .sort((a, b) => a - b);
   const segments: [number, number][] = [];
-  let segmentStart: number | null = null;
-  for (let line = startLine; line <= endLine; line += 1) {
-    if (skip.has(line)) {
-      if (segmentStart !== null) {
-        segments.push([segmentStart, line - 1]);
-        segmentStart = null;
-      }
-      continue;
-    }
-    segmentStart ??= line;
+  let cur = startLine;
+  for (const line of sorted) {
+    if (line > cur) segments.push([cur, line - 1]);
+    cur = line + 1;
   }
-  if (segmentStart !== null) segments.push([segmentStart, endLine]);
+  if (cur <= endLine) segments.push([cur, endLine]);
   return segments;
 }
 
@@ -402,12 +400,23 @@ export function buildLocalWorkspaceTools(
       if (allowedPaths.length === 0) {
         return { matches: [], truncated: false, pathsSearched: 0, filesScanned: 0 };
       }
-      const result = await workspace.grepLiteral({
-        query,
-        maxResults,
-        maxOutputBytes: limits.searchMaxTotalBytes,
-        paths: allowedPaths,
-      });
+      // Full-tree coverage searches the same on-disk tree either way
+      // (symlinks are stripped at checkout, `.git` lives outside the
+      // worktree), so use the single-shot scan instead of one git grep
+      // process per 256-pathspec chunk.
+      const fullCoverage = allowedPaths.length === workspace.sortedCheckoutPaths.length;
+      const result = fullCoverage
+        ? await workspace.grepLiteral({
+            query,
+            maxResults,
+            maxOutputBytes: limits.searchMaxTotalBytes,
+          })
+        : await workspace.grepLiteral({
+            query,
+            maxResults,
+            maxOutputBytes: limits.searchMaxTotalBytes,
+            paths: allowedPaths,
+          });
       const truncated = result.truncated || result.matches.length > maxResults;
       if (truncated) {
         workspace.noteSearchTruncated();

--- a/src/agent/tools/toolOutputBudget.ts
+++ b/src/agent/tools/toolOutputBudget.ts
@@ -191,9 +191,13 @@ function splitLines(text: string): string[] {
 
 function endLineForText(text: string): number {
   if (text.length === 0) return 0;
+  // `for..of` iterates Unicode code points; `\n` is BMP so an `indexOf`
+  // scan counts the same newlines without per-character decoding.
   let endLine = 1;
-  for (const char of text) {
-    if (char === "\n") endLine += 1;
+  let idx = text.indexOf("\n");
+  while (idx !== -1) {
+    endLine += 1;
+    idx = text.indexOf("\n", idx + 1);
   }
   if (text.endsWith("\n")) {
     endLine -= 1;

--- a/src/prWorkspace/localPrWorkspace.ts
+++ b/src/prWorkspace/localPrWorkspace.ts
@@ -640,6 +640,7 @@ async function finishLocalPrWorkspace(
   let checkoutPaths = new Set<string>();
   let sortedCheckoutPaths: string[] = [];
   let searchTruncated = false;
+  const blameCache = new Map<string, Promise<string>>();
 
   function isPathInCheckout(path: string): boolean {
     return checkoutPaths.has(path.replace(/\\/g, "/"));
@@ -685,10 +686,23 @@ async function finishLocalPrWorkspace(
     if (!isPathInCheckout(normalized)) {
       return "";
     }
-    const { stdout } = await git(["blame", "--line-porcelain", headSha, "--", normalized]);
-    return stdout.length > LOCAL_WORKSPACE_MAX_DIFF_BYTES
-      ? `${stdout.slice(0, LOCAL_WORKSPACE_MAX_DIFF_BYTES)}\n...[blame truncated]`
-      : stdout;
+    // Blame is immutable at this workspace's pinned headSha, and the four
+    // specialists routinely blame the same path: one git process per path.
+    const cached = blameCache.get(normalized);
+    if (cached !== undefined) return cached;
+    const pending = (async () => {
+      const { stdout } = await git(["blame", "--line-porcelain", headSha, "--", normalized]);
+      return stdout.length > LOCAL_WORKSPACE_MAX_DIFF_BYTES
+        ? `${stdout.slice(0, LOCAL_WORKSPACE_MAX_DIFF_BYTES)}\n...[blame truncated]`
+        : stdout;
+    })();
+    blameCache.set(normalized, pending);
+    try {
+      return await pending;
+    } catch (error) {
+      if (blameCache.get(normalized) === pending) blameCache.delete(normalized);
+      throw error;
+    }
   }
 
   const grepLiteral = async (grepParams: GitGrepWorkspaceParams) => {
@@ -814,6 +828,7 @@ async function finishLocalPrWorkspace(
     getSymbolIndexStatus,
     cleanup: async () => {
       symbolIndex = null;
+      blameCache.clear();
       await resource.release();
     },
   };

--- a/test/context7Tools.test.ts
+++ b/test/context7Tools.test.ts
@@ -110,7 +110,7 @@ describe("buildContext7Tools — executors", () => {
       expect(u.searchParams.get("query")).toBe("react");
       expect(headersOf(init).Authorization).toBeUndefined();
       expect(out).toMatchObject({
-        content: JSON.stringify({ results: [{ id: "/facebook/react", title: "React" }] }, null, 2),
+        content: JSON.stringify({ results: [{ id: "/facebook/react", title: "React" }] }),
         truncated: false,
         returnedBytes: expect.any(Number),
       });

--- a/test/localWorkspaceTools.test.ts
+++ b/test/localWorkspaceTools.test.ts
@@ -634,6 +634,44 @@ describe("local workspace tools", () => {
     }
   });
 
+  it("searchWorkspace uses the single-shot scan at full coverage with identical reporting", async () => {
+    const root = await mkdtemp(join(tmpdir(), "workspace-tools-"));
+    try {
+      const files: Record<string, string> = {
+        "src/changed.ts": "export const changed = true;\n",
+        "src/a.ts": "const needle = true;\n",
+        "src/b.ts": "const needle = true;\n",
+      };
+      await writeWorkspaceFiles(root, files);
+
+      const base = mockWorkspace(root, Object.keys(files));
+      const seen: GitGrepWorkspaceParams[] = [];
+      const workspace: LocalPrWorkspace = {
+        ...base,
+        grepLiteral: async (params) => {
+          seen.push(params);
+          return base.grepLiteral(params);
+        },
+      };
+      const { executors } = buildLocalWorkspaceTools(workspace, { limits: testLimits() });
+      const out = (await executors.searchWorkspace?.({ query: "needle" })) as {
+        matches: Array<{ path: string }>;
+        truncated: boolean;
+        pathsSearched: number;
+        filesScanned: number;
+      };
+
+      expect(out.matches.map((match) => match.path).sort()).toEqual(["src/a.ts", "src/b.ts"]);
+      expect(out.truncated).toBe(false);
+      expect(out.pathsSearched).toBe(3);
+      expect(out.filesScanned).toBe(2);
+      expect(seen).toHaveLength(1);
+      expect(seen[0]?.paths).toBeUndefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("readWorkspaceFile records evidence in the ledger on success", async () => {
     const root = await mkdtemp(join(tmpdir(), "workspace-tools-evidence-"));
     try {


### PR DESCRIPTION
## Summary
- Count newlines with `indexOf` in `endLineForText` instead of decoding each character.
- Walk clamp intervals in `segmentsExcluding` instead of scanning each line in the range.
- Cache `git blame` output per workspace path and read each code-index file once per search.
- Search fully covered checkouts with one `git grep` call instead of one call per path chunk.
- Return compact JSON from Context7 tools instead of indented JSON.

## Details
- `getBlameForPath` keeps error paths uncached and drops rejected entries so transient `git` failures retry; the cache clears on workspace `cleanup`.
- The single-shot grep applies only at full gate coverage, so the searched file set stays identical; `pathsSearched` and truncation reporting do not change.