### PR TITLE
Raise Valibot to 1.5.0

### DIFF
--- a/nub.jsonc
+++ b/nub.jsonc
@@ -21,6 +21,7 @@
       "posthog-node@5.51.7",
       "@posthog/*",
       "brace-expansion@5.0.8",
+      "valibot@1.5.0",
     ],
   },
 }

--- a/nub.lock
+++ b/nub.lock
@@ -49,7 +49,7 @@ importers:
         version: 18.0.0
       '@valibot/to-json-schema':
         specifier: ^1.7.1
-        version: 1.7.1(valibot@1.4.2(typescript@7.0.2))
+        version: 1.7.1(valibot@1.5.0(typescript@7.0.2))
       acorn:
         specifier: ^8.18.0
         version: 8.18.0
@@ -69,8 +69,8 @@ importers:
         specifier: 5.51.7
         version: 5.51.7
       valibot:
-        specifier: ^1.4.2
-        version: 1.4.2(typescript@7.0.2)
+        specifier: ^1.5.0
+        version: 1.5.0(typescript@7.0.2)
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -3101,8 +3101,8 @@ packages:
     resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
-  valibot@1.4.2:
-    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
+  valibot@1.5.0:
+    resolution: {integrity: sha512-nil6AkP2TChWL43Z5uJ6GTxX01CUA+g8LWUM+N/rB9NBbkUMaUsi9PUNzlUPgoKASgmx9f7eGOYpJ04/fSa6FQ==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -4860,9 +4860,9 @@ snapshots:
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
-  '@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@7.0.2))':
+  '@valibot/to-json-schema@1.7.1(valibot@1.5.0(typescript@7.0.2))':
     dependencies:
-      valibot: 1.4.2(typescript@7.0.2)
+      valibot: 1.5.0(typescript@7.0.2)
 
   '@vitejs/plugin-react@6.1.1(vite@8.2.2(@types/node@26.5.0)(yaml@2.9.0))':
     dependencies:
@@ -5809,7 +5809,7 @@ snapshots:
 
   uuid@11.1.1: {}
 
-  valibot@1.4.2(typescript@7.0.2):
+  valibot@1.5.0(typescript@7.0.2):
     dependencies:
       typescript: 7.0.2
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "pg": "^8.23.0",
     "pg-boss": "^12.30.0",
     "posthog-node": "5.51.7",
-    "valibot": "^1.4.2",
+    "valibot": "^1.5.0",
     "yaml": "^2.9.0"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Raise the `valibot` range in `package.json` from `^1.4.2` to `^1.5.0`.
- Lock `valibot@1.5.0` and relink `@valibot/to-json-schema@1.7.1` to that release in `nub.lock`.
- Add `valibot@1.5.0` to `nub.jsonc` `install.minimumReleaseAgeExclude` so Nub can resolve a release younger than 7 days.

```diff
 package.json
-  "valibot": "^1.4.2"
+  "valibot": "^1.5.0"

 nub.jsonc  install.minimumReleaseAgeExclude
+  "valibot@1.5.0"
```

```text
/
├── package.json   # valibot caret range
├── nub.lock       # resolved valibot@1.5.0
└── nub.jsonc      # cooling-window exclude
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6971c40b-b373-4411-b3f7-7ef82bba91cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6971c40b-b373-4411-b3f7-7ef82bba91cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- PR_AGENT_DESCRIPTION_BEGIN -->
## PR Agent Description

### PR Type

Enhancement

### Description

- The change bumps valibot from ^1.4.2 to ^1.5.0 in package.json.
- The lockfile updates valibot and to-json-schema peer resolution to 1.5.0.
- The change adds valibot 1.5.0 to the audit allowlist in nub.jsonc.
<!-- pr-agent:operation-intent 14dcf074e0cde5d243c96686 -->
<!-- PR_AGENT_DESCRIPTION_END -->